### PR TITLE
Replace the memPool lists with standard "mempool.h".  This makes one big cudaMallocHost, and vastly simplifies memory handling in the hybrid API.

### DIFF
--- a/src/arch/cuda/hybridAPI/cuda-hybrid-api.h
+++ b/src/arch/cuda/hybridAPI/cuda-hybrid-api.h
@@ -37,27 +37,6 @@ void gpuProgressFn();
 */
 void exitHybridAPI();
 
-
-#ifdef GPU_MEMPOOL
-// data and metadata reside in same chunk of memory
-typedef struct _header {
-  struct _header *next;
-  int slot;
-#ifdef GPU_MEMPOOL_DEBUG
-  int size;
-#endif
-} Header;
-
-typedef struct _bufferPool {
-  Header *head;
-  size_t size;
-#ifdef GPU_MEMPOOL_DEBUG
-  int num;
-#endif
-} BufferPool;
-
-#endif // GPU_MEMPOOL
-
 extern void cudaErrorDie(int err, const char* code, const char* file, int line);
 
 #define cudaChk(code)                                                  \

--- a/src/arch/cuda/hybridAPI/wr.h
+++ b/src/arch/cuda/hybridAPI/wr.h
@@ -175,7 +175,7 @@ void setWRCallback(workRequest* wr, void* cb);
 
 #ifdef GPU_MEMPOOL
 void hapi_poolFree(void*);
-void *hapi_poolMalloc(int size);
+void *hapi_poolMalloc(size_t size);
 #endif
 /* external declarations needed by the user */
 


### PR DESCRIPTION
*Original author: Dr. Orion Lawlor*
*Original date: 2016-12-20 22:00:51*
*Original PR: https://charm.cs.illinois.edu/gerrit/2070*

---

Change-Id: I8c8ba60bb8d48530284ebfdd97a1f110e4b4bba5