### PR TITLE
AMPI #1258: derived datatype support for RMA routines

### DIFF
--- a/src/libs/ck-libs/ampi/Makefile
+++ b/src/libs/ck-libs/ampi/Makefile
@@ -7,7 +7,7 @@ COMPAT=compat_ampius.o compat_ampifus.o compat_ampi.o \
        compat_ampim.o compat_ampifm.o compat_ampicm.o \
 	   compat_ampicpp.o
 OBJS=ampi.o ampif.o ampiProjections.o ampiOneSided.o \
-     ampiMisc.o mpich-alltoall.o  
+     ampiMisc.o mpich-alltoall.o ddt.o 
 ROMIOMAKE=romio/adio/ad_hfs/Makefile romio/adio/ad_nfs/Makefile romio/adio/ad_pfs/Makefile romio/adio/ad_piofs/Makefile \
 	  romio/adio/ad_pvfs/Makefile romio/adio/ad_sfs/Makefile romio/adio/ad_testfs/Makefile romio/adio/ad_ufs/Makefile \
 	  romio/adio/ad_xfs/Makefile romio/adio/common/Makefile romio/adio/include/romioconf.h romio/Makefile \
@@ -96,7 +96,7 @@ ampi.o: ampi.C $(HEADDEP)
 ampif.o: ampif.C $(HEADDEP)
 	$(CHARMC) -c ampif.C
 
-ampiOneSided.o: ampiOneSided.C ampiimpl.h $(HEADDEP)
+ampiOneSided.o: ampiOneSided.C ampiimpl.h ampi.def.h $(HEADDEP)
 	$(CHARMC) -c ampiOneSided.C
 
 ampiMisc.o: ampiMisc.C ampiimpl.h $(HEADDEP)
@@ -105,7 +105,10 @@ ampiMisc.o: ampiMisc.C ampiimpl.h $(HEADDEP)
 mpich-alltoall.o: mpich-alltoall.C $(HEADDEP)
 	$(CHARMC) -c mpich-alltoall.C 
 
-ampi.decl.h ampi.def.h: ampi.ci
+ddt.o:./../../conv-libs/ddt/ddt.C ./../../conv-libs/ddt/ddt.h
+	$(CHARMC) -c ./../../conv-libs/ddt/ddt.C
+
+ampi.decl.h ampi.def.h: ampi.ci ./../../conv-libs/ddt/ddt.h
 	$(CHARMC) ampi.ci
 
 ampiProjections.o: ampiProjections.C ampiEvents.h ampiProjections.h $(HEADDEP)

--- a/src/libs/ck-libs/ampi/ampi.ci
+++ b/src/libs/ck-libs/ampi/ampi.ci
@@ -23,6 +23,8 @@
 #endif
 
 module ampi {
+  include "./../../conv-libs/ddt/ddt.h";
+
   message AmpiMsg {
     char data[];
   };
@@ -65,6 +67,9 @@ module ampi {
     entry EXPEDITED_SYNC void winRemoteAccumulate(int orgtotalsize, char orgaddr[orgtotalsize], int orgcnt,
                                                   MPI_Datatype orgtype, MPI_Aint targdisp, int targcnt,
                                                   MPI_Datatype targtype, MPI_Op op, int winIndex);
+    entry EXPEDITED_SYNC AmpiMsg *winRemoteGetAccumulate(int orgTotalSize, char orgaddr[orgTotalSize], int orgcnt,
+                                                         MPI_Datatype orgtype, MPI_Aint targdisp, int targcnt,
+                                                         MPI_Datatype targtype, MPI_Op op, int winIndex);
     entry EXPEDITED_SYNC AmpiMsg *winRemoteCompareAndSwap(int size, char sorgaddr[size],
                                                           char compaddr[size], MPI_Datatype type,
                                                           MPI_Aint targdisp, int winIndex);
@@ -74,6 +79,138 @@ module ampi {
                                                 MPI_Aint targdisp, int targcnt, MPI_Datatype targtype,
                                                 int winIndex);
     entry EXPEDITED_IGET AmpiMsg *Alltoall_RemoteIget(MPI_Aint disp, int cnt, MPI_Datatype type, int tag);
+
+    template<typename T>
+    entry EXPEDITED_SYNC void winRemotePutNewDataType(int orgtotalsize, char orgaddr[orgtotalsize], int orgcnt,
+                                           MPI_Datatype orgtype, MPI_Aint targdisp, int targcnt,
+                                           MPI_Datatype targtype, int winIndex, T newDataType, int derivedDataType);
+    template<typename T>
+    entry EXPEDITED_SYNC AmpiMsg *winRemoteGetNewDataType(int orgcnt, MPI_Datatype orgtype, MPI_Aint targdisp, int targcnt,
+                                               MPI_Datatype targtype, int winIndex, T newDataType, int derivedDataType);
+    template<typename T>
+    entry EXPEDITED_SYNC void winRemoteAccumulateNewDataType(int orgtotalsize, char orgaddr[orgtotalsize],
+                                                             int orgcnt, MPI_Datatype orgtype, MPI_Aint targdisp,
+                                                             int targcnt, MPI_Datatype targtype, MPI_Op op,
+                                                             int winIndex, T newDataType, int derivedDataType);
+    template<typename T>
+    entry EXPEDITED_SYNC AmpiMsg *winRemoteGetAccumulateNewDataType(int orgTotalSize, char orgaddr[orgTotalSize], int orgcnt,
+                                                         MPI_Datatype orgtype, MPI_Aint targdisp, int targcnt,
+                                                         MPI_Datatype targtype, MPI_Op op, int winIndex,
+                                                         T newDataType, int derivedDataType);
+    // Templated entry method instantiations for Get:
+    entry EXPEDITED_SYNC void winRemotePutNewDataType(int orgtotalsize, char orgaddr[orgtotalsize], int orgcnt,
+                                           MPI_Datatype orgtype, MPI_Aint targdisp, int targcnt,
+                                           MPI_Datatype targtype, int winIndex, CkDDT_Contiguous newDataType, int derivedDataType);
+    entry EXPEDITED_SYNC void winRemotePutNewDataType(int orgtotalsize, char orgaddr[orgtotalsize], int orgcnt,
+                                           MPI_Datatype orgtype, MPI_Aint targdisp, int targcnt,
+                                           MPI_Datatype targtype, int winIndex, CkDDT_Vector newDataType, int derivedDataType);
+    entry EXPEDITED_SYNC void winRemotePutNewDataType(int orgtotalsize, char orgaddr[orgtotalsize], int orgcnt,
+                                           MPI_Datatype orgtype, MPI_Aint targdisp, int targcnt,
+                                           MPI_Datatype targtype, int winIndex, CkDDT_HVector newDataType, int derivedDataType);
+    entry EXPEDITED_SYNC void winRemotePutNewDataType(int orgtotalsize, char orgaddr[orgtotalsize], int orgcnt,
+                                           MPI_Datatype orgtype, MPI_Aint targdisp, int targcnt,
+                                           MPI_Datatype targtype, int winIndex, CkDDT_Indexed newDataType, int derivedDataType);
+    entry EXPEDITED_SYNC void winRemotePutNewDataType(int orgtotalsize, char orgaddr[orgtotalsize], int orgcnt,
+                                           MPI_Datatype orgtype, MPI_Aint targdisp, int targcnt,
+                                           MPI_Datatype targtype, int winIndex, CkDDT_HIndexed newDataType, int derivedDataType);
+    entry EXPEDITED_SYNC void winRemotePutNewDataType(int orgtotalsize, char orgaddr[orgtotalsize], int orgcnt,
+                                           MPI_Datatype orgtype, MPI_Aint targdisp, int targcnt,
+                                           MPI_Datatype targtype, int winIndex, CkDDT_Indexed_Block newDataType, int derivedDataType);
+    entry EXPEDITED_SYNC void winRemotePutNewDataType(int orgtotalsize, char orgaddr[orgtotalsize], int orgcnt,
+                                           MPI_Datatype orgtype, MPI_Aint targdisp, int targcnt,
+                                           MPI_Datatype targtype, int winIndex, CkDDT_HIndexed_Block newDataType, int derivedDataType);
+    entry EXPEDITED_SYNC void winRemotePutNewDataType(int orgtotalsize, char orgaddr[orgtotalsize], int orgcnt,
+                                           MPI_Datatype orgtype, MPI_Aint targdisp, int targcnt,
+                                           MPI_Datatype targtype, int winIndex, CkDDT_Struct newDataType, int derivedDataType);
+    entry EXPEDITED_SYNC AmpiMsg *winRemoteGetNewDataType(int orgcnt, MPI_Datatype orgtype, MPI_Aint targdisp, int targcnt,
+                                               MPI_Datatype targtype, int winIndex, CkDDT_Contiguous newDataType, int derivedDataType);
+    entry EXPEDITED_SYNC AmpiMsg *winRemoteGetNewDataType(int orgcnt, MPI_Datatype orgtype, MPI_Aint targdisp, int targcnt,
+                                               MPI_Datatype targtype, int winIndex, CkDDT_Vector newDataType, int derivedDataType);
+    entry EXPEDITED_SYNC AmpiMsg *winRemoteGetNewDataType(int orgcnt, MPI_Datatype orgtype, MPI_Aint targdisp, int targcnt,
+                                               MPI_Datatype targtype, int winIndex, CkDDT_HVector newDataType, int derivedDataType);
+    entry EXPEDITED_SYNC AmpiMsg *winRemoteGetNewDataType(int orgcnt, MPI_Datatype orgtype, MPI_Aint targdisp, int targcnt,
+                                               MPI_Datatype targtype, int winIndex, CkDDT_Indexed newDataType, int derivedDataType);
+    entry EXPEDITED_SYNC AmpiMsg *winRemoteGetNewDataType(int orgcnt, MPI_Datatype orgtype, MPI_Aint targdisp, int targcnt,
+                                               MPI_Datatype targtype, int winIndex, CkDDT_HIndexed newDataType, int derivedDataType);
+    entry EXPEDITED_SYNC AmpiMsg *winRemoteGetNewDataType(int orgcnt, MPI_Datatype orgtype, MPI_Aint targdisp, int targcnt,
+                                               MPI_Datatype targtype, int winIndex, CkDDT_Indexed_Block newDataType, int derivedDataType);
+    entry EXPEDITED_SYNC AmpiMsg *winRemoteGetNewDataType(int orgcnt, MPI_Datatype orgtype, MPI_Aint targdisp, int targcnt,
+                                               MPI_Datatype targtype, int winIndex, CkDDT_HIndexed_Block newDataType, int derivedDataType);
+    entry EXPEDITED_SYNC AmpiMsg *winRemoteGetNewDataType(int orgcnt, MPI_Datatype orgtype, MPI_Aint targdisp, int targcnt,
+                                               MPI_Datatype targtype, int winIndex, CkDDT_Struct newDataType, int derivedDataType);
+    // Templated entry method instantiations for Accumulate:
+    entry EXPEDITED_SYNC void winRemoteAccumulateNewDataType(int orgtotalsize, char sorgaddr[orgtotalsize],
+                                                             int orgcnt, MPI_Datatype orgtype, MPI_Aint targdisp,
+                                                             int targcnt, MPI_Datatype targtype, MPI_Op op,
+                                                             int winIndex, CkDDT_Contiguous newDataType,
+                                                             int derivedDataType);
+    entry EXPEDITED_SYNC void winRemoteAccumulateNewDataType(int orgtotalsize, char sorgaddr[orgtotalsize],
+                                                             int orgcnt, MPI_Datatype orgtype, MPI_Aint targdisp,
+                                                             int targcnt, MPI_Datatype targtype, MPI_Op op,
+                                                             int winIndex, CkDDT_Vector newDataType,
+                                                             int derivedDataType);
+    entry EXPEDITED_SYNC void winRemoteAccumulateNewDataType(int orgtotalsize, char sorgaddr[orgtotalsize],
+                                                             int orgcnt, MPI_Datatype orgtype, MPI_Aint targdisp,
+                                                             int targcnt, MPI_Datatype targtype, MPI_Op op,
+                                                             int winIndex, CkDDT_HVector newDataType,
+                                                             int derivedDataType);
+    entry EXPEDITED_SYNC void winRemoteAccumulateNewDataType(int orgtotalsize, char sorgaddr[orgtotalsize],
+                                                             int orgcnt, MPI_Datatype orgtype, MPI_Aint targdisp,
+                                                             int targcnt, MPI_Datatype targtype, MPI_Op op,
+                                                             int winIndex, CkDDT_Indexed newDataType,
+                                                             int derivedDataType);
+    entry EXPEDITED_SYNC void winRemoteAccumulateNewDataType(int orgtotalsize, char sorgaddr[orgtotalsize],
+                                                             int orgcnt, MPI_Datatype orgtype, MPI_Aint targdisp,
+                                                             int targcnt, MPI_Datatype targtype, MPI_Op op,
+                                                             int winIndex, CkDDT_HIndexed newDataType,
+                                                             int derivedDataType);
+    entry EXPEDITED_SYNC void winRemoteAccumulateNewDataType(int orgtotalsize, char sorgaddr[orgtotalsize],
+                                                             int orgcnt, MPI_Datatype orgtype, MPI_Aint targdisp,
+                                                             int targcnt, MPI_Datatype targtype, MPI_Op op,
+                                                             int winIndex, CkDDT_Indexed_Block newDataType,
+                                                             int derivedDataType);
+    entry EXPEDITED_SYNC void winRemoteAccumulateNewDataType(int orgtotalsize, char sorgaddr[orgtotalsize],
+                                                             int orgcnt, MPI_Datatype orgtype, MPI_Aint targdisp,
+                                                             int targcnt, MPI_Datatype targtype, MPI_Op op,
+                                                             int winIndex, CkDDT_HIndexed_Block newDataType,
+                                                             int derivedDataType);
+    entry EXPEDITED_SYNC void winRemoteAccumulateNewDataType(int orgtotalsize, char sorgaddr[orgtotalsize],
+                                                             int orgcnt, MPI_Datatype orgtype, MPI_Aint targdisp,
+                                                             int targcnt, MPI_Datatype targtype, MPI_Op op,
+                                                             int winIndex, CkDDT_Struct newDataType,
+                                                             int derivedDataType);
+    entry EXPEDITED_SYNC AmpiMsg *winRemoteGetAccumulateNewDataType(int orgTotalSize, char orgaddr[orgTotalSize], int orgcnt,
+                                                                    MPI_Datatype orgtype, MPI_Aint targdisp, int targcnt,
+                                                                    MPI_Datatype targtype, MPI_Op op, int winIndex,
+                                                                    CkDDT_Contiguous newDataType, int derivedDataType);
+    entry EXPEDITED_SYNC AmpiMsg *winRemoteGetAccumulateNewDataType(int orgTotalSize, char orgaddr[orgTotalSize], int orgcnt,
+                                                                    MPI_Datatype orgtype, MPI_Aint targdisp, int targcnt,
+                                                                    MPI_Datatype targtype, MPI_Op op, int winIndex,
+                                                                    CkDDT_Vector newDataType, int derivedDataType);
+    entry EXPEDITED_SYNC AmpiMsg *winRemoteGetAccumulateNewDataType(int orgTotalSize, char orgaddr[orgTotalSize], int orgcnt,
+                                                                    MPI_Datatype orgtype, MPI_Aint targdisp, int targcnt,
+                                                                    MPI_Datatype targtype, MPI_Op op, int winIndex,
+                                                                    CkDDT_HVector newDataType, int derivedDataType);
+    entry EXPEDITED_SYNC AmpiMsg *winRemoteGetAccumulateNewDataType(int orgTotalSize, char orgaddr[orgTotalSize], int orgcnt,
+                                                                    MPI_Datatype orgtype, MPI_Aint targdisp, int targcnt,
+                                                                    MPI_Datatype targtype, MPI_Op op, int winIndex,
+                                                                    CkDDT_Indexed newDataType, int derivedDataType);
+    entry EXPEDITED_SYNC AmpiMsg *winRemoteGetAccumulateNewDataType(int orgTotalSize, char orgaddr[orgTotalSize], int orgcnt,
+                                                                    MPI_Datatype orgtype, MPI_Aint targdisp, int targcnt,
+                                                                    MPI_Datatype targtype, MPI_Op op, int winIndex,
+                                                                    CkDDT_HIndexed newDataType, int derivedDataType);
+    entry EXPEDITED_SYNC AmpiMsg *winRemoteGetAccumulateNewDataType(int orgTotalSize, char orgaddr[orgTotalSize], int orgcnt,
+                                                                    MPI_Datatype orgtype, MPI_Aint targdisp, int targcnt,
+                                                                    MPI_Datatype targtype, MPI_Op op, int winIndex,
+                                                                    CkDDT_Indexed_Block newDataType, int derivedDataType);
+    entry EXPEDITED_SYNC AmpiMsg *winRemoteGetAccumulateNewDataType(int orgTotalSize, char orgaddr[orgTotalSize], int orgcnt,
+                                                                    MPI_Datatype orgtype, MPI_Aint targdisp, int targcnt,
+                                                                    MPI_Datatype targtype, MPI_Op op, int winIndex,
+                                                                    CkDDT_HIndexed_Block newDataType, int derivedDataType);
+    entry EXPEDITED_SYNC AmpiMsg *winRemoteGetAccumulateNewDataType(int orgTotalSize, char orgaddr[orgTotalSize], int orgcnt,
+                                                                    MPI_Datatype orgtype, MPI_Aint targdisp, int targcnt,
+                                                                    MPI_Datatype targtype, MPI_Op op, int winIndex,
+                                                                    CkDDT_Struct newDataType, int derivedDataType);
   };
 
   group [migratable] ampiWorlds {

--- a/src/libs/ck-libs/ampi/ampiOneSided.C
+++ b/src/libs/ck-libs/ampi/ampiOneSided.C
@@ -126,12 +126,12 @@ int win_obj::iget(int orgcnt, int orgunit, MPI_Aint targdisp,
   return WIN_SUCCESS;
 }
 
-int win_obj::accumulate(void *orgaddr, int orgcnt, MPI_Datatype orgtype,
-                        MPI_Aint targdisp, int targcnt,
-                        MPI_Datatype targtype, MPI_Op op, ampiParent* pptr){
+int win_obj::accumulate(void *orgaddr, int count, MPI_Aint targdisp, MPI_Aint structDisp, MPI_Datatype targtype,
+                        MPI_Op op, ampiParent* pptr)
+{
   //when called from winRemote entry methods, pptr must be taken from the ampi instance, not getAmpiParent().
   CkAssert(pptr != NULL);
-  pptr->applyOp(targtype, op, targcnt, (void*)((int*)baseAddr+targdisp), (void*)orgaddr);
+  pptr->applyOp(targtype, op, count, (void*)(orgaddr),(void*)((char*)baseAddr+disp_unit*targdisp+structDisp));
   return WIN_SUCCESS;
 }
 
@@ -208,19 +208,100 @@ void ampiParent::removeWinStruct(WinStruct *win) {/*winStructList.remove(win);*/
 int ampi::winPut(void *orgaddr, int orgcnt, MPI_Datatype orgtype, int rank,
                  MPI_Aint targdisp, int targcnt, MPI_Datatype targtype, WinStruct *win){
   CkDDT_DataType *ddt = getDDT()->getType(orgtype);
-  int orgtotalsize = ddt->getSize(orgcnt);
-
-  if (ddt->isContig()) {
-    thisProxy[rank].winRemotePut(orgtotalsize, (char*)orgaddr, orgcnt, orgtype, targdisp,
-                          targcnt, targtype, win->index);
+  int orgTotalSize = ddt->getSize(orgcnt);
+  AMPI_DEBUG("    Rank[%d:%d] invoke Remote accumulate at [%d]\n", thisIndex, myRank, rank);
+  if (!getDDT()->isPrimitive(targtype))
+  {
+    int newTypeIndex = getDDT()->getType(targtype)->getType();
+    CkDDT_DataType *newDataType = getDDT()->getType(targtype);
+    bool isContiguousData = true;
+    vector<char> sorgaddr;
+    if (!ddt->isContig())
+    {
+      isContiguousData = false;
+      sorgaddr.resize(orgTotalSize);
+      ddt->serialize((char*)orgaddr, &sorgaddr[0], orgcnt, 1);
+    }
+    char* orgData;
+    if (isContiguousData)
+    {
+      orgData = (char*)orgaddr;
+    }
+    else
+    {
+      orgData = &sorgaddr[0];
+    }
+    switch(newTypeIndex)
+    {
+      case CkDDT_CONTIGUOUS:
+      {
+        CkDDT_Contiguous newType = *(static_cast<CkDDT_Contiguous*>(newDataType));
+        thisProxy[rank].winRemotePutNewDataType(orgTotalSize, orgData, orgcnt, orgtype,
+          targdisp, targcnt, targtype, win->index, newType, newTypeIndex);
+        break;
+       }
+      case CkDDT_VECTOR:
+      {
+        CkDDT_Vector newType = *(static_cast<CkDDT_Vector*> (newDataType));
+        thisProxy[rank].winRemotePutNewDataType(orgTotalSize, orgData, orgcnt, orgtype,
+          targdisp, targcnt, targtype, win->index, newType, newTypeIndex);
+        break;
+      }
+      case CkDDT_HVECTOR:
+      {
+        CkDDT_HVector newType = *(static_cast<CkDDT_HVector*>(newDataType));
+        thisProxy[rank].winRemotePutNewDataType(orgTotalSize, orgData, orgcnt, orgtype,
+          targdisp, targcnt, targtype, win->index, newType, newTypeIndex);
+        break;
+       }
+      case CkDDT_INDEXED:
+      {
+        CkDDT_Indexed newType = *(static_cast<CkDDT_Indexed*>(newDataType));
+        thisProxy[rank].winRemotePutNewDataType(orgTotalSize, orgData, orgcnt, orgtype,
+          targdisp, targcnt, targtype, win->index, newType, newTypeIndex);
+        break;
+       }
+      case CkDDT_HINDEXED:
+      {
+        CkDDT_HIndexed newType = *(static_cast<CkDDT_HIndexed*>(newDataType));
+        thisProxy[rank].winRemotePutNewDataType(orgTotalSize, orgData, orgcnt, orgtype,
+          targdisp, targcnt, targtype, win->index, newType, newTypeIndex);
+        break;
+       }
+      case CkDDT_INDEXED_BLOCK:
+      {
+        CkDDT_Indexed_Block newType = *(static_cast<CkDDT_HIndexed_Block*>(newDataType));
+        thisProxy[rank].winRemotePutNewDataType(orgTotalSize, orgData, orgcnt, orgtype,
+          targdisp, targcnt, targtype, win->index, newType, newTypeIndex);
+        break;
+       }
+      case CkDDT_HINDEXED_BLOCK:
+      {
+        CkDDT_HIndexed_Block newType = *(static_cast<CkDDT_HIndexed_Block*>(newDataType));
+        thisProxy[rank].winRemotePutNewDataType(orgTotalSize, orgData, orgcnt, orgtype,
+          targdisp, targcnt, targtype, win->index, newType, newTypeIndex);
+        break;
+       }
+      case CkDDT_STRUCT:
+      {
+        CkDDT_Struct newType = *(static_cast<CkDDT_Struct*>(newDataType));
+        thisProxy[rank].winRemotePutNewDataType(orgTotalSize, orgData, orgcnt, orgtype,
+          targdisp, targcnt, targtype, win->index, newType, newTypeIndex);
+        break;
+       }
+      default:
+      {
+        CkAbort("AMPI>MPI_Accumulate does not recognize the target derived datatype!");
+        break;
+      }
+    }
   }
-  else {
-    vector<char> sorgaddr(orgtotalsize);
-    ddt->serialize((char*)orgaddr, &sorgaddr[0], orgcnt, 1);
-    thisProxy[rank].winRemotePut(orgtotalsize, &sorgaddr[0], orgcnt, orgtype, targdisp,
-                          targcnt, targtype, win->index);
+  else
+  {
+    thisProxy[rank].winRemotePut(orgTotalSize, (char*)orgaddr, orgcnt, orgtype,
+                               targdisp, targcnt, targtype, win->index);
   }
-
+  
   return MPI_SUCCESS;
 }
 
@@ -229,10 +310,9 @@ void ampi::winRemotePut(int orgtotalsize, char* sorgaddr, int orgcnt, MPI_Dataty
   win_obj *winobj = winObjects[winIndex];
   CkDDT_DataType *tddt = getDDT()->getType(targtype);
   int targunit = tddt->getSize();
-  int orgunit = getDDT()->getSize(orgtype);
 
-  winobj->put(sorgaddr, orgcnt, orgunit, targdisp, targcnt, targunit);
-  char* targaddr = ((char*)(winobj->baseAddr)) + targunit*targdisp;
+  winobj->put(sorgaddr, orgcnt, orgtotalsize, targdisp, targcnt, targunit);        // This call doesnt even do anything.
+  char* targaddr = ((char*)(winobj->baseAddr)) + winobj->disp_unit*targdisp;
   tddt->serialize(targaddr, (char*)sorgaddr, targcnt, (-1));
 }
 
@@ -243,10 +323,85 @@ int ampi::winGet(void *orgaddr, int orgcnt, MPI_Datatype orgtype, int rank,
   AMPI_DEBUG("    Rank[%d:%d] invoke Remote get at [%d]\n", thisIndex, myRank, rank);
   CkDDT_DataType *ddt = getDDT()->getType(orgtype);
   int orgtotalsize = ddt->getSize(orgcnt);
+  int targTotalExtent = targcnt*getDDT()->getType(targtype)->getExtent();	// added the "targcnt*" part recently
   AmpiMsg *msg = new AmpiMsg();
 
-  msg = thisProxy[rank].winRemoteGet(orgcnt, orgtype, targdisp, targcnt, targtype, win->index);
 
+  if (!getDDT()->isPrimitive(targtype))
+  {
+    int newTypeIndex = getDDT()->getType(targtype)->getType();
+    CkDDT_DataType *newDataType = getDDT()->getType(targtype);
+  
+    switch(newTypeIndex)
+    {
+      case CkDDT_CONTIGUOUS:
+      {
+        CkDDT_Contiguous newType = *(static_cast<CkDDT_Contiguous*>(newDataType));
+        msg = thisProxy[rank].winRemoteGetNewDataType(orgcnt, orgtype, targdisp, targcnt, targtype, win->index,
+          newType, newTypeIndex);
+        break;
+       }
+      case CkDDT_VECTOR:
+      {
+        CkDDT_Vector newType = *(static_cast<CkDDT_Vector*> (newDataType));
+        msg = thisProxy[rank].winRemoteGetNewDataType(orgcnt, orgtype, targdisp, targcnt, targtype, win->index,
+          newType, newTypeIndex);
+        break;
+      }
+      case CkDDT_HVECTOR:
+      {
+        CkDDT_HVector newType = *(static_cast<CkDDT_HVector*>(newDataType));
+        msg = thisProxy[rank].winRemoteGetNewDataType(orgcnt, orgtype, targdisp, targcnt, targtype, win->index,
+          newType, newTypeIndex);
+        break;
+       }
+      case CkDDT_INDEXED:
+      {
+        CkDDT_Indexed newType = *(static_cast<CkDDT_Indexed*>(newDataType));
+        msg = thisProxy[rank].winRemoteGetNewDataType(orgcnt, orgtype, targdisp, targcnt, targtype, win->index,
+          newType, newTypeIndex);
+        break;
+       }
+      case CkDDT_HINDEXED:
+      {
+        CkDDT_HIndexed newType = *(static_cast<CkDDT_HIndexed*>(newDataType));
+        msg = thisProxy[rank].winRemoteGetNewDataType(orgcnt, orgtype, targdisp, targcnt, targtype, win->index,
+          newType, newTypeIndex);
+        break;
+       }
+      case CkDDT_INDEXED_BLOCK:
+      {
+        CkDDT_Indexed_Block newType = *(static_cast<CkDDT_HIndexed_Block*>(newDataType));
+        msg = thisProxy[rank].winRemoteGetNewDataType(orgcnt, orgtype, targdisp, targcnt, targtype, win->index,
+          newType, newTypeIndex);
+        break;
+       }
+      case CkDDT_HINDEXED_BLOCK:
+      {
+        CkDDT_HIndexed_Block newType = *(static_cast<CkDDT_HIndexed_Block*>(newDataType));
+        msg = thisProxy[rank].winRemoteGetNewDataType(orgcnt, orgtype, targdisp, targcnt, targtype, win->index,
+          newType, newTypeIndex);
+        break;
+       }
+      case CkDDT_STRUCT:
+      {
+        CkDDT_Struct newType = *(static_cast<CkDDT_Struct*>(newDataType));
+        msg = thisProxy[rank].winRemoteGetNewDataType(orgcnt, orgtype, targdisp, targcnt, targtype, win->index,
+          newType, newTypeIndex);
+        break;
+       }
+      default:
+      {
+        CkAbort("AMPI>MPI_Accumulate does not recognize the target derived datatype!");
+        break;
+      }
+    }
+  }
+  else
+  {
+    msg = thisProxy[rank].winRemoteGet(orgcnt, orgtype, targdisp, targcnt, targtype, win->index);
+  }
+  
   // Process the reply message by serializing the data into the desired memory position
   ddt->serialize((char*)orgaddr, msg->getData(), orgcnt, (-1));
   AMPI_DEBUG("    Rank[%d] got win  [%d] \n", thisIndex, *(int*)msg->getData());
@@ -263,11 +418,12 @@ AmpiMsg* ampi::winRemoteGet(int orgcnt, MPI_Datatype orgtype, MPI_Aint targdisp,
   CkDDT_DataType *tddt = getDDT()->getType(targtype);
   int targunit = tddt->getSize();
   int targtotalsize = targunit*targcnt;
-  int orgunit = getDDT()->getSize(orgtype);
+  //int orgunit = getDDT()->getSize(orgtype);	// WE DONT WANT THIS CALL because what if orgtype is derived?
+  int orgunit = -1;		// this can be changed later, but the call to winobj->get(..) doesnt do anything anways!
   win_obj *winobj = winObjects[winIndex];
-  char* targaddr = (char*)(winobj->baseAddr) + targunit*targdisp;
 
-  winobj->get(targaddr, orgcnt, orgunit, targdisp, targcnt, targunit);
+  char* targaddr = (char*)(winobj->baseAddr) + winobj->disp_unit*targdisp;
+  winobj->get(targaddr, orgcnt, orgunit, targdisp, targcnt, targunit);    // This call doesnt do anything
 
   AMPI_DEBUG("    Rank[%d] get win  [%d] \n", thisIndex, *(int*)(targaddr));
   AmpiMsg *msg = new (targtotalsize, 0) AmpiMsg(-1, MPI_RMA_TAG, thisIndex, targtotalsize);
@@ -333,18 +489,100 @@ int ampi::winAccumulate(void *orgaddr, int orgcnt, MPI_Datatype orgtype, int ran
                         MPI_Aint targdisp, int targcnt, MPI_Datatype targtype,
                         MPI_Op op, WinStruct *win) {
   CkDDT_DataType *ddt = getDDT()->getType(orgtype);
-  int orgtotalsize = ddt->getSize(orgcnt);
+  int orgTotalSize = ddt->getSize(orgcnt);
   AMPI_DEBUG("    Rank[%d:%d] invoke Remote accumulate at [%d]\n", thisIndex, myRank, rank);
 
-  if (ddt->isContig()) {
-    thisProxy[rank].winRemoteAccumulate(orgtotalsize, (char*)orgaddr, orgcnt, orgtype,
-                                 targdisp, targcnt, targtype,  op, win->index);
+  if (!getDDT()->isPrimitive(targtype))
+  {
+    int newTypeIndex = getDDT()->getType(targtype)->getType();
+    CkDDT_DataType *newDataType = getDDT()->getType(targtype);
+    bool isContiguousData = true;
+    vector<char> sorgaddr;
+    if (!ddt->isContig())
+    {
+      isContiguousData = false;
+      sorgaddr.resize(orgTotalSize);
+      ddt->serialize((char*)orgaddr, &sorgaddr[0], orgcnt, 1);
+    }
+    char* orgData;
+    if (isContiguousData)
+    {
+      orgData = (char*)orgaddr;
+    }
+    else
+    {
+      orgData = &sorgaddr[0];
+    }
+  
+    switch(newTypeIndex)
+    {
+      case CkDDT_CONTIGUOUS:
+      {
+        CkDDT_Contiguous newType = *(static_cast<CkDDT_Contiguous*>(newDataType));
+        thisProxy[rank].winRemoteAccumulateNewDataType(orgTotalSize, orgData, orgcnt, orgtype,
+          targdisp, targcnt, targtype, op, win->index, newType, newTypeIndex);
+        break;
+       }
+      case CkDDT_VECTOR:
+      {
+        CkDDT_Vector newType = *(static_cast<CkDDT_Vector*> (newDataType));
+        thisProxy[rank].winRemoteAccumulateNewDataType(orgTotalSize, orgData, orgcnt, orgtype,
+          targdisp, targcnt, targtype, op, win->index, newType, newTypeIndex);
+        break;
+      }
+      case CkDDT_HVECTOR:
+      {
+        CkDDT_HVector newType = *(static_cast<CkDDT_HVector*>(newDataType));
+        thisProxy[rank].winRemoteAccumulateNewDataType(orgTotalSize, orgData, orgcnt, orgtype,
+          targdisp, targcnt, targtype, op, win->index, newType, newTypeIndex);
+        break;
+       }
+      case CkDDT_INDEXED:
+      {
+        CkDDT_Indexed newType = *(static_cast<CkDDT_Indexed*>(newDataType));
+        thisProxy[rank].winRemoteAccumulateNewDataType(orgTotalSize, orgData, orgcnt, orgtype,
+          targdisp, targcnt, targtype, op, win->index, newType, newTypeIndex);
+        break;
+       }
+      case CkDDT_HINDEXED:
+      {
+        CkDDT_HIndexed newType = *(static_cast<CkDDT_HIndexed*>(newDataType));
+        thisProxy[rank].winRemoteAccumulateNewDataType(orgTotalSize, orgData, orgcnt, orgtype,
+          targdisp, targcnt, targtype, op, win->index, newType, newTypeIndex);
+        break;
+       }
+      case CkDDT_INDEXED_BLOCK:
+      {
+        CkDDT_Indexed_Block newType = *(static_cast<CkDDT_HIndexed_Block*>(newDataType));
+        thisProxy[rank].winRemoteAccumulateNewDataType(orgTotalSize, orgData, orgcnt, orgtype,
+          targdisp, targcnt, targtype, op, win->index, newType, newTypeIndex);
+        break;
+       }
+      case CkDDT_HINDEXED_BLOCK:
+      {
+        CkDDT_HIndexed_Block newType = *(static_cast<CkDDT_HIndexed_Block*>(newDataType));
+        thisProxy[rank].winRemoteAccumulateNewDataType(orgTotalSize, orgData, orgcnt, orgtype,
+          targdisp, targcnt, targtype, op, win->index, newType, newTypeIndex);
+        break;
+       }
+      case CkDDT_STRUCT:
+      {
+        CkDDT_Struct newType = *(static_cast<CkDDT_Struct*>(newDataType));
+        thisProxy[rank].winRemoteAccumulateNewDataType(orgTotalSize, orgData, orgcnt, orgtype,
+          targdisp, targcnt, targtype, op, win->index, newType, newTypeIndex);
+        break;
+       }
+      default:
+      {
+        CkAbort("AMPI>MPI_Accumulate does not recognize the target derived datatype!");
+        break;
+      }
+    }
   }
-  else {
-    vector<char> sorgaddr(orgtotalsize);
-    ddt->serialize((char*)orgaddr, &sorgaddr[0], orgcnt, 1);
-    thisProxy[rank].winRemoteAccumulate(orgtotalsize, &sorgaddr[0], orgcnt, orgtype,
-                                 targdisp, targcnt, targtype,  op, win->index);
+  else
+  {
+    thisProxy[rank].winRemoteAccumulate(orgTotalSize, (char*)orgaddr, orgcnt, orgtype,
+                               targdisp, targcnt, targtype,  op, win->index);
   }
 
   return MPI_SUCCESS;
@@ -356,14 +594,22 @@ void ampi::winRemoteAccumulate(int orgtotalsize, char* sorgaddr, int orgcnt,
                                int winIndex) {
   win_obj *winobj = winObjects[winIndex];
   CkDDT_DataType *ddt = getDDT()->getType(targtype);
+
+/* 	// Not needed I am pretty sure because ddt should be a contiguous datatype.
   if (ddt->isContig()) {
-    winobj->accumulate(sorgaddr, targcnt, targtype, targdisp, targcnt, targtype, op, parent);
+    winobj->accumulate(sorgaddr, targcnt, targdisp, 0, targtype, op, parent);
   }
   else {
+    // Note that orgtotalsize is really targetTotalExtent
     vector<char> getdata(orgtotalsize);
     ddt->serialize(&getdata[0], sorgaddr, targcnt, (-1));
-    winobj->accumulate(&getdata[0], targcnt, targtype, targdisp, targcnt, targtype, op, parent);
+    winobj->accumulate(&getdata[0], targcnt, targdisp, 0, targtype, op, parent);
   }
+
+*/
+
+  // I actually think that if we ever get here, sorgaddr will be contiguous because it is only made up of primitive types
+  winobj->accumulate(sorgaddr,targcnt,targdisp,0,targtype,op,parent);
 }
 
 int ampi::winGetAccumulate(void *orgaddr, int orgcnt, MPI_Datatype orgtype,
@@ -371,24 +617,115 @@ int ampi::winGetAccumulate(void *orgaddr, int orgcnt, MPI_Datatype orgtype,
                            MPI_Aint targdisp, int targcnt, MPI_Datatype targtype,
                            MPI_Op op, WinStruct *win) {
   CkDDT_DataType *ddt = getDDT()->getType(orgtype);
-  int orgtotalsize = ddt->getSize(orgcnt);
+  int orgTotalSize = ddt->getSize(orgcnt);
   AmpiMsg *msg = new AmpiMsg();
   AMPI_DEBUG("    Rank[%d:%d] invoke Remote get at [%d]\n", thisIndex, myRank, rank);
 
-  msg = thisProxy[rank].winRemoteGet(orgcnt, orgtype, targdisp, targcnt, targtype, win->index);
-
-  ddt->serialize((char*)resaddr, msg->getData(), orgcnt, (-1));
-  if (ddt->isContig()) {
-    parent->applyOp(orgtype, op, orgcnt, resaddr, orgaddr);
-  } else {
-    vector<char> sorgaddr(orgtotalsize);
-    ddt->serialize((char*)orgaddr, &sorgaddr[0], orgcnt, 1);
-    parent->applyOp(orgtype, op, orgcnt, resaddr, &sorgaddr[0]);
-    ddt->serialize((char*)orgaddr, &sorgaddr[0], orgcnt, -1);
+  if (!getDDT()->isPrimitive(targtype))
+  {
+    int newTypeIndex = getDDT()->getType(targtype)->getType();
+    CkDDT_DataType *newDataType = getDDT()->getType(targtype);
+    bool isContiguousData = true;
+    vector<char> sorgaddr;
+    if (!ddt->isContig())
+    {
+      isContiguousData = false;
+      sorgaddr.resize(orgTotalSize);
+      ddt->serialize((char*)orgaddr, &sorgaddr[0], orgcnt, 1);
+    }
+    char* orgData;
+    if (isContiguousData)
+    {
+      orgData = (char*)orgaddr;
+    }
+    else
+    {
+      orgData = &sorgaddr[0];
+    }
+    
+    switch(newTypeIndex)
+    {
+      case CkDDT_CONTIGUOUS:
+      {
+        CkDDT_Contiguous newType = *(static_cast<CkDDT_Contiguous*>(newDataType));
+        msg = thisProxy[rank].winRemoteGetAccumulateNewDataType(orgTotalSize, orgData, orgcnt, orgtype,
+          targdisp, targcnt, targtype, op, win->index, newType, newTypeIndex);
+        break;
+       }
+      case CkDDT_VECTOR:
+      {
+        CkDDT_Vector newType = *(static_cast<CkDDT_Vector*> (newDataType));
+        msg = thisProxy[rank].winRemoteGetAccumulateNewDataType(orgTotalSize, orgData, orgcnt, orgtype,
+          targdisp, targcnt, targtype, op, win->index, newType, newTypeIndex);
+        break;
+      }
+      case CkDDT_HVECTOR:
+      {
+        CkDDT_HVector newType = *(static_cast<CkDDT_HVector*>(newDataType));
+        msg = thisProxy[rank].winRemoteGetAccumulateNewDataType(orgTotalSize, orgData, orgcnt, orgtype,
+          targdisp, targcnt, targtype, op, win->index, newType, newTypeIndex);
+        break;
+       }
+      case CkDDT_INDEXED:
+      {
+        CkDDT_Indexed newType = *(static_cast<CkDDT_Indexed*>(newDataType));
+        msg = thisProxy[rank].winRemoteGetAccumulateNewDataType(orgTotalSize, orgData, orgcnt, orgtype,
+          targdisp, targcnt, targtype, op, win->index, newType, newTypeIndex);
+        break;
+       }
+      case CkDDT_HINDEXED:
+      {
+        CkDDT_HIndexed newType = *(static_cast<CkDDT_HIndexed*>(newDataType));
+        msg = thisProxy[rank].winRemoteGetAccumulateNewDataType(orgTotalSize, orgData, orgcnt, orgtype,
+          targdisp, targcnt, targtype, op, win->index, newType, newTypeIndex);
+        break;
+       }
+      case CkDDT_INDEXED_BLOCK:
+      {
+        CkDDT_Indexed_Block newType = *(static_cast<CkDDT_HIndexed_Block*>(newDataType));
+        msg = thisProxy[rank].winRemoteGetAccumulateNewDataType(orgTotalSize, orgData, orgcnt, orgtype,
+          targdisp, targcnt, targtype, op, win->index, newType, newTypeIndex);
+        break;
+       }
+      case CkDDT_HINDEXED_BLOCK:
+      {
+        CkDDT_HIndexed_Block newType = *(static_cast<CkDDT_HIndexed_Block*>(newDataType));
+        msg = thisProxy[rank].winRemoteGetAccumulateNewDataType(orgTotalSize, orgData, orgcnt, orgtype,
+          targdisp, targcnt, targtype, op, win->index, newType, newTypeIndex);
+        break;
+       }
+      case CkDDT_STRUCT:
+      {
+        CkDDT_Struct newType = *(static_cast<CkDDT_Struct*>(newDataType));
+        msg = thisProxy[rank].winRemoteGetAccumulateNewDataType(orgTotalSize, orgData, orgcnt, orgtype,
+          targdisp, targcnt, targtype, op, win->index, newType, newTypeIndex);
+        break;
+       }
+      default:
+      {
+        CkAbort("AMPI>MPI_Get_accumulate does not recognize the target derived datatype!");
+        break;
+      }
+    }
   }
+  else
+  {
+    msg = thisProxy[rank].winRemoteGetAccumulate(orgTotalSize, (char*)orgaddr, orgcnt, orgtype,
+                               targdisp, targcnt, targtype,  op, win->index);
+  }
+ 
+  getDDT()->getType(restype)->serialize((char*)resaddr, msg->getData(), rescnt, (-1));
 
   delete msg;
   return MPI_SUCCESS;
+}
+
+AmpiMsg* ampi::winRemoteGetAccumulate(int orgTotalSize, char *sorgaddr, int orgcnt, MPI_Datatype orgtype,
+                                MPI_Aint targdisp, int targcnt, MPI_Datatype targtype, MPI_Op op, int winIndex)
+{
+  AmpiMsg* msg = winRemoteGet(orgcnt, orgtype, targdisp, targcnt, targtype, winIndex);
+  winRemoteAccumulate(orgTotalSize, sorgaddr, orgcnt, orgtype, targdisp, targcnt, targtype, op, winIndex);
+  return msg;
 }
 
 int ampi::winCompareAndSwap(void *orgaddr, void *compaddr, void *resaddr, MPI_Datatype type,

--- a/src/libs/conv-libs/ddt/ddt.C
+++ b/src/libs/conv-libs/ddt/ddt.C
@@ -1,4 +1,5 @@
 #include "ddt.h"
+#include "pup_stl.h"
 #include <algorithm>
 #include <limits>
 
@@ -29,17 +30,22 @@ CkDDT::getType(int nIndex) const
     return 0 ;
 }
 
+int
+CkDDT::getTypeTag(int nIndex) const
+{
+  return getType(nIndex)->getType();
+}
+
 void
 CkDDT::pup(PUP::er &p)
 {
   p(max_types);
   p(num_types);
-  if(p.isUnpacking())
+  p|types;
+  if (p.isUnpacking())
   {
-    typeTable = new CkDDT_DataType*[max_types];
-    types = new int[max_types];
+    typeTable.resize(max_types);
   }
-  p(types,max_types);
   int i;
   //unPacking
   if(p.isUnpacking())
@@ -95,8 +101,8 @@ CkDDT::getNextFreeIndex(void)
     if(typeTable[i] == 0)
       return i ;
   int newmax = max_types*2;
-  CkDDT_DataType** newtable = new CkDDT_DataType*[newmax];
-  int *newtype = new int[newmax];
+  vector<CkDDT_DataType*> newtable(newmax);
+  vector<int> newtype(newmax);
   for(i=0;i<max_types;i++)
   {
     newtable[i] = typeTable[i];
@@ -107,8 +113,6 @@ CkDDT::getNextFreeIndex(void)
     newtable[i] = 0;
     newtype[i] = CkDDT_TYPE_NULL;
   }
-  delete[] typeTable;
-  delete[] types;
   typeTable = newtable;
   types = newtype;
   num_types = max_types;
@@ -136,8 +140,6 @@ CkDDT::~CkDDT()
        delete typeTable[i];
     }
   }
-  delete[] typeTable ;
-  delete[] types;
 }
 
 
@@ -482,7 +484,7 @@ CkDDT_DataType::CkDDT_DataType(int datatype, int size, CkDDT_Aint extent, int co
             bool iscontig, int baseSize, CkDDT_Aint baseExtent, CkDDT_DataType* baseType, int numElements, int baseIndex,
             CkDDT_Aint trueExtent, CkDDT_Aint trueLB) :
     datatype(datatype), size(size), extent(extent), count(count), lb(lb), ub(ub), trueExtent(trueExtent),
-    trueLB(trueLB), iscontig(iscontig), baseSize(baseSize), baseExtent(baseExtent), baseType(baseType),
+    trueLB(trueLB), iscontig(iscontig), baseSize(baseSize), baseExtent(baseExtent), baseType(baseType),	// isnt this a shallow copy?
     numElements(numElements), baseIndex(baseIndex), nameLen(0), isAbsolute(false)
 {}
 
@@ -520,7 +522,7 @@ CkDDT_DataType::CkDDT_DataType(const CkDDT_DataType &obj, CkDDT_Aint _lb, CkDDT_
   count       = obj.count;
   isAbsolute  = obj.isAbsolute;
   nameLen     = obj.nameLen;
-  memcpy(name, obj.name, nameLen+1);
+  name        = obj.name;
 
   extent = _extent;
   lb     = _lb;
@@ -560,14 +562,14 @@ CkDDT_DataType::serialize(char* userdata, char* buffer, int num, int dir) const
 void
 CkDDT_DataType::setName(const char *src)
 {
-  CkDDT_SetName(name, src, &nameLen);
+  CkDDT_SetName(&name[0], src, &nameLen);
 }
 
 void
 CkDDT_DataType::getName(char *dest, int *len) const
 {
   *len = nameLen;
-  memcpy(dest, name, *len+1);
+  memcpy(dest,name.c_str(),*len+1);
 }
 
 bool
@@ -691,7 +693,7 @@ CkDDT_DataType::pupType(PUP::er  &p, CkDDT* ddt)
   p(isAbsolute);
   p(numElements);
   p(nameLen);
-  p(name,CkDDT_MAX_NAME_LEN);
+  p|name;
 }
 
 int
@@ -991,7 +993,7 @@ CkDDT_Indexed::CkDDT_Indexed(int nCount, int* arrBlock, CkDDT_Aint* arrDisp, int
     : CkDDT_DataType(CkDDT_INDEXED, 0, 0, nCount, numeric_limits<CkDDT_Aint>::max(),
 		     numeric_limits<CkDDT_Aint>::min(), 0, base->getSize(), base->getExtent(),
 		     base, nCount* base->getNumElements(), bindex, 0, 0),
-    arrayBlockLength(new int[nCount]), arrayDisplacements(new CkDDT_Aint[nCount])
+      arrayBlockLength(nCount), arrayDisplacements(nCount)
 {
     CkDDT_Aint positiveExtent = 0;
     CkDDT_Aint negativeExtent = 0;
@@ -1064,10 +1066,7 @@ CkDDT_Indexed::serialize(char* userdata, char* buffer, int num, int dir) const
 }
 
 CkDDT_Indexed::~CkDDT_Indexed()
-{
-  delete [] arrayBlockLength ;
-  delete [] arrayDisplacements ;
-}
+{}
 
 void
 CkDDT_Indexed::pupType(PUP::er &p, CkDDT* ddt)
@@ -1085,12 +1084,8 @@ CkDDT_Indexed::pupType(PUP::er &p, CkDDT* ddt)
   p(trueLB);
   p(iscontig);
   p(numElements);
-
-  if(p.isUnpacking() )  arrayBlockLength = new int[count] ;
-  p(arrayBlockLength, count);
-
-  if(p.isUnpacking() )  arrayDisplacements = new CkDDT_Aint[count] ;
-  p(arrayDisplacements, count);
+  p|arrayBlockLength;
+  p|arrayDisplacements;
 
   if(p.isUnpacking()) baseType = ddt->getType(baseIndex);
 }
@@ -1129,7 +1124,7 @@ CkDDT_HIndexed::CkDDT_HIndexed(int nCount, int* arrBlock, CkDDT_Aint* arrDisp,  
       ub = std::max(arrBlock[i]*baseExtent + baseType->getLB() + arrayDisplacements[i], ub);
   }
 
-  lb = baseType->getLB() + *std::min_element(arrDisp, arrDisp+nCount+1);
+  lb = baseType->getLB() + *std::min_element(&arrDisp[0],&arrDisp[0]+nCount+1);
   extent = ub - lb;
 
   trueExtent = extent;
@@ -1215,7 +1210,7 @@ CkDDT_Indexed_Block::CkDDT_Indexed_Block(int count, int Blength, CkDDT_Aint *Arr
   CkDDT_DataType *type)     : CkDDT_DataType(CkDDT_INDEXED_BLOCK, 0, 0, count, numeric_limits<CkDDT_Aint>::max(),
          numeric_limits<CkDDT_Aint>::min(), 0, type->getSize(), type->getExtent(),
          type, count * type->getNumElements(), index, 0, 0),
-    BlockLength(Blength), arrayDisplacements(new CkDDT_Aint[count])
+    BlockLength(Blength), arrayDisplacements(count)
 {
   CkDDT_Aint positiveExtent = 0;
   CkDDT_Aint negativeExtent = 0;
@@ -1232,7 +1227,7 @@ CkDDT_Indexed_Block::CkDDT_Indexed_Block(int count, int Blength, CkDDT_Aint *Arr
   }
 
   extent = positiveExtent + (-1)*negativeExtent;
-  lb = baseType->getLB() + *std::min_element(arrayDisplacements, arrayDisplacements + count+1)*baseExtent;
+  lb = baseType->getLB() + *std::min_element(&arrayDisplacements[0], &arrayDisplacements[0] + count+1)*baseExtent;
   ub = lb + extent;
 
   trueExtent = extent;
@@ -1261,9 +1256,7 @@ CkDDT_Indexed_Block::CkDDT_Indexed_Block(int count, int Blength, CkDDT_Aint *Arr
 }
 
 CkDDT_Indexed_Block::~CkDDT_Indexed_Block()
-{
-  delete [] arrayDisplacements;
-}
+{}
 
 size_t
 CkDDT_Indexed_Block::serialize(char *userdata, char *buffer, int num, int dir) const
@@ -1310,9 +1303,7 @@ CkDDT_Indexed_Block::pupType(PUP::er &p, CkDDT *ddt)
   p(iscontig);
   p(numElements);
   p(BlockLength);
-
-  if(p.isUnpacking() )  arrayDisplacements = new CkDDT_Aint[count] ;
-  p(arrayDisplacements, count);
+  p|arrayDisplacements;
 
   if(p.isUnpacking()) baseType = ddt->getType(baseIndex);
 }
@@ -1357,7 +1348,7 @@ CkDDT_HIndexed_Block::CkDDT_HIndexed_Block(int count, int Blength, CkDDT_Aint *A
   }
 
   extent = positiveExtent + (-1)*negativeExtent;
-  lb = baseType->getLB() + *std::min_element(arrayDisplacements, arrayDisplacements + count+1);
+  lb = baseType->getLB() + *std::min_element(&arrayDisplacements[0], &arrayDisplacements[0] + count+1);
   ub = lb + extent;
 
   trueExtent = extent;
@@ -1386,9 +1377,7 @@ CkDDT_HIndexed_Block::CkDDT_HIndexed_Block(int count, int Blength, CkDDT_Aint *A
 }
 
 CkDDT_HIndexed_Block::~CkDDT_HIndexed_Block()
-{
-  delete [] arrayDisplacements;
-}
+{}
 
 size_t
 CkDDT_HIndexed_Block::serialize(char *userdata, char *buffer, int num, int dir) const
@@ -1435,9 +1424,7 @@ CkDDT_HIndexed_Block::pupType(PUP::er &p, CkDDT *ddt)
   p(iscontig);
   p(numElements);
   p(BlockLength);
-
-  if(p.isUnpacking() )  arrayDisplacements = new CkDDT_Aint[count] ;
-  p(arrayDisplacements, count);
+  p|arrayDisplacements;
 
   if(p.isUnpacking()) baseType = ddt->getType(baseIndex);
 }
@@ -1468,8 +1455,8 @@ CkDDT_Struct::CkDDT_Struct(int nCount, int* arrBlock,
                        CkDDT_Aint* arrDisp, int *bindex, CkDDT_DataType** arrBase)
     : CkDDT_DataType(CkDDT_STRUCT, 0, 0, nCount, numeric_limits<CkDDT_Aint>::max(),
     numeric_limits<CkDDT_Aint>::min(), 0, 0, 0, NULL, 0, 0, 0, 0),
-    arrayBlockLength(new int[nCount]), arrayDisplacements(new CkDDT_Aint[nCount]),
-    index(new int[nCount]), arrayDataType(new CkDDT_DataType*[nCount])
+    arrayBlockLength(nCount), arrayDisplacements(nCount),
+    index(nCount), arrayDataType(nCount)
 {
   int saveExtent = 0;
   for (int i=0; i<count; i++) {
@@ -1597,20 +1584,16 @@ CkDDT_Struct::pupType(PUP::er &p, CkDDT* ddt)
   p(trueLB);
   p(iscontig);
   p(numElements);
-  if(p.isUnpacking())
-  {
-    arrayBlockLength = new int[count] ;
-    arrayDisplacements = new CkDDT_Aint[count] ;
-    index = new int[count] ;
-    arrayDataType = new CkDDT_DataType*[count] ;
-  }
-  p(arrayBlockLength, count);
-  p(arrayDisplacements, count);
-  p(index, count);
+  p|arrayBlockLength;
+  p|arrayDisplacements;
+  p|index;
 
   if(p.isUnpacking())
+  {
+    arrayDataType.resize(count);
     for(int i=0 ; i < count; i++)
       arrayDataType[i] = ddt->getType(index[i]);
+  }
 }
 
 int

--- a/src/libs/conv-libs/ddt/ddt.C
+++ b/src/libs/conv-libs/ddt/ddt.C
@@ -696,6 +696,28 @@ CkDDT_DataType::pupType(PUP::er  &p, CkDDT* ddt)
   p|name;
 }
 
+void
+CkDDT_DataType::pup(PUP::er &p)
+{
+  p(datatype);
+  p(refCount);
+  p(size);
+  p(extent);
+  p(count);
+  p(baseSize);
+  p(baseExtent);
+  p(baseIndex);
+  p(trueExtent);
+  p(trueLB);
+  p(lb);
+  p(ub);
+  p(iscontig);
+  p(isAbsolute);
+  p(numElements);
+  p(nameLen);
+  p|name;
+}
+
 int
 CkDDT_DataType::getEnvelope(int *ni, int *na, int *nd, int *combiner) const
 {
@@ -774,6 +796,27 @@ CkDDT_Contiguous::pupType(PUP::er &p, CkDDT *ddt)
   p(iscontig);
   p(numElements);
   if(p.isUnpacking()) baseType = ddt->getType(baseIndex);
+}
+
+void
+CkDDT_Contiguous::pup(PUP::er &p)
+{
+  p(datatype);
+  p(size);
+  p(extent);
+  p(count);
+  p(baseSize);
+  p(baseExtent);
+  p(baseIndex);
+  p(lb);
+  p(ub);
+  p(trueExtent);
+  p(trueLB);
+  p(iscontig);
+  p(numElements);
+
+  /* Note that pup methods for derived datatypes currently only support primitive baseTypes */
+  CmiAssert(baseIndex <= CkDDT_MAX_PRIMITIVE_TYPE);
 }
 
 int
@@ -878,6 +921,29 @@ CkDDT_Vector::pupType(PUP::er &p, CkDDT* ddt)
   if(p.isUnpacking()) baseType = ddt->getType(baseIndex);
 }
 
+void
+CkDDT_Vector::pup(PUP::er &p)
+{
+  p(datatype);
+  p(size);
+  p(extent);
+  p(count);
+  p(baseSize);
+  p(baseExtent);
+  p(blockLength);
+  p(strideLength);
+  p(baseIndex);
+  p(lb);
+  p(ub);
+  p(trueExtent);
+  p(trueLB);
+  p(iscontig);
+  p(numElements);
+  
+  /* Note that pup methods for derived datatypes currently only support primitive baseTypes */
+  CmiAssert(baseIndex <= CkDDT_MAX_PRIMITIVE_TYPE);
+}
+
 int
 CkDDT_Vector::getEnvelope(int *ni, int *na, int *nd, int *combiner) const
 {
@@ -966,6 +1032,12 @@ void
 CkDDT_HVector::pupType(PUP::er &p, CkDDT* ddt)
 {
   CkDDT_Vector::pupType(p, ddt);
+}
+
+void
+CkDDT_HVector::pup(PUP::er &p)
+{
+  CkDDT_Vector::pup(p);
 }
 
 int
@@ -1090,6 +1162,29 @@ CkDDT_Indexed::pupType(PUP::er &p, CkDDT* ddt)
   if(p.isUnpacking()) baseType = ddt->getType(baseIndex);
 }
 
+void
+CkDDT_Indexed::pup(PUP::er &p)
+{
+  p(datatype);
+  p(size);
+  p(extent);
+  p(count);
+  p(baseSize);
+  p(baseExtent);
+  p(baseIndex);
+  p(lb);
+  p(ub);
+  p(trueExtent);
+  p(trueLB);
+  p(iscontig);
+  p(numElements);
+  p|arrayBlockLength;
+  p|arrayDisplacements;
+
+  /* Note that pup methods for derived datatypes currently only support primitive baseTypes */
+  CmiAssert(baseIndex <= CkDDT_MAX_PRIMITIVE_TYPE);
+}
+
 int
 CkDDT_Indexed::getEnvelope(int *ni, int *na, int *nd, int *combiner) const
 {
@@ -1182,6 +1277,12 @@ void
 CkDDT_HIndexed::pupType(PUP::er &p, CkDDT* ddt)
 {
   CkDDT_Indexed::pupType(p, ddt);
+}
+
+void
+CkDDT_HIndexed::pup(PUP::er &p)
+{
+  CkDDT_Indexed::pup(p);
 }
 
 int
@@ -1308,6 +1409,29 @@ CkDDT_Indexed_Block::pupType(PUP::er &p, CkDDT *ddt)
   if(p.isUnpacking()) baseType = ddt->getType(baseIndex);
 }
 
+void
+CkDDT_Indexed_Block::pup(PUP::er &p)
+{
+  p(datatype);
+  p(size);
+  p(extent);
+  p(count);
+  p(baseSize);
+  p(baseExtent);
+  p(baseIndex);
+  p(lb);
+  p(ub);
+  p(trueExtent);
+  p(trueLB);
+  p(iscontig);
+  p(numElements);
+  p(BlockLength);
+  p|arrayDisplacements;
+
+  /* Note that pup methods for derived datatypes currently only support primitive baseTypes */
+  CmiAssert(baseIndex <= CkDDT_MAX_PRIMITIVE_TYPE);
+}
+
 int
 CkDDT_Indexed_Block::getEnvelope(int *ni, int *na, int *nd, int *combiner) const
 {
@@ -1427,6 +1551,29 @@ CkDDT_HIndexed_Block::pupType(PUP::er &p, CkDDT *ddt)
   p|arrayDisplacements;
 
   if(p.isUnpacking()) baseType = ddt->getType(baseIndex);
+}
+
+void
+CkDDT_HIndexed_Block::pup(PUP::er &p)
+{
+  p(datatype);
+  p(size);
+  p(extent);
+  p(count);
+  p(baseSize);
+  p(baseExtent);
+  p(baseIndex);
+  p(lb);
+  p(ub);
+  p(trueExtent);
+  p(trueLB);
+  p(iscontig);
+  p(numElements);
+  p(BlockLength);
+  p|arrayDisplacements;
+
+  /* Note that pup methods for derived datatypes currently only support primitive baseTypes */
+  CmiAssert(baseIndex <= CkDDT_MAX_PRIMITIVE_TYPE);
 }
 
 int
@@ -1594,6 +1741,27 @@ CkDDT_Struct::pupType(PUP::er &p, CkDDT* ddt)
     for(int i=0 ; i < count; i++)
       arrayDataType[i] = ddt->getType(index[i]);
   }
+}
+
+void
+CkDDT_Struct::pup(PUP::er &p)
+{
+  p(datatype);
+  p(size);
+  p(extent);
+  p(count);
+  p(lb);
+  p(ub);
+  p(trueExtent);
+  p(trueLB);
+  p(iscontig);
+  p(numElements);
+  p|arrayBlockLength;
+  p|arrayDisplacements;
+  p|index;
+
+  /* Note that pup methods for derived datatypes currently only support primitive baseTypes */
+  CmiAssert(baseIndex <= CkDDT_MAX_PRIMITIVE_TYPE);
 }
 
 int

--- a/src/libs/conv-libs/ddt/ddt.C
+++ b/src/libs/conv-libs/ddt/ddt.C
@@ -149,6 +149,12 @@ CkDDT::isContig(int nIndex) const
   return getType(nIndex)->isContig();
 }
 
+bool
+CkDDT::isPrimitive(int nIndex) const
+{
+  return nIndex <= CkDDT_MAX_PRIMITIVE_TYPE;
+}
+
 int
 CkDDT::getSize(int nIndex, int count) const
 {
@@ -264,7 +270,7 @@ CkDDT::newHVector(int count, int blocklength, int stride,
 }
 
 void
-CkDDT::newIndexed(int count, int* arrbLength, CkDDT_Aint* arrDisp,
+CkDDT::newIndexed(int count, const int* arrbLength, const CkDDT_Aint* arrDisp,
                   CkDDT_Type oldtype, CkDDT_Type* newType)
 {
   int index = *newType =  getNextFreeIndex() ;
@@ -275,7 +281,7 @@ CkDDT::newIndexed(int count, int* arrbLength, CkDDT_Aint* arrDisp,
 }
 
 void
-CkDDT::newHIndexed(int count, int* arrbLength, CkDDT_Aint* arrDisp,
+CkDDT::newHIndexed(int count, const int* arrbLength, const CkDDT_Aint* arrDisp,
                    CkDDT_Type oldtype, CkDDT_Type* newType)
 {
   int index = *newType =  getNextFreeIndex() ;
@@ -286,7 +292,7 @@ CkDDT::newHIndexed(int count, int* arrbLength, CkDDT_Aint* arrDisp,
 }
 
 void
-CkDDT::newIndexedBlock(int count, int Blocklength, CkDDT_Aint *arrDisp, CkDDT_Type oldtype,
+CkDDT::newIndexedBlock(int count, int Blocklength, const CkDDT_Aint *arrDisp, CkDDT_Type oldtype,
                   CkDDT_Type *newtype)
 {
   int index = *newtype = getNextFreeIndex();
@@ -296,7 +302,7 @@ CkDDT::newIndexedBlock(int count, int Blocklength, CkDDT_Aint *arrDisp, CkDDT_Ty
 }
 
 void
-CkDDT::newHIndexedBlock(int count, int Blocklength, CkDDT_Aint *arrDisp, CkDDT_Type oldtype,
+CkDDT::newHIndexedBlock(int count, int Blocklength, const CkDDT_Aint *arrDisp, CkDDT_Type oldtype,
                   CkDDT_Type *newtype)
 {
   int index = *newtype = getNextFreeIndex();
@@ -306,8 +312,8 @@ CkDDT::newHIndexedBlock(int count, int Blocklength, CkDDT_Aint *arrDisp, CkDDT_T
 }
 
 void
-CkDDT::newStruct(int count, int* arrbLength, CkDDT_Aint* arrDisp,
-                 CkDDT_Type *oldtype, CkDDT_Type* newType)
+CkDDT::newStruct(int count, const int* arrbLength, const CkDDT_Aint* arrDisp,
+                 const CkDDT_Type *oldtype, CkDDT_Type* newType)
 {
   int index = *newType =  getNextFreeIndex() ;
   CkDDT_DataType **olddatatypes = new CkDDT_DataType*[count];
@@ -735,6 +741,41 @@ CkDDT_DataType::getContents(int ni, int na, int nd, int i[], CkDDT_Aint a[], int
   return -1;
 }
 
+int
+CkDDT_DataType::getBlockLength() const
+{
+  CmiAbort("Wrong Type. Should have never gotten here");
+  return -1;
+}
+
+int
+CkDDT_DataType::getStrideLength() const
+{
+  CmiAbort("Wrong Type. Should have never gotten here");
+  return -1;
+}
+
+const int*
+CkDDT_DataType::getArrayBlockLength() const
+{
+  CmiAbort("Wrong Type. Should have never gotten here");
+  return NULL;
+}
+
+const CkDDT_Aint*
+CkDDT_DataType::getArrayDisps() const
+{
+  CmiAbort("Wrong Type. Should have never gotten here");
+  return NULL;
+}
+
+const CkDDT_Type*
+CkDDT_DataType::getTypes() const
+{
+  CmiAbort("Wrong Type. Should have never gotten here");
+  return NULL;
+}
+
 CkDDT_Contiguous::CkDDT_Contiguous(int nCount, int bindex, CkDDT_DataType* oldType)
 {
   datatype = CkDDT_CONTIGUOUS;
@@ -757,6 +798,24 @@ CkDDT_Contiguous::CkDDT_Contiguous(int nCount, int bindex, CkDDT_DataType* oldTy
   else {
     iscontig = baseType->isContig();
   }
+}
+
+CkDDT_Contiguous::CkDDT_Contiguous(const CkDDT_Contiguous& obj)
+{
+  this->datatype = obj.datatype;
+  this->count = obj.count;
+  this->baseIndex = obj.baseIndex;
+  this->baseType =  obj.baseType;	// deep copy problem?
+  this->baseSize = obj.baseSize;
+  this->baseExtent = obj.baseExtent;
+  this->numElements = obj.numElements;
+  this->size = obj.size;
+  this->extent = obj.extent;
+  this->ub = obj.ub;
+  this->lb = obj.lb;
+  this->iscontig = obj.iscontig;
+  this->trueLB = obj.trueLB;
+  this->trueExtent = obj.trueExtent;
 }
 
 size_t
@@ -837,6 +896,41 @@ CkDDT_Contiguous::getContents(int ni, int na, int nd, int i[], CkDDT_Aint a[], i
   return 0;
 }
 
+int
+CkDDT_Contiguous::getBlockLength() const
+{
+  CmiAbort("Wrong Type. Should have never gotten here");
+  return -1;
+}
+
+int
+CkDDT_Contiguous::getStrideLength() const
+{
+  CmiAbort("Wrong Type. Should have never gotten here");
+  return -1;
+}
+
+const int*
+CkDDT_Contiguous::getArrayBlockLength() const
+{
+  CmiAbort("Wrong Type. Should have never gotten here");
+  return NULL;
+}
+
+const CkDDT_Aint*
+CkDDT_Contiguous::getArrayDisps() const
+{
+  CmiAbort("Wrong Type. Should have never gotten here");
+  return NULL;
+}
+
+const CkDDT_Type*
+CkDDT_Contiguous::getTypes() const
+{
+  CmiAbort("Wrong Type. Should have never gotten here");
+  return NULL;
+}
+
 CkDDT_Vector::CkDDT_Vector(int nCount, int blength, int stride, int bindex, CkDDT_DataType* oldType)
 {
   datatype = CkDDT_VECTOR;
@@ -874,6 +968,26 @@ CkDDT_Vector::CkDDT_Vector(int nCount, int blength, int stride, int bindex, CkDD
     else
       iscontig = false;
   }
+}
+
+CkDDT_Vector::CkDDT_Vector(const CkDDT_Vector& obj)
+{
+  this->datatype = obj.datatype;
+  this->count = obj.count;
+  this->blockLength = obj.blockLength;
+  this->strideLength = obj.strideLength;
+  this->baseIndex = obj.baseIndex;
+  this->baseType =  obj.baseType;	// deep copy problem?
+  this->baseSize = obj.baseSize;
+  this->baseExtent = obj.baseExtent;
+  this->numElements = obj.numElements;
+  this->size = obj.size;
+  this->extent = obj.extent;
+  this->ub = obj.ub;
+  this->lb = obj.lb;
+  this->iscontig = obj.iscontig;
+  this->trueLB = obj.trueLB;
+  this->trueExtent = obj.trueExtent;
 }
 
 size_t
@@ -964,6 +1078,39 @@ CkDDT_Vector::getContents(int ni, int na, int nd, int i[], CkDDT_Aint a[], int d
   return 0;
 }
 
+int
+CkDDT_Vector::getBlockLength() const
+{
+  return this->blockLength;
+}
+
+int
+CkDDT_Vector::getStrideLength() const
+{
+  return this->strideLength;
+}
+
+const int*
+CkDDT_Vector::getArrayBlockLength() const
+{
+  CmiAbort("Wrong Type. Should have never gotten here");
+  return NULL;
+}
+
+const CkDDT_Aint*
+CkDDT_Vector::getArrayDisps() const
+{
+  CmiAbort("Wrong Type. Should have never gotten here");
+  return NULL;
+}
+
+const CkDDT_Type*
+CkDDT_Vector::getTypes() const
+{
+  CmiAbort("Wrong Type. Should have never gotten here");
+  return NULL;
+}
+
 CkDDT_HVector::CkDDT_HVector(int nCount, int blength, int stride,  int bindex,
                          CkDDT_DataType* oldType)
 {
@@ -1002,6 +1149,26 @@ CkDDT_HVector::CkDDT_HVector(int nCount, int blength, int stride,  int bindex,
     else
       iscontig = false;
   }
+}
+
+CkDDT_HVector::CkDDT_HVector(const CkDDT_HVector& obj)
+{
+  this->datatype = obj.datatype;
+  this->count = obj.count;
+  this->blockLength = obj.blockLength;
+  this->strideLength = obj.strideLength;
+  this->baseIndex = obj.baseIndex;
+  this->baseType =  obj.baseType;	// deep copy problem?
+  this->baseSize = obj.baseSize;
+  this->baseExtent = obj.baseExtent;
+  this->numElements = obj.numElements;
+  this->size = obj.size;
+  this->extent = obj.extent;
+  this->ub = obj.ub;
+  this->lb = obj.lb;
+  this->iscontig = obj.iscontig;
+  this->trueLB = obj.trueLB;
+  this->trueExtent = obj.trueExtent;
 }
 
 size_t
@@ -1060,7 +1227,40 @@ CkDDT_HVector::getContents(int ni, int na, int nd, int i[], CkDDT_Aint a[], int 
   return 0;
 }
 
-CkDDT_Indexed::CkDDT_Indexed(int nCount, int* arrBlock, CkDDT_Aint* arrDisp, int bindex,
+int
+CkDDT_HVector::getBlockLength() const
+{
+  CkDDT_Vector::getBlockLength();
+}
+
+int
+CkDDT_HVector::getStrideLength() const
+{
+  CkDDT_Vector::getStrideLength();
+}
+
+const int*
+CkDDT_HVector::getArrayBlockLength() const
+{
+  CmiAbort("Wrong Type. Should have never gotten here");
+  return NULL;
+}
+
+const CkDDT_Aint*
+CkDDT_HVector::getArrayDisps() const
+{
+  CmiAbort("Wrong Type. Should have never gotten here");
+  return NULL;
+}
+
+const CkDDT_Type*
+CkDDT_HVector::getTypes() const
+{
+  CmiAbort("Wrong Type. Should have never gotten here");
+  return NULL;
+}
+
+CkDDT_Indexed::CkDDT_Indexed(int nCount, const int* arrBlock, const CkDDT_Aint* arrDisp, int bindex,
                          CkDDT_DataType* base)
     : CkDDT_DataType(CkDDT_INDEXED, 0, 0, nCount, numeric_limits<CkDDT_Aint>::max(),
 		     numeric_limits<CkDDT_Aint>::min(), 0, base->getSize(), base->getExtent(),
@@ -1106,6 +1306,26 @@ CkDDT_Indexed::CkDDT_Indexed(int nCount, int* arrBlock, CkDDT_Aint* arrDisp, int
         }
         iscontig = (contig && baseType->isContig());
     }
+}
+
+CkDDT_Indexed::CkDDT_Indexed(const CkDDT_Indexed& obj)
+{
+  this->datatype = obj.datatype;
+  this->count = obj.count;
+  this->arrayBlockLength = obj.arrayBlockLength;
+  this->arrayDisplacements = obj.arrayDisplacements;
+  this->baseIndex = obj.baseIndex;
+  this->baseType =  obj.baseType;	// deep copy problem?
+  this->baseSize = obj.baseSize;
+  this->baseExtent = obj.baseExtent;
+  this->numElements = obj.numElements;
+  this->size = obj.size;
+  this->extent = obj.extent;
+  this->ub = obj.ub;
+  this->lb = obj.lb;
+  this->iscontig = obj.iscontig;
+  this->trueLB = obj.trueLB;
+  this->trueExtent = obj.trueExtent;
 }
 
 size_t
@@ -1207,7 +1427,40 @@ CkDDT_Indexed::getContents(int ni, int na, int nd, int i[], CkDDT_Aint a[], int 
   return 0;
 }
 
-CkDDT_HIndexed::CkDDT_HIndexed(int nCount, int* arrBlock, CkDDT_Aint* arrDisp,  int bindex,
+const int*
+CkDDT_Indexed::getArrayBlockLength() const
+{
+  return &this->arrayBlockLength[0];
+}
+
+const CkDDT_Aint*
+CkDDT_Indexed::getArrayDisps() const
+{
+  return &this->arrayDisplacements[0];
+}
+
+int
+CkDDT_Indexed::getBlockLength() const
+{
+  CmiAbort("Wrong Type. Should have never gotten here");
+  return -1;
+}
+
+int
+CkDDT_Indexed::getStrideLength() const
+{
+  CmiAbort("Wrong Type. Should have never gotten here");
+  return -1;
+}
+
+const CkDDT_Type*
+CkDDT_Indexed::getTypes() const
+{
+  CmiAbort("Wrong Type. Should have never gotten here");
+  return NULL;
+}
+
+CkDDT_HIndexed::CkDDT_HIndexed(int nCount, const int* arrBlock, const CkDDT_Aint* arrDisp,  int bindex,
                            CkDDT_DataType* base)
     : CkDDT_Indexed(nCount, arrBlock, arrDisp, bindex, base)
 {
@@ -1242,6 +1495,26 @@ CkDDT_HIndexed::CkDDT_HIndexed(int nCount, int* arrBlock, CkDDT_Aint* arrDisp,  
     }
     iscontig = (contig && baseType->isContig());
   }
+}
+
+CkDDT_HIndexed::CkDDT_HIndexed(const CkDDT_HIndexed& obj)
+{
+  this->datatype = obj.datatype;
+  this->count = obj.count;
+  this->arrayBlockLength = obj.arrayBlockLength;
+  this->arrayDisplacements = obj.arrayDisplacements;
+  this->baseIndex = obj.baseIndex;
+  this->baseType =  obj.baseType;	// deep copy problem?
+  this->baseSize = obj.baseSize;
+  this->baseExtent = obj.baseExtent;
+  this->numElements = obj.numElements;
+  this->size = obj.size;
+  this->extent = obj.extent;
+  this->ub = obj.ub;
+  this->lb = obj.lb;
+  this->iscontig = obj.iscontig;
+  this->trueLB = obj.trueLB;
+  this->trueExtent = obj.trueExtent;
 }
 
 size_t
@@ -1307,7 +1580,40 @@ CkDDT_HIndexed::getContents(int ni, int na, int nd, int i[], CkDDT_Aint a[], int
   return 0;
 }
 
-CkDDT_Indexed_Block::CkDDT_Indexed_Block(int count, int Blength, CkDDT_Aint *ArrDisp, int index,
+const int*
+CkDDT_HIndexed::getArrayBlockLength() const
+{
+  return CkDDT_Indexed::getArrayBlockLength();
+}
+
+const CkDDT_Aint*
+CkDDT_HIndexed::getArrayDisps() const
+{
+  return CkDDT_Indexed::getArrayDisps();
+}
+
+int
+CkDDT_HIndexed::getBlockLength() const
+{
+  CmiAbort("Wrong Type. Should have never gotten here");
+  return -1;
+}
+
+int
+CkDDT_HIndexed::getStrideLength() const
+{
+  CmiAbort("Wrong Type. Should have never gotten here");
+  return -1;
+}
+
+const CkDDT_Type*
+CkDDT_HIndexed::getTypes() const
+{
+  CmiAbort("Wrong Type. Should have never gotten here");
+  return NULL;
+}
+
+CkDDT_Indexed_Block::CkDDT_Indexed_Block(int count, int Blength, const CkDDT_Aint *ArrDisp, int index,
   CkDDT_DataType *type)     : CkDDT_DataType(CkDDT_INDEXED_BLOCK, 0, 0, count, numeric_limits<CkDDT_Aint>::max(),
          numeric_limits<CkDDT_Aint>::min(), 0, type->getSize(), type->getExtent(),
          type, count * type->getNumElements(), index, 0, 0),
@@ -1354,6 +1660,26 @@ CkDDT_Indexed_Block::CkDDT_Indexed_Block(int count, int Blength, CkDDT_Aint *Arr
     }
     iscontig = (contig && baseType->isContig());
   }
+}
+
+CkDDT_Indexed_Block::CkDDT_Indexed_Block(const CkDDT_Indexed_Block& obj)
+{
+  this->datatype = obj.datatype;
+  this->count = obj.count;
+  this->BlockLength = obj.BlockLength;
+  this->arrayDisplacements = obj.arrayDisplacements;
+  this->baseIndex = obj.baseIndex;
+  this->baseType =  obj.baseType;	// deep copy problem?
+  this->baseSize = obj.baseSize;
+  this->baseExtent = obj.baseExtent;
+  this->numElements = obj.numElements;
+  this->size = obj.size;
+  this->extent = obj.extent;
+  this->ub = obj.ub;
+  this->lb = obj.lb;
+  this->iscontig = obj.iscontig;
+  this->trueLB = obj.trueLB;
+  this->trueExtent = obj.trueExtent;
 }
 
 CkDDT_Indexed_Block::~CkDDT_Indexed_Block()
@@ -1454,7 +1780,40 @@ CkDDT_Indexed_Block::getContents(int ni, int na, int nd, int i[], CkDDT_Aint a[]
   return 0;
 }
 
-CkDDT_HIndexed_Block::CkDDT_HIndexed_Block(int count, int Blength, CkDDT_Aint *ArrDisp, int index,
+int
+CkDDT_Indexed_Block::getBlockLength() const
+{
+  return this->BlockLength;
+}
+
+const CkDDT_Aint*
+CkDDT_Indexed_Block::getArrayDisps() const
+{
+  return &this->arrayDisplacements[0];
+}
+
+const int*
+CkDDT_Indexed_Block::getArrayBlockLength() const
+{
+  CmiAbort("Wrong Type. Should have never gotten here");
+  return NULL;
+}
+
+int
+CkDDT_Indexed_Block::getStrideLength() const
+{
+  CmiAbort("Wrong Type. Should have never gotten here");
+  return -1;
+}
+
+const CkDDT_Type*
+CkDDT_Indexed_Block::getTypes() const
+{
+  CmiAbort("Wrong Type. Should have never gotten here");
+  return NULL;
+}
+
+CkDDT_HIndexed_Block::CkDDT_HIndexed_Block(int count, int Blength, const CkDDT_Aint *ArrDisp, int index,
   CkDDT_DataType *type)     : CkDDT_Indexed_Block(count, Blength,ArrDisp,index,type)
 {
   CkDDT_Aint positiveExtent = 0;
@@ -1498,6 +1857,26 @@ CkDDT_HIndexed_Block::CkDDT_HIndexed_Block(int count, int Blength, CkDDT_Aint *A
     }
     iscontig = (contig && baseType->isContig());
   }
+}
+
+CkDDT_HIndexed_Block::CkDDT_HIndexed_Block(const CkDDT_HIndexed_Block& obj)
+{
+  this->datatype = obj.datatype;
+  this->count = obj.count;
+  this->BlockLength = obj.BlockLength;
+  this->arrayDisplacements = obj.arrayDisplacements;
+  this->baseIndex = obj.baseIndex;
+  this->baseType =  obj.baseType;	// deep copy problem?
+  this->baseSize = obj.baseSize;
+  this->baseExtent = obj.baseExtent;
+  this->numElements = obj.numElements;
+  this->size = obj.size;
+  this->extent = obj.extent;
+  this->ub = obj.ub;
+  this->lb = obj.lb;
+  this->iscontig = obj.iscontig;
+  this->trueLB = obj.trueLB;
+  this->trueExtent = obj.trueExtent;
 }
 
 CkDDT_HIndexed_Block::~CkDDT_HIndexed_Block()
@@ -1598,8 +1977,41 @@ CkDDT_HIndexed_Block::getContents(int ni, int na, int nd, int i[], CkDDT_Aint a[
   return 0;
 }
 
-CkDDT_Struct::CkDDT_Struct(int nCount, int* arrBlock,
-                       CkDDT_Aint* arrDisp, int *bindex, CkDDT_DataType** arrBase)
+int
+CkDDT_HIndexed_Block::getBlockLength() const
+{
+  return CkDDT_Indexed_Block::getBlockLength();
+}
+
+const CkDDT_Aint*
+CkDDT_HIndexed_Block::getArrayDisps() const
+{
+  return CkDDT_Indexed_Block::getArrayDisps();
+}
+
+const int*
+CkDDT_HIndexed_Block::getArrayBlockLength() const
+{
+  CmiAbort("Wrong Type. Should have never gotten here");
+  return NULL;
+}
+
+int
+CkDDT_HIndexed_Block::getStrideLength() const
+{
+  CmiAbort("Wrong Type. Should have never gotten here");
+  return -1;
+}
+
+const CkDDT_Type*
+CkDDT_HIndexed_Block::getTypes() const
+{
+  CmiAbort("Wrong Type. Should have never gotten here");
+  return NULL;
+}
+
+CkDDT_Struct::CkDDT_Struct(int nCount, const int* arrBlock,
+                       const CkDDT_Aint* arrDisp, const int *bindex, CkDDT_DataType** arrBase)
     : CkDDT_DataType(CkDDT_STRUCT, 0, 0, nCount, numeric_limits<CkDDT_Aint>::max(),
     numeric_limits<CkDDT_Aint>::min(), 0, 0, 0, NULL, 0, 0, 0, 0),
     arrayBlockLength(nCount), arrayDisplacements(nCount),
@@ -1674,6 +2086,28 @@ CkDDT_Struct::CkDDT_Struct(int nCount, int* arrBlock,
     }
   }
   DDTDEBUG("type %d: ub=%ld, lb=%ld, extent=%ld, size=%d, iscontig=%d\n",datatype,ub,lb,extent,size,iscontig);
+}
+
+CkDDT_Struct::CkDDT_Struct(const CkDDT_Struct& obj)
+{
+  this->datatype = obj.datatype;
+  this->count = obj.count;
+  this->arrayBlockLength = obj.arrayBlockLength;
+  this->arrayDisplacements = obj.arrayDisplacements;
+  this->index = obj.index;
+  this->arrayDataType = obj.arrayDataType;	// deep copy problem?
+  this->baseIndex = obj.baseIndex;
+  this->baseType =  obj.baseType;	        // deep copy problem?
+  this->baseSize = obj.baseSize;
+  this->baseExtent = obj.baseExtent;
+  this->numElements = obj.numElements;
+  this->size = obj.size;
+  this->extent = obj.extent;
+  this->ub = obj.ub;
+  this->lb = obj.lb;
+  this->iscontig = obj.iscontig;
+  this->trueLB = obj.trueLB;
+  this->trueExtent = obj.trueExtent;
 }
 
 size_t
@@ -1786,3 +2220,34 @@ CkDDT_Struct::getContents(int ni, int na, int nd, int i[], CkDDT_Aint a[], int d
   return 0;
 }
 
+const int*
+CkDDT_Struct::getArrayBlockLength() const
+{
+  return &this->arrayBlockLength[0];
+}
+
+const CkDDT_Aint*
+CkDDT_Struct::getArrayDisps() const
+{
+  return &this->arrayDisplacements[0];
+}
+
+const CkDDT_Type*
+CkDDT_Struct::getTypes() const
+{
+  return &this->index[0];
+}
+
+int
+CkDDT_Struct::getBlockLength() const
+{
+  CmiAbort("Wrong Type. Should have never gotten here");
+  return -1;
+}
+
+int
+CkDDT_Struct::getStrideLength() const
+{
+  CmiAbort("Wrong Type. Should have never gotten here");
+  return -1;
+}

--- a/src/libs/conv-libs/ddt/ddt.h
+++ b/src/libs/conv-libs/ddt/ddt.h
@@ -185,6 +185,7 @@ class CkDDT_DataType {
     virtual void inrRefCount(void) ;
     virtual int getRefCount(void) const;
     virtual void pupType(PUP::er &p, CkDDT* ddt) ;
+    virtual void pup(PUP::er &p);
 
     virtual int getEnvelope(int *num_integers, int *num_addresses, int *num_datatypes, int *combiner) const;
     virtual int getContents(int max_integers, int max_addresses, int max_datatypes,
@@ -213,6 +214,7 @@ class CkDDT_Contiguous : public CkDDT_DataType {
   CkDDT_Contiguous(int count, int index, CkDDT_DataType* oldType);
   virtual size_t serialize(char* userdata, char* buffer, int num, int dir) const;
   virtual void pupType(PUP::er &p, CkDDT* ddt) ;
+  virtual void pup(PUP::er &p);
   virtual int getEnvelope(int *ni, int *na, int *nd, int *combiner) const;
   virtual int getContents(int ni, int na, int nd, int i[], CkDDT_Aint a[], int d[]) const;
 };
@@ -244,6 +246,7 @@ class CkDDT_Vector : public CkDDT_DataType {
     ~CkDDT_Vector() { } ;
     virtual size_t serialize(char* userdata, char* buffer, int num, int dir) const;
     virtual  void pupType(PUP::er &p, CkDDT* ddt) ;
+    virtual void pup(PUP::er &p);
     virtual int getEnvelope(int *ni, int *na, int *nd, int *combiner) const;
     virtual int getContents(int ni, int na, int nd, int i[], CkDDT_Aint a[], int d[]) const;
 };
@@ -273,6 +276,7 @@ class CkDDT_HVector : public CkDDT_Vector {
     ~CkDDT_HVector() { } ;
     virtual size_t serialize(char* userdata, char* buffer, int num, int dir) const;
     virtual void pupType(PUP::er &p, CkDDT* ddt);
+    virtual void pup(PUP::er &p);
     virtual int getEnvelope(int *ni, int *na, int *nd, int *combiner) const;
     virtual int getContents(int ni, int na, int nd, int i[], CkDDT_Aint a[], int d[]) const;
 };
@@ -306,6 +310,7 @@ class CkDDT_Indexed : public CkDDT_DataType {
     ~CkDDT_Indexed() ;
     virtual size_t serialize(char* userdata, char* buffer, int num, int dir) const;
     virtual  void pupType(PUP::er &p, CkDDT* ddt) ;
+    virtual void pup(PUP::er &p);
     virtual int getEnvelope(int *ni, int *na, int *nd, int *combiner) const;
     virtual int getContents(int ni, int na, int nd, int i[], CkDDT_Aint a[], int d[]) const;
 };
@@ -334,6 +339,7 @@ class CkDDT_HIndexed : public CkDDT_Indexed {
                  CkDDT_DataType* type);
     virtual size_t serialize(char* userdata, char* buffer, int num, int dir) const;
     virtual void pupType(PUP::er &p, CkDDT* ddt);
+    virtual void pup(PUP::er &p);
     virtual int getEnvelope(int *ni, int *na, int *nd, int *combiner) const;
     virtual int getContents(int ni, int na, int nd, int i[], CkDDT_Aint a[], int d[]) const;
 };
@@ -369,6 +375,7 @@ class CkDDT_Indexed_Block : public CkDDT_DataType
     ~CkDDT_Indexed_Block() ;
     virtual size_t serialize(char *userdata, char *buffer, int num, int dir) const;
     virtual void pupType(PUP::er &p, CkDDT *ddt);
+    virtual void pup(PUP::er &p);
     virtual int getEnvelope(int *ni, int *na, int *nd, int *combiner) const;
     virtual int getContents(int ni, int na, int nd, int i[], CkDDT_Aint a[], int d[]) const;
 };
@@ -401,6 +408,7 @@ class CkDDT_HIndexed_Block : public CkDDT_Indexed_Block
     ~CkDDT_HIndexed_Block() ;
     virtual size_t serialize(char *userdata, char *buffer, int num, int dir) const;
     virtual void pupType(PUP::er &p, CkDDT *ddt);
+    virtual void pup(PUP::er &p);
     virtual int getEnvelope(int *ni, int *na, int *nd, int *combiner) const;
     virtual int getContents(int ni, int na, int nd, int i[], CkDDT_Aint a[], int d[]) const;
 };
@@ -436,6 +444,7 @@ class CkDDT_Struct : public CkDDT_DataType {
                CkDDT_DataType **type);
     virtual size_t serialize(char* userdata, char* buffer, int num, int dir) const;
     virtual  void pupType(PUP::er &p, CkDDT* ddt) ;
+    virtual void  pup(PUP::er &p);
     virtual int getEnvelope(int *ni, int *na, int *nd, int *combiner) const;
     virtual int getContents(int ni, int na, int nd, int i[], CkDDT_Aint a[], int d[]) const;
 };

--- a/src/libs/conv-libs/ddt/ddt.h
+++ b/src/libs/conv-libs/ddt/ddt.h
@@ -195,6 +195,13 @@ class CkDDT_DataType {
     void setName(const char *src);
     void getName(char *dest, int *len) const;
     void setAbsolute(bool arg);
+
+    /* These are dummy methods. They need to be defined to allow templated entry methods */
+    virtual int getBlockLength() const;
+    virtual int getStrideLength() const;
+    virtual const int* getArrayBlockLength() const;
+    virtual const CkDDT_Aint* getArrayDisps() const;
+    virtual const CkDDT_Type* getTypes() const;
 };
 
 /*
@@ -206,17 +213,24 @@ class CkDDT_DataType {
 class CkDDT_Contiguous : public CkDDT_DataType {
 
  private:
-  CkDDT_Contiguous(const CkDDT_Contiguous& obj);
   CkDDT_Contiguous& operator=(const CkDDT_Contiguous& obj);
 
  public:
   CkDDT_Contiguous() { };
   CkDDT_Contiguous(int count, int index, CkDDT_DataType* oldType);
+  CkDDT_Contiguous(const CkDDT_Contiguous& obj);
   virtual size_t serialize(char* userdata, char* buffer, int num, int dir) const;
   virtual void pupType(PUP::er &p, CkDDT* ddt) ;
   virtual void pup(PUP::er &p);
   virtual int getEnvelope(int *ni, int *na, int *nd, int *combiner) const;
   virtual int getContents(int ni, int na, int nd, int i[], CkDDT_Aint a[], int d[]) const;
+
+  /* These are dummy methods. They need to be defined to allow templated entry methods */
+  virtual int getBlockLength() const;
+  virtual int getStrideLength() const;
+  virtual const int* getArrayBlockLength() const;
+  virtual const CkDDT_Aint* getArrayDisps() const;
+  virtual const CkDDT_Type* getTypes() const;
 };
 
 /*
@@ -236,19 +250,26 @@ class CkDDT_Vector : public CkDDT_DataType {
     int strideLength ;
 
   private:
-    CkDDT_Vector(const CkDDT_Vector& obj);
     CkDDT_Vector& operator=(const CkDDT_Vector& obj);
 
   public:
     CkDDT_Vector(int count, int blklen, int stride, int index,
                 CkDDT_DataType* type);
     CkDDT_Vector() { } ;
+    CkDDT_Vector(const CkDDT_Vector& obj);
     ~CkDDT_Vector() { } ;
     virtual size_t serialize(char* userdata, char* buffer, int num, int dir) const;
     virtual  void pupType(PUP::er &p, CkDDT* ddt) ;
     virtual void pup(PUP::er &p);
     virtual int getEnvelope(int *ni, int *na, int *nd, int *combiner) const;
     virtual int getContents(int ni, int na, int nd, int i[], CkDDT_Aint a[], int d[]) const;
+    virtual int getBlockLength() const;
+    virtual int getStrideLength() const;
+
+    /* These are dummy methods. They need to be defined to allow templated entry methods */
+    virtual const int* getArrayBlockLength() const;
+    virtual const CkDDT_Aint* getArrayDisps() const;
+    virtual const CkDDT_Type* getTypes() const;
 };
 
 /*
@@ -266,19 +287,26 @@ class CkDDT_Vector : public CkDDT_DataType {
 class CkDDT_HVector : public CkDDT_Vector {
 
   private:
-    CkDDT_HVector(const CkDDT_HVector& obj) ;
     CkDDT_HVector& operator=(const CkDDT_HVector& obj);
 
   public:
     CkDDT_HVector() { } ;
     CkDDT_HVector(int nCount,int blength,int strideLen,int index,
                 CkDDT_DataType* type);
+    CkDDT_HVector(const CkDDT_HVector& obj);
     ~CkDDT_HVector() { } ;
     virtual size_t serialize(char* userdata, char* buffer, int num, int dir) const;
     virtual void pupType(PUP::er &p, CkDDT* ddt);
     virtual void pup(PUP::er &p);
     virtual int getEnvelope(int *ni, int *na, int *nd, int *combiner) const;
     virtual int getContents(int ni, int na, int nd, int i[], CkDDT_Aint a[], int d[]) const;
+    virtual int getBlockLength() const;
+    virtual int getStrideLength() const;
+  
+    /* These are dummy methods. They need to be defined to allow templated entry methods */
+    virtual const int* getArrayBlockLength() const;
+    virtual const CkDDT_Aint* getArrayDisps() const;
+    virtual const CkDDT_Type* getTypes() const;
 };
 
 /*
@@ -300,19 +328,26 @@ class CkDDT_Indexed : public CkDDT_DataType {
     vector<CkDDT_Aint> arrayDisplacements;
 
   private:
-    CkDDT_Indexed(const CkDDT_Indexed& obj);
     CkDDT_Indexed& operator=(const CkDDT_Indexed& obj) ;
 
   public:
-    CkDDT_Indexed(int count, int* arrBlock, CkDDT_Aint* arrDisp, int index,
+    CkDDT_Indexed(int count, const int* arrBlock, const CkDDT_Aint* arrDisp, int index,
                 CkDDT_DataType* type);
     CkDDT_Indexed() { } ;
+    CkDDT_Indexed(const CkDDT_Indexed& obj);
     ~CkDDT_Indexed() ;
     virtual size_t serialize(char* userdata, char* buffer, int num, int dir) const;
     virtual  void pupType(PUP::er &p, CkDDT* ddt) ;
     virtual void pup(PUP::er &p);
     virtual int getEnvelope(int *ni, int *na, int *nd, int *combiner) const;
     virtual int getContents(int ni, int na, int nd, int i[], CkDDT_Aint a[], int d[]) const;
+    virtual const int* getArrayBlockLength() const;
+    virtual const CkDDT_Aint* getArrayDisps() const;
+
+    /* These are dummy methods. They need to be defined to allow templated entry methods */
+    virtual int getBlockLength() const;
+    virtual int getStrideLength() const;
+    virtual const CkDDT_Type* getTypes() const;
 };
 
 /*
@@ -330,18 +365,25 @@ class CkDDT_Indexed : public CkDDT_DataType {
 class CkDDT_HIndexed : public CkDDT_Indexed {
 
   private:
-    CkDDT_HIndexed(const CkDDT_HIndexed& obj);
     CkDDT_HIndexed& operator=(const CkDDT_HIndexed& obj);
 
   public:
     CkDDT_HIndexed() { } ;
-    CkDDT_HIndexed(int count, int* arrBlock, CkDDT_Aint* arrDisp, int index,
+    CkDDT_HIndexed(int count, const int* arrBlock, const CkDDT_Aint* arrDisp, int index,
                  CkDDT_DataType* type);
+    CkDDT_HIndexed(const CkDDT_HIndexed& obj);
     virtual size_t serialize(char* userdata, char* buffer, int num, int dir) const;
     virtual void pupType(PUP::er &p, CkDDT* ddt);
     virtual void pup(PUP::er &p);
     virtual int getEnvelope(int *ni, int *na, int *nd, int *combiner) const;
     virtual int getContents(int ni, int na, int nd, int i[], CkDDT_Aint a[], int d[]) const;
+    virtual const int* getArrayBlockLength() const;
+    virtual const CkDDT_Aint* getArrayDisps() const;
+
+    /* These are dummy methods. They need to be defined to allow templated entry methods */
+    virtual int getBlockLength() const;
+    virtual int getStrideLength() const;
+    virtual const CkDDT_Type* getTypes() const;
 };
 
 /*
@@ -366,18 +408,25 @@ class CkDDT_Indexed_Block : public CkDDT_DataType
     vector<CkDDT_Aint> arrayDisplacements;
 
   private:
-    CkDDT_Indexed_Block(const CkDDT_Indexed_Block &obj);
     CkDDT_Indexed_Block& operator=(const CkDDT_Indexed_Block &obj);
 
   public:
-    CkDDT_Indexed_Block(int count, int Blength, CkDDT_Aint *ArrDisp, int index, CkDDT_DataType *type);
+    CkDDT_Indexed_Block(int count, int Blength, const CkDDT_Aint *ArrDisp, int index, CkDDT_DataType *type);
     CkDDT_Indexed_Block() { };
+    CkDDT_Indexed_Block(const CkDDT_Indexed_Block &obj);
     ~CkDDT_Indexed_Block() ;
     virtual size_t serialize(char *userdata, char *buffer, int num, int dir) const;
     virtual void pupType(PUP::er &p, CkDDT *ddt);
     virtual void pup(PUP::er &p);
     virtual int getEnvelope(int *ni, int *na, int *nd, int *combiner) const;
     virtual int getContents(int ni, int na, int nd, int i[], CkDDT_Aint a[], int d[]) const;
+    virtual int getBlockLength() const;
+    virtual const CkDDT_Aint* getArrayDisps() const;
+
+    /* These are dummy methods. They need to be defined to allow templated entry methods */
+    virtual int getStrideLength() const;
+    virtual const int* getArrayBlockLength() const;
+    virtual const CkDDT_Type* getTypes() const;
 };
 
 /*
@@ -399,18 +448,25 @@ class CkDDT_HIndexed_Block : public CkDDT_Indexed_Block
 {
   
   private:
-    CkDDT_HIndexed_Block(const CkDDT_Indexed_Block &obj);
     CkDDT_HIndexed_Block& operator=(const CkDDT_Indexed_Block &obj);
 
   public:
-    CkDDT_HIndexed_Block(int count, int Blength, CkDDT_Aint *ArrDisp, int index, CkDDT_DataType *type);
+    CkDDT_HIndexed_Block(int count, int Blength, const CkDDT_Aint *ArrDisp, int index, CkDDT_DataType *type);
     CkDDT_HIndexed_Block() { };
+    CkDDT_HIndexed_Block(const CkDDT_HIndexed_Block &obj);
     ~CkDDT_HIndexed_Block() ;
     virtual size_t serialize(char *userdata, char *buffer, int num, int dir) const;
     virtual void pupType(PUP::er &p, CkDDT *ddt);
     virtual void pup(PUP::er &p);
     virtual int getEnvelope(int *ni, int *na, int *nd, int *combiner) const;
     virtual int getContents(int ni, int na, int nd, int i[], CkDDT_Aint a[], int d[]) const;
+    virtual int getBlockLength() const;
+    virtual const CkDDT_Aint* getArrayDisps() const;
+
+    /* These are dummy methods. They need to be defined to allow templated entry methods */
+    virtual int getStrideLength() const;
+    virtual const int* getArrayBlockLength() const;
+    virtual const CkDDT_Type* getTypes() const;
 };
 
 /*
@@ -435,18 +491,25 @@ class CkDDT_Struct : public CkDDT_DataType {
     vector<CkDDT_DataType*> arrayDataType;
 
   private:
-    CkDDT_Struct(const CkDDT_Struct& obj);
     CkDDT_Struct& operator=(const CkDDT_Struct& obj);
 
   public:
     CkDDT_Struct() { } ;
-    CkDDT_Struct(int count, int* arrBlock, CkDDT_Aint* arrDisp, int *index,
+    CkDDT_Struct(int count, const int* arrBlock, const CkDDT_Aint* arrDisp, const int *index,
                CkDDT_DataType **type);
+    CkDDT_Struct(const CkDDT_Struct& obj);
     virtual size_t serialize(char* userdata, char* buffer, int num, int dir) const;
     virtual  void pupType(PUP::er &p, CkDDT* ddt) ;
     virtual void  pup(PUP::er &p);
     virtual int getEnvelope(int *ni, int *na, int *nd, int *combiner) const;
     virtual int getContents(int ni, int na, int nd, int i[], CkDDT_Aint a[], int d[]) const;
+    virtual const int* getArrayBlockLength() const;
+    virtual const CkDDT_Aint* getArrayDisps() const;
+    virtual const CkDDT_Type* getTypes() const;
+
+    /* These are dummy methods. They need to be defined to allow templated entry methods */
+    virtual int getBlockLength() const;
+    virtual int getStrideLength() const;
 };
 
 /*
@@ -580,22 +643,22 @@ class CkDDT {
                 CkDDT_Type* newtype);
   void newHVector(int count, int blocklength, int stride, CkDDT_Type oldtype,
                  CkDDT_Type* newtype);
-  void newIndexed(int count, int* arrbLength, CkDDT_Aint* arrDisp , CkDDT_Type oldtype,
+  void newIndexed(int count, const int* arrbLength, const CkDDT_Aint* arrDisp , CkDDT_Type oldtype,
                  CkDDT_Type* newtype);
-  void newHIndexed(int count, int* arrbLength, CkDDT_Aint* arrDisp , CkDDT_Type oldtype,
+  void newHIndexed(int count, const int* arrbLength, const CkDDT_Aint* arrDisp , CkDDT_Type oldtype,
                   CkDDT_Type* newtype);
-  void newIndexedBlock(int count, int Blocklength, CkDDT_Aint *arrDisp, CkDDT_Type oldtype,
+  void newIndexedBlock(int count, int Blocklength, const CkDDT_Aint *arrDisp, CkDDT_Type oldtype,
                       CkDDT_Type *newtype);
-  void newHIndexedBlock(int count, int Blocklength, CkDDT_Aint *arrDisp, CkDDT_Type oldtype,
+  void newHIndexedBlock(int count, int Blocklength, const CkDDT_Aint *arrDisp, CkDDT_Type oldtype,
                        CkDDT_Type *newtype);
-  void newStruct(int count, int* arrbLength, CkDDT_Aint* arrDisp , CkDDT_Type *oldtype,
+  void newStruct(int count, const int* arrbLength, const CkDDT_Aint* arrDisp , const CkDDT_Type *oldtype,
                 CkDDT_Type* newtype);
   void  freeType(int* index);
   int   getNextFreeIndex(void);
   void  pup(PUP::er &p);
   CkDDT_DataType*  getType(int nIndex) const;
   int getTypeTag(int nIndex) const;
-
+  bool isPrimitive(int nIndex) const;
   bool isContig(int nIndex) const;
   int getSize(int nIndex, int count=1) const;
   CkDDT_Aint getExtent(int nIndex) const;

--- a/src/libs/conv-libs/ddt/ddt.h
+++ b/src/libs/conv-libs/ddt/ddt.h
@@ -1,7 +1,12 @@
 #ifndef __CkDDT_H_
 #define __CkDDT_H_
 
+#include <string>
+#include <vector>
 #include "pup.h"
+
+using std::vector;
+using std::string;
 
 #define CkDDT_MAXTYPE           100
 
@@ -49,6 +54,8 @@
 #define CkDDT_LONG_DOUBLE_COMPLEX 40
 #define CkDDT_AINT                41
 
+#define CkDDT_MAX_PRIMITIVE_TYPE  41
+
 #define CkDDT_CONTIGUOUS          42
 #define CkDDT_VECTOR              43
 #define CkDDT_HVECTOR             44
@@ -95,33 +102,30 @@ class CkDDT ;
 
   Members:
 
-  datatype - Used for primitive datatypes for size calculations
-  refCount - to keep track of how many references are present to this type.
-
-  size - size of one unit of datatype
-  extent - extent is different from size in that it also counts
-           displacements between blocks.
-  count -  count of base datatype present in this datatype
-  baseSize - size of Base Datatype
-  baseExtent - extent of Base dataType
-  name - user specified name for datatype
-  nameLen - length of user specified name for datatype
+  datatype         - Identifies the datatype based on the identification system above.
+  refCount         - to keep track of how many references are present to this type.
+  size             - size of one unit of datatype
+  extent           - extent is different from size in that it also counts displacements between blocks.
+  count            - count of base datatype present in this datatype
+  baseSize         - size of Base Datatype
+  baseExtent       - extent of Base dataType
+  name             - user specified name for datatype
+  nameLen          - length of user specified name for datatype
 
   Methods:
 
-  getSize -  returns the size of the datatype. 
-  getExtent - returns the extent of the datatype.
+  getSize          -  returns the size of the datatype. 
+  getExtent        - returns the extent of the datatype.
 
-  inrRefCount - increament the reference count.
-  getRefCount - returns the RefCount
+  inrRefCount      - increament the reference count.
+  getRefCount      - returns the RefCount
 
-  serialize - This is the function which actually copies the contents from
-    user's space to buffer if dir=1 or reverse if dir=-1
-    according to the datatype.
-
-  setName - set the name of datatype
-  getName - get the name of datatype
-  setAbsolute - tells DDT's serialize methods that we are dealing with absolute addresses
+  serialize        - This is the function which actually copies the contents from
+                      user's space to buffer if dir=1 or reverse if dir=-1
+                      according to the datatype.
+  setName          - set the name of datatype
+  getName          - get the name of datatype
+  setAbsolute      - tells DDT's serialize methods that we are dealing with absolute addresses
 
   Reference Counting currently disabled. To add this feature back in, the refcount variable
     cannot be copied when making a duplicate.
@@ -147,7 +151,7 @@ class CkDDT_DataType {
     CkDDT_DataType *baseType;
     int baseIndex;
     int numElements;
-    char name[CkDDT_MAX_NAME_LEN];
+    string name;
     int nameLen;
     bool isAbsolute;
 
@@ -288,8 +292,8 @@ class CkDDT_HVector : public CkDDT_Vector {
 class CkDDT_Indexed : public CkDDT_DataType {
 
   protected:
-    int* arrayBlockLength ;
-    CkDDT_Aint* arrayDisplacements ;
+    vector<int> arrayBlockLength;
+    vector<CkDDT_Aint> arrayDisplacements;
 
   private:
     CkDDT_Indexed(const CkDDT_Indexed& obj);
@@ -353,7 +357,7 @@ class CkDDT_Indexed_Block : public CkDDT_DataType
 
   protected:
     int BlockLength;
-    CkDDT_Aint *arrayDisplacements;
+    vector<CkDDT_Aint> arrayDisplacements;
 
   private:
     CkDDT_Indexed_Block(const CkDDT_Indexed_Block &obj);
@@ -417,10 +421,10 @@ class CkDDT_HIndexed_Block : public CkDDT_Indexed_Block
 class CkDDT_Struct : public CkDDT_DataType {
 
   protected:
-    int* arrayBlockLength ;
-    CkDDT_Aint* arrayDisplacements ;
-    int* index;
-    CkDDT_DataType** arrayDataType;
+    vector<int> arrayBlockLength;
+    vector<CkDDT_Aint> arrayDisplacements;
+    vector<int> index;
+    vector<CkDDT_DataType*> arrayDataType;
 
   private:
     CkDDT_Struct(const CkDDT_Struct& obj);
@@ -455,8 +459,8 @@ class CkDDT_Struct : public CkDDT_DataType {
 
 class CkDDT {
   private:
-    CkDDT_DataType**  typeTable;
-    int*  types; //used for pup
+    vector<CkDDT_DataType*> typeTable;
+    vector<int> types;
     int max_types;
     int num_types;
 
@@ -466,8 +470,8 @@ class CkDDT {
   CkDDT()
   {
     max_types = CkDDT_MAXTYPE;
-    typeTable = new CkDDT_DataType*[max_types];
-    types = new int[max_types];
+    typeTable.resize(max_types);
+    types.resize(max_types);
     typeTable[0] = new CkDDT_DataType(CkDDT_DOUBLE);
     types[0] = CkDDT_DOUBLE;
     typeTable[1] = new CkDDT_DataType(CkDDT_INT);
@@ -581,6 +585,7 @@ class CkDDT {
   int   getNextFreeIndex(void);
   void  pup(PUP::er &p);
   CkDDT_DataType*  getType(int nIndex) const;
+  int getTypeTag(int nIndex) const;
 
   bool isContig(int nIndex) const;
   int getSize(int nIndex, int count=1) const;


### PR DESCRIPTION
*Original author: Edward Hutter*
*Original date: 2017-02-16 05:10:23*
*Original PR: https://charm.cs.illinois.edu/gerrit/2166*

---

For non-predefined datatypes, we send the CkDDT_DataType along with
the message so we can deserialize it properly on the remote side.

Templated entry methods are used to support all the different kinds
of derived datatypes.

Change-Id: I7dd25467411f133478b4f3bfffdc94c5f552fa7c