### PR TITLE
Add API for doing a local broadcast to PEs on a node

### DIFF
--- a/doc/charm++/manual.rst
+++ b/doc/charm++/manual.rst
@@ -3367,6 +3367,21 @@ on all branches of the group. This call is also asynchronous and
 non-blocking, and it, too, returns immediately after sending the
 message.
 
+Finally, when running in SMP mode with multiple PEs per node, one can
+broadcast a message to the branches of a group local to the sending node:
+
+.. code-block:: c++
+
+   CkWithinNodeBroadcast(CkIndex_Foo::bar(), msg, fooProxy);
+
+Where ``CkIndex_Foo::bar()`` is the index of the entry method you wish to
+invoke, msg is the ``Charm++`` message (section :numref:`messages`) you wish to
+send, and ``fooProxy`` is the proxy to the group you wish to send. As before,
+it is an asynchrounous call which returns immediately. Furthermore, if the
+receiving entry method is marked as ``[nokeep]`` (:numref:`attributes`), the
+message pointer will be shared with each group chare instead of creating an
+independent copy per receiver.
+
 Recall that each PE hosts a branch of every instantiated group.
 Sequential objects, chares and other groups can gain access to this
 *PE-local* branch using ckLocalBranch():

--- a/src/arch/gni/conv-common.h
+++ b/src/arch/gni/conv-common.h
@@ -18,9 +18,9 @@
 
 #if DELTA_COMPRESS
 #if CMK_ERROR_CHECKING
-#define CMK_MSG_HEADER_EXT_    CmiUInt4 size; CmiUInt2 seq; unsigned char cksum, magic; CmiUInt2 rank,hdl,xhdl,info,redID; CmiInt4 root; CmiUInt4 compressStart; CmiUInt2 compress_flag,xxhdl; CmiUInt8 persistRecvHandler; CmiUInt1 zcMsgType:3, cmaMsgType:2;
+#define CMK_MSG_HEADER_EXT_    CmiUInt4 size; CmiUInt2 seq; unsigned char cksum, magic; CmiUInt2 rank,hdl,xhdl,info,redID; CmiInt4 root; CmiUInt4 compressStart; CmiUInt2 compress_flag,xxhdl; CmiUInt8 persistRecvHandler; CmiUInt1 zcMsgType:3, cmaMsgType:2, nokeep:1;
 #else
-#define CMK_MSG_HEADER_EXT_    CmiUInt4 size; CmiUInt4 seq; CmiUInt2 rank,hdl,xhdl,info,redID; CmiInt4 root; CmiUInt4 compressStart; CmiUInt2 compress_flag,xxhdl; CmiUInt8 persistRecvHandler; CmiUInt1 zcMsgType:3, cmaMsgType:2;
+#define CMK_MSG_HEADER_EXT_    CmiUInt4 size; CmiUInt4 seq; CmiUInt2 rank,hdl,xhdl,info,redID; CmiInt4 root; CmiUInt4 compressStart; CmiUInt2 compress_flag,xxhdl; CmiUInt8 persistRecvHandler; CmiUInt1 zcMsgType:3, cmaMsgType:2, nokeep:1;
 #endif
 #else 
 #if CMK_ERROR_CHECKING

--- a/src/arch/gni/conv-common.h
+++ b/src/arch/gni/conv-common.h
@@ -24,9 +24,9 @@
 #endif
 #else 
 #if CMK_ERROR_CHECKING
-#define CMK_MSG_HEADER_EXT_    CmiUInt4 size; CmiUInt2 seq; unsigned char cksum, magic; CmiUInt2 rank,hdl,xhdl,info,redID; CmiInt4 root; CmiUInt1 zcMsgType:3, cmaMsgType:2;
+#define CMK_MSG_HEADER_EXT_    CmiUInt4 size; CmiUInt2 seq; unsigned char cksum, magic; CmiUInt2 rank,hdl,xhdl,info,redID; CmiInt4 root; CmiUInt1 zcMsgType:3, cmaMsgType:2, nokeep:1;
 #else
-#define CMK_MSG_HEADER_EXT_    CmiUInt4 size; CmiUInt4 seq; CmiUInt2 rank,hdl,xhdl,info,redID; CmiInt4 root; CmiUInt1 zcMsgType:3, cmaMsgType:2;
+#define CMK_MSG_HEADER_EXT_    CmiUInt4 size; CmiUInt4 seq; CmiUInt2 rank,hdl,xhdl,info,redID; CmiInt4 root; CmiUInt1 zcMsgType:3, cmaMsgType:2, nokeep:1;
 #endif
 #endif
 

--- a/src/arch/gni/conv-mach-syncft.h
+++ b/src/arch/gni/conv-mach-syncft.h
@@ -3,7 +3,7 @@
 //#undef CMK_MSG_HEADER_EXT
 //#undef CMK_MSG_HEADER_BIGSIM_
 /* expand the header to store the restart phase counter(pn) */
-#define CMK_MSG_HEADER_EXT_    CmiUInt4 size; CmiUInt4 seq; CmiUInt2 rank,hdl,xhdl,info,type,redID,pn,d9; CmiInt4 root; CmiUInt1 zcMsgType:3, cmaMsgType:2;;
+#define CMK_MSG_HEADER_EXT_    CmiUInt4 size; CmiUInt4 seq; CmiUInt2 rank,hdl,xhdl,info,type,redID,pn,d9; CmiInt4 root; CmiUInt1 zcMsgType:3, cmaMsgType:2, nokeep:1;;
 //#define CMK_MSG_HEADER_EXT    { CMK_MSG_HEADER_EXT_ }
 //#define CMK_MSG_HEADER_BIGSIM_    { CmiUInt2 d0,d1,d2,d3,d4,d5,hdl,xhdl,pn,info; int nd, n; double rt; CmiInt2 tID; CmiUInt2 hID; char t; int msgID; int srcPe;}
 //#define CMK_MSG_HEADER_BIGSIM_  { CMK_MSG_HEADER_EXT_ CMK_BIGSIM_FIELDS }

--- a/src/arch/mpi/conv-common.h
+++ b/src/arch/mpi/conv-common.h
@@ -15,9 +15,9 @@
 #define CMK_HANDLE_SIGUSR                                  1
 
 #if CMK_ERROR_CHECKING
-#define CMK_MSG_HEADER_EXT_    CmiUInt2 rank, hdl,xhdl,info, redID; CmiInt4 root; unsigned char cksum, magic, mpiMsgType; CmiUInt1 zcMsgType:3, cmaMsgType:2;
+#define CMK_MSG_HEADER_EXT_    CmiUInt2 rank, hdl,xhdl,info, redID; CmiInt4 root; unsigned char cksum, magic, mpiMsgType; CmiUInt1 zcMsgType:3, cmaMsgType:2, readonly:1;
 #else
-#define CMK_MSG_HEADER_EXT_    CmiUInt2 rank, hdl,xhdl,info, redID; CmiInt4 root; unsigned char mpiMsgType; CmiUInt1 zcMsgType:3, cmaMsgType:2;
+#define CMK_MSG_HEADER_EXT_    CmiUInt2 rank, hdl,xhdl,info, redID; CmiInt4 root; unsigned char mpiMsgType; CmiUInt1 zcMsgType:3, cmaMsgType:2, readonly:1;
 #endif
 
 #define CMK_MSG_HEADER_BASIC  CMK_MSG_HEADER_EXT

--- a/src/arch/mpi/conv-common.h
+++ b/src/arch/mpi/conv-common.h
@@ -15,9 +15,9 @@
 #define CMK_HANDLE_SIGUSR                                  1
 
 #if CMK_ERROR_CHECKING
-#define CMK_MSG_HEADER_EXT_    CmiUInt2 rank, hdl,xhdl,info, redID; CmiInt4 root; unsigned char cksum, magic, mpiMsgType; CmiUInt1 zcMsgType:3, cmaMsgType:2, readonly:1;
+#define CMK_MSG_HEADER_EXT_    CmiUInt2 rank, hdl,xhdl,info, redID; CmiInt4 root; unsigned char cksum, magic, mpiMsgType; CmiUInt1 zcMsgType:3, cmaMsgType:2, nokeep:1;
 #else
-#define CMK_MSG_HEADER_EXT_    CmiUInt2 rank, hdl,xhdl,info, redID; CmiInt4 root; unsigned char mpiMsgType; CmiUInt1 zcMsgType:3, cmaMsgType:2, readonly:1;
+#define CMK_MSG_HEADER_EXT_    CmiUInt2 rank, hdl,xhdl,info, redID; CmiInt4 root; unsigned char mpiMsgType; CmiUInt1 zcMsgType:3, cmaMsgType:2, nokeep:1;
 #endif
 
 #define CMK_MSG_HEADER_BASIC  CMK_MSG_HEADER_EXT

--- a/src/arch/mpi/conv-mach-syncft.h
+++ b/src/arch/mpi/conv-mach-syncft.h
@@ -3,7 +3,7 @@
 //#undef CMK_MSG_HEADER_EXT
 //#undef CMK_MSG_HEADER_BIGSIM_
 /* expand the header to store the restart phase counter(pn) */
-#define CMK_MSG_HEADER_EXT_   CmiUInt2 rank, root, hdl,xhdl,info, type, pn,d7; unsigned char cksum, magic, mpiMsgType; CmiUInt2 redID; CmiUInt1 zcMsgType:3, cmaMsgType:2;
+#define CMK_MSG_HEADER_EXT_   CmiUInt2 rank, root, hdl,xhdl,info, type, pn,d7; unsigned char cksum, magic, mpiMsgType; CmiUInt2 redID; CmiUInt1 zcMsgType:3, cmaMsgType:2, nokeep:1;
 //#define CMK_MSG_HEADER_EXT    { CMK_MSG_HEADER_EXT_ }
 //#define CMK_MSG_HEADER_BIGSIM_    { CmiUInt2 d0,d1,d2,d3,d4,d5,hdl,xhdl,pn,info; int nd, n; double rt; CmiInt2 tID; CmiUInt2 hID; char t; int msgID; int srcPe;}
 //#define CMK_MSG_HEADER_BIGSIM_  { CMK_MSG_HEADER_EXT_ CMK_BIGSIM_FIELDS }

--- a/src/arch/netlrts/conv-common.h
+++ b/src/arch/netlrts/conv-common.h
@@ -23,7 +23,7 @@
 */
 #define CMK_MSG_HEADER_BASIC   CMK_MSG_HEADER_EXT
 
-#define CMK_MSG_HEADER_EXT_    CmiUInt2 d0,d1,d2,d3,hdl,type,xhdl,info,redID,rank; CmiInt4 root, size; CmiUInt1 zcMsgType:3, cmaMsgType:2, readonly:1;
+#define CMK_MSG_HEADER_EXT_    CmiUInt2 d0,d1,d2,d3,hdl,type,xhdl,info,redID,rank; CmiInt4 root, size; CmiUInt1 zcMsgType:3, cmaMsgType:2, nokeep:1;
 
 #define CMK_MSG_HEADER_EXT       { CMK_MSG_HEADER_EXT_ }
 #define CMK_MSG_HEADER_BIGSIM_  { CMK_MSG_HEADER_EXT_ CMK_BIGSIM_FIELDS }

--- a/src/arch/netlrts/conv-common.h
+++ b/src/arch/netlrts/conv-common.h
@@ -23,7 +23,7 @@
 */
 #define CMK_MSG_HEADER_BASIC   CMK_MSG_HEADER_EXT
 
-#define CMK_MSG_HEADER_EXT_    CmiUInt2 d0,d1,d2,d3,hdl,type,xhdl,info,redID,rank; CmiInt4 root, size; CmiUInt1 zcMsgType:3, cmaMsgType:2;
+#define CMK_MSG_HEADER_EXT_    CmiUInt2 d0,d1,d2,d3,hdl,type,xhdl,info,redID,rank; CmiInt4 root, size; CmiUInt1 zcMsgType:3, cmaMsgType:2, readonly:1;
 
 #define CMK_MSG_HEADER_EXT       { CMK_MSG_HEADER_EXT_ }
 #define CMK_MSG_HEADER_BIGSIM_  { CMK_MSG_HEADER_EXT_ CMK_BIGSIM_FIELDS }

--- a/src/arch/ofi/conv-common.h
+++ b/src/arch/ofi/conv-common.h
@@ -23,7 +23,7 @@
  * - startid, redID
  * - rank is needed by broadcast
  */
-#define CMK_MSG_HEADER_UNIQUE    CmiUInt4 size; CmiUInt2 rank,hdl,xhdl,info,redID; CmiInt4 root; CmiUInt1 zcMsgType:3, cmaMsgType:2;
+#define CMK_MSG_HEADER_UNIQUE    CmiUInt4 size; CmiUInt2 rank,hdl,xhdl,info,redID; CmiInt4 root; CmiUInt1 zcMsgType:3, cmaMsgType:2, nokeep:1;
 
 #define CMK_MSG_HEADER_BASIC  CMK_MSG_HEADER_EXT
 #define CMK_MSG_HEADER_EXT            { CMK_MSG_HEADER_UNIQUE }

--- a/src/arch/pamilrts/conv-common.h
+++ b/src/arch/pamilrts/conv-common.h
@@ -11,9 +11,9 @@
 
 //#define  DELTA_COMPRESS                                     1
 #if DELTA_COMPRESS
-#define CMK_MSG_HEADER_EXT_    CmiUInt2 rank, hdl,xhdl,info; unsigned char cksum, magic; int root, size; CmiUInt2 redID, padding; CmiUInt4 compressStart; CmiUInt2 compress_flag,xxhdl; CmiUInt8 persistRecvHandler; CmiUInt1 zcMsgType:3, cmaMsgType:2;
+#define CMK_MSG_HEADER_EXT_    CmiUInt2 rank, hdl,xhdl,info; unsigned char cksum, magic; int root, size; CmiUInt2 redID, padding; CmiUInt4 compressStart; CmiUInt2 compress_flag,xxhdl; CmiUInt8 persistRecvHandler; CmiUInt1 zcMsgType:3, cmaMsgType:2, nokeep:1;
 #else
-#define CMK_MSG_HEADER_EXT_    CmiUInt2 rank, hdl,xhdl,info; unsigned char cksum, magic; int root, size; CmiUInt2 redID, padding; CmiUInt1 zcMsgType:3, cmaMsgType:2;
+#define CMK_MSG_HEADER_EXT_    CmiUInt2 rank, hdl,xhdl,info; unsigned char cksum, magic; int root, size; CmiUInt2 redID, padding; CmiUInt1 zcMsgType:3, cmaMsgType:2, nokeep:1;
 #endif
 
 #define CMK_MSG_HEADER_BASIC  CMK_MSG_HEADER_EXT

--- a/src/arch/ucx/conv-common.h
+++ b/src/arch/ucx/conv-common.h
@@ -23,7 +23,7 @@
  * - startid, redID
  * - rank is needed by broadcast
  */
-#define CMK_MSG_HEADER_UNIQUE    CmiUInt4 size; CmiUInt2 rank,hdl,xhdl,info,redID; CmiInt4 root; CmiUInt1 zcMsgType:3, cmaMsgType:2;
+#define CMK_MSG_HEADER_UNIQUE    CmiUInt4 size; CmiUInt2 rank,hdl,xhdl,info,redID; CmiInt4 root; CmiUInt1 zcMsgType:3, cmaMsgType:2, nokeep:1;
 
 #define CMK_MSG_HEADER_BASIC  CMK_MSG_HEADER_EXT
 #define CMK_MSG_HEADER_EXT            { CMK_MSG_HEADER_UNIQUE }

--- a/src/arch/util/machine-broadcast.C
+++ b/src/arch/util/machine-broadcast.C
@@ -389,6 +389,30 @@ void CmiFreeNodeBroadcastAllFn(int size, char *msg) {
     CmiSendNodeSelf(msg);
 }
 #endif
+
+void CmiWithinNodeBroadcast(int size, char* msg) {
+  int nodefirst = CmiNodeFirst(CmiMyNode());
+  int nodelast = nodefirst + CmiNodeSize(CmiMyNode());
+  if (CMI_MSG_READONLY(msg)) {
+    for (int i = nodefirst; i < CmiMyPe(); i++) {
+      CmiReference(msg);
+      CmiFreeSendFn(i, size, msg);
+    }
+    for (int i = CmiMyPe() + 1; i < nodelast; i++) {
+      CmiReference(msg);
+      CmiFreeSendFn(i, size, msg);
+    }
+  } else {
+    for (int i = nodefirst; i < CmiMyPe(); i++) {
+      CmiSyncSendFn(i, size, msg);
+    }
+    for (int i = CmiMyPe() + 1; i < nodelast; i++) {
+      CmiSyncSendFn(i, size, msg);
+    }
+  }
+  CmiSyncSendAndFree(CmiMyPe(), size, msg);
+}
+
 /* ##### End of Functions Related with Message Sending OPs ##### */
 
 #if ! CMK_MULTICAST_LIST_USE_COMMON_CODE

--- a/src/arch/util/machine-broadcast.C
+++ b/src/arch/util/machine-broadcast.C
@@ -391,22 +391,22 @@ void CmiFreeNodeBroadcastAllFn(int size, char *msg) {
 #endif
 
 void CmiWithinNodeBroadcastFn(int size, char* msg) {
-  int nodefirst = CmiNodeFirst(CmiMyNode());
-  int nodelast = nodefirst + CmiNodeSize(CmiMyNode());
+  int nodeFirst = CmiNodeFirst(CmiMyNode());
+  int nodeLast = nodeFirst + CmiNodeSize(CmiMyNode());
   if (CMI_MSG_NOKEEP(msg)) {
-    for (int i = nodefirst; i < CmiMyPe(); i++) {
+    for (int i = nodeFirst; i < CmiMyPe(); i++) {
       CmiReference(msg);
       CmiFreeSendFn(i, size, msg);
     }
-    for (int i = CmiMyPe() + 1; i < nodelast; i++) {
+    for (int i = CmiMyPe() + 1; i < nodeLast; i++) {
       CmiReference(msg);
       CmiFreeSendFn(i, size, msg);
     }
   } else {
-    for (int i = nodefirst; i < CmiMyPe(); i++) {
+    for (int i = nodeFirst; i < CmiMyPe(); i++) {
       CmiSyncSendFn(i, size, msg);
     }
-    for (int i = CmiMyPe() + 1; i < nodelast; i++) {
+    for (int i = CmiMyPe() + 1; i < nodeLast; i++) {
       CmiSyncSendFn(i, size, msg);
     }
   }

--- a/src/arch/util/machine-broadcast.C
+++ b/src/arch/util/machine-broadcast.C
@@ -390,10 +390,10 @@ void CmiFreeNodeBroadcastAllFn(int size, char *msg) {
 }
 #endif
 
-void CmiWithinNodeBroadcast(int size, char* msg) {
+void CmiWithinNodeBroadcastFn(int size, char* msg) {
   int nodefirst = CmiNodeFirst(CmiMyNode());
   int nodelast = nodefirst + CmiNodeSize(CmiMyNode());
-  if (CMI_MSG_READONLY(msg)) {
+  if (CMI_MSG_NOKEEP(msg)) {
     for (int i = nodefirst; i < CmiMyPe(); i++) {
       CmiReference(msg);
       CmiFreeSendFn(i, size, msg);

--- a/src/arch/verbs/conv-common.h
+++ b/src/arch/verbs/conv-common.h
@@ -24,7 +24,7 @@
    of the message and used in the LRTS based CMA implementaion.
 */
 #define CMK_MSG_HEADER_BASIC   CMK_MSG_HEADER_EXT
-#define CMK_MSG_HEADER_EXT_    CmiUInt2 d0,d1,d2,d3,hdl,xhdl,info,redID,rank; CmiInt4 root, size; CmiUInt1 zcMsgType:3, cmaMsgType:2;
+#define CMK_MSG_HEADER_EXT_    CmiUInt2 d0,d1,d2,d3,hdl,xhdl,info,redID,rank; CmiInt4 root, size; CmiUInt1 zcMsgType:3, cmaMsgType:2, nokeep:1;
 #define CMK_MSG_HEADER_EXT       { CMK_MSG_HEADER_EXT_ }
 #define CMK_MSG_HEADER_BIGSIM_  { CMK_MSG_HEADER_EXT_ CMK_BIGSIM_FIELDS }
 

--- a/src/arch/verbs/conv-mach-syncft.h
+++ b/src/arch/verbs/conv-mach-syncft.h
@@ -5,7 +5,7 @@
 //#undef CMK_MSG_HEADER_BIGSIM_
 /* expand the header to store the restart phase counter(pn) */
 #define CMK_MSG_HEADER_BASIC   CMK_MSG_HEADER_EXT
-#define CMK_MSG_HEADER_EXT_    CmiUInt2 d0,d1,d2,d3,hdl,pn,d4,type,xhdl,info,dd,redID,pad2,rank; CmiUInt4 root,size; CmiUInt1 zcMsgType:3, cmaMsgType:2;
+#define CMK_MSG_HEADER_EXT_    CmiUInt2 d0,d1,d2,d3,hdl,pn,d4,type,xhdl,info,dd,redID,pad2,rank; CmiUInt4 root,size; CmiUInt1 zcMsgType:3, cmaMsgType:2, nokeep:1;
 //#define CMK_MSG_HEADER_EXT    { CMK_MSG_HEADER_EXT_ }
 //#define CMK_MSG_HEADER_BIGSIM_    { CmiUInt2 d0,d1,d2,d3,d4,d5,hdl,xhdl,pn,info; int nd, n; double rt; CmiInt2 tID; CmiUInt2 hID; char t; int msgID; int srcPe;}
 //#define CMK_MSG_HEADER_BIGSIM_  { CMK_MSG_HEADER_EXT_ CMK_BIGSIM_FIELDS }

--- a/src/ck-core/charm.h
+++ b/src/ck-core/charm.h
@@ -376,6 +376,7 @@ extern void CkSendMsgBranchGroup(int eIdx,void *msg,CkGroupID gID,CmiGroup grp, 
 extern void CkSendMsgNodeBranch(int eIdx, void *msg, int destNode, CkGroupID gID, int opts CK_MSGOPTIONAL);
 extern void CkSendMsgNodeBranchInline(int eIdx, void *msg, int destNode, CkGroupID gID, int opts CK_MSGOPTIONAL);
 extern void CkSendMsgNodeBranchMulti(int eIdx, void *msg, CkGroupID gID, int npes, const int *nodes, int opts CK_MSGOPTIONAL);
+extern void CkBroadcastWithinNode(int eIdx, void *msg, CkGroupID gID, int opts CK_MSGOPTIONAL);
 extern void CkBroadcastMsgBranch(int eIdx, void *msg, CkGroupID gID, int opts CK_MSGOPTIONAL);
 extern void CkBroadcastMsgNodeBranch(int eIdx, void *msg, CkGroupID gID, int opts CK_MSGOPTIONAL);
 

--- a/src/ck-core/ck.C
+++ b/src/ck-core/ck.C
@@ -1660,7 +1660,7 @@ static inline envelope *_prepareMsgBranch(int eIdx,void *msg,CkGroupID gID,int t
   env->setGroupNum(gID);
   env->setSrcPe(CkMyPe());
 
-  CMI_MSG_READONLY(env) = _entryTable[eIdx]->noKeep;
+  CMI_MSG_NOKEEP(env) = _entryTable[eIdx]->noKeep;
   /*
 #if CMK_ERROR_CHECKING
   nodeRedMgr.setZero();

--- a/src/ck-core/ck.h
+++ b/src/ck-core/ck.h
@@ -36,6 +36,13 @@ inline void _CldEnqueue(int pe, void *msg, int infofn) {
 #endif
   CldEnqueue(pe, msg, infofn);
 }
+inline void _CldEnqueueWithinNode(void *msg, int infofn) {
+  if (!ConverseDeliver(-1)) {
+    CmiFree(msg);
+    return;
+  }
+  CldEnqueueWithinNode(msg, infofn);
+}
 inline void _CldEnqueueMulti(int npes, const int *pes, void *msg, int infofn) {
   if (!ConverseDeliver(-1)) {
     CmiFree(msg);
@@ -84,8 +91,9 @@ inline void _CldNodeEnqueue(int node, void *msg, int infofn) {
 #endif
   CldNodeEnqueue(node, msg, infofn);
 }
-#define _CldEnqueueMulti  CldEnqueueMulti
-#define _CldEnqueueGroup  CldEnqueueGroup
+#define _CldEnqueueMulti      CldEnqueueMulti
+#define _CldEnqueueGroup      CldEnqueueGroup
+#define _CldEnqueueWithinNode CldEnqueueWithinNode
 #endif
 
 #ifndef CMK_CHARE_USE_PTR

--- a/src/conv-core/convcore.C
+++ b/src/conv-core/convcore.C
@@ -3088,12 +3088,13 @@ static void *CmiAllocFindEnclosing(void *blk) {
 }
 
 void CmiInitMsgHeader(void *msg, int size) {
+  if(size >= CmiMsgHeaderSizeBytes) {
 #if CMK_ONESIDED_IMPL
-  // Set zcMsgType in the converse message header to CMK_REG_NO_ZC_MSG
-  if(size >= CmiMsgHeaderSizeBytes)
+    // Set zcMsgType in the converse message header to CMK_REG_NO_ZC_MSG
     CMI_ZC_MSGTYPE(msg) = CMK_REG_NO_ZC_MSG;
 #endif
-  CMI_MSG_NOKEEP(msg) = 0;
+    CMI_MSG_NOKEEP(msg) = 0;
+  }
 }
 
 int CmiGetReference(void *blk)

--- a/src/conv-core/convcore.C
+++ b/src/conv-core/convcore.C
@@ -3093,6 +3093,7 @@ void CmiInitMsgHeader(void *msg, int size) {
   if(size >= CmiMsgHeaderSizeBytes)
     CMI_ZC_MSGTYPE(msg) = CMK_REG_NO_ZC_MSG;
 #endif
+  CMI_MSG_NOKEEP(msg) = 0;
 }
 
 int CmiGetReference(void *blk)

--- a/src/conv-core/converse.h
+++ b/src/conv-core/converse.h
@@ -69,6 +69,8 @@
 #define CMI_IS_ZC(msg)                       (CMI_IS_ZC_P2P(msg) || CMI_IS_ZC_BCAST(msg))
 #endif
 
+#define CMI_MSG_READONLY(msg)                  ((CmiMsgHeaderBasic *)msg)->readonly
+
 #define CMIALIGN(x,n)       (size_t)((~((size_t)n-1))&((x)+(n-1)))
 /*#define ALIGN8(x)        (size_t)((~7)&((x)+7)) */
 #define ALIGN8(x)          CMIALIGN(x,8)
@@ -1382,6 +1384,8 @@ void          CmiSyncNodeBroadcastAllFn(int, char *);
 CmiCommHandle CmiAsyncNodeBroadcastAllFn(int, char *);
 void          CmiFreeNodeBroadcastAllFn(int, char *);
 
+void          CmiWithinNodeBroadcast(int, char*);
+
 /* if node queue is available, adding inter partition counterparts */
 void          CmiInterSyncNodeSendFn(int, int, int, char *);
 void          CmiInterFreeNodeSendFn(int, int, int, char *);
@@ -1715,7 +1719,10 @@ const char *CldGetStrategy(void);
 void CldEnqueue(int pe, void *msg, int infofn);
 void CldEnqueueMulti(int npes, const int *pes, void *msg, int infofn);
 void CldEnqueueGroup(CmiGroup grp, void *msg, int infofn);
+// CldNodeEnqueue enqueues a single message for a node, whereas
+// CldEnqueueWithinNode enqueues a message for each PE on the node.
 void CldNodeEnqueue(int node, void *msg, int infofn);
+void CldEnqueueWithinNode(void *msg, int infofn);
 
 /****** CMM: THE MESSAGE MANAGER ******/
 

--- a/src/conv-core/converse.h
+++ b/src/conv-core/converse.h
@@ -69,7 +69,7 @@
 #define CMI_IS_ZC(msg)                       (CMI_IS_ZC_P2P(msg) || CMI_IS_ZC_BCAST(msg))
 #endif
 
-#define CMI_MSG_READONLY(msg)                  ((CmiMsgHeaderBasic *)msg)->readonly
+#define CMI_MSG_NOKEEP(msg)                  ((CmiMsgHeaderBasic *)msg)->nokeep
 
 #define CMIALIGN(x,n)       (size_t)((~((size_t)n-1))&((x)+(n-1)))
 /*#define ALIGN8(x)        (size_t)((~7)&((x)+7)) */
@@ -1384,7 +1384,7 @@ void          CmiSyncNodeBroadcastAllFn(int, char *);
 CmiCommHandle CmiAsyncNodeBroadcastAllFn(int, char *);
 void          CmiFreeNodeBroadcastAllFn(int, char *);
 
-void          CmiWithinNodeBroadcast(int, char*);
+void          CmiWithinNodeBroadcastFn(int, char*);
 
 /* if node queue is available, adding inter partition counterparts */
 void          CmiInterSyncNodeSendFn(int, int, int, char *);
@@ -1401,6 +1401,7 @@ void          CmiInterFreeNodeSendFn(int, int, int, char *);
 #define CmiSyncNodeBroadcastAll(s,m)        (CmiSyncNodeBroadcastAllFn((s),(char *)(m)))
 #define CmiAsyncNodeBroadcastAll(s,m)       (CmiAsyncNodeBroadcastAllFn((s),(char *)(m)))
 #define CmiSyncNodeBroadcastAllAndFree(s,m) (CmiFreeNodeBroadcastAllFn((s),(char *)(m)))
+#define CmiWithinNodeBroadcast(s,m)         (CmiWithinNodeBroadcastFn((s),(char *)(m)))
 
 /* counterparts of inter partition */
 #if CMK_HAS_PARTITION
@@ -1438,6 +1439,7 @@ void          CmiInterFreeNodeSendFn(int, int, int, char *);
           CmiSyncNodeBroadcastAll(s,m); \
           CmiFree(m); \
         } while(0)
+#define CmiWithinNodeBroadcast(s,m)         (CmiWithinNodeBroadcastFn((s),(char *)(m)))
 #else
 #define CmiSyncNodeBroadcast(s,m)           CmiSyncBroadcast(s,m)
 #define CmiAsyncNodeBroadcast(s,m)          CmiAsyncBroadcast(s,m)
@@ -1445,6 +1447,7 @@ void          CmiInterFreeNodeSendFn(int, int, int, char *);
 #define CmiSyncNodeBroadcastAll(s,m)        CmiSyncBroadcastAll(s,m)
 #define CmiAsyncNodeBroadcastAll(s,m)       CmiAsyncBroadcastAll(s,m)
 #define CmiSyncNodeBroadcastAllAndFree(s,m) CmiSyncBroadcastAllAndFree(s,m)
+#define CmiWithinNodeBroadcast(s,m)         CmiSyncSendAndFree(CmiMyPe(),s,m)
 #endif
 /* and the inter partition counterparts */
 #if CMK_HAS_PARTITION

--- a/src/conv-ldb/cldb.bluegene.C
+++ b/src/conv-ldb/cldb.bluegene.C
@@ -94,10 +94,14 @@ void CldEnqueueGroup(CmiGroup grp, void *msg, int infofn)
 
 void CldEnqueueWithinNode(void *msg, int infofn)
 {
-  int len, queueing, priobits,i; unsigned int *prioptr, start, size;
-  CldInfoFn ifn = (CldInfoFn)CmiHandlerToFunction(infofn);
+  int len, queueing, priobits;
+  unsigned int *prioptr;
   CldPackFn pfn;
+  CldInfoFn ifn = (CldInfoFn)CmiHandlerToFunction(infofn);
   ifn(msg, &pfn, &len, &queueing, &priobits, &prioptr);
+
+  // If message is NOKEEP, do not pack it since its pointer is just going to
+  // be shared with the other PEs on this node.
   if (pfn && !CMI_MSG_NOKEEP(msg)) {
     pfn(&msg);
     ifn(msg, &pfn, &len, &queueing, &priobits, &prioptr);

--- a/src/conv-ldb/cldb.bluegene.C
+++ b/src/conv-ldb/cldb.bluegene.C
@@ -92,6 +92,22 @@ void CldEnqueueGroup(CmiGroup grp, void *msg, int infofn)
   CmiAbort("CldEnqueueGroup not supported!");
 }
 
+void CldEnqueueWithinNode(void *msg, int infofn)
+{
+  int len, queueing, priobits,i; unsigned int *prioptr, start, size;
+  CldInfoFn ifn = (CldInfoFn)CmiHandlerToFunction(infofn);
+  CldPackFn pfn;
+  ifn(msg, &pfn, &len, &queueing, &priobits, &prioptr);
+  if (pfn && !CMI_MSG_READONLY(msg)) {
+    pfn(&msg);
+    ifn(msg, &pfn, &len, &queueing, &priobits, &prioptr);
+  }
+  CldSwitchHandler((char *)msg, CpvAccess(CldHandlerIndex));
+  CmiSetInfo(msg,infofn);
+
+  CmiWithinNodeBroadcast(len, (char *)msg);
+}
+
 void CldEnqueueMulti(int npes, const int *pes, void *msg, int infofn)
 {
   int len, queueing, priobits,i; unsigned int *prioptr;

--- a/src/conv-ldb/cldb.bluegene.C
+++ b/src/conv-ldb/cldb.bluegene.C
@@ -98,7 +98,7 @@ void CldEnqueueWithinNode(void *msg, int infofn)
   CldInfoFn ifn = (CldInfoFn)CmiHandlerToFunction(infofn);
   CldPackFn pfn;
   ifn(msg, &pfn, &len, &queueing, &priobits, &prioptr);
-  if (pfn && !CMI_MSG_READONLY(msg)) {
+  if (pfn && !CMI_MSG_NOKEEP(msg)) {
     pfn(&msg);
     ifn(msg, &pfn, &len, &queueing, &priobits, &prioptr);
   }

--- a/src/conv-ldb/cldb.neighbor.C
+++ b/src/conv-ldb/cldb.neighbor.C
@@ -391,6 +391,22 @@ void CldEnqueueGroup(CmiGroup grp, void *msg, int infofn)
   CmiSyncMulticastAndFree(grp, len, msg);
 }
 
+void CldEnqueueWithinNode(void *msg, int infofn)
+{
+  int len, queueing, priobits,i; unsigned int *prioptr, start, size;
+  CldInfoFn ifn = (CldInfoFn)CmiHandlerToFunction(infofn);
+  CldPackFn pfn;
+  ifn(msg, &pfn, &len, &queueing, &priobits, &prioptr);
+  if (pfn && !CMI_MSG_READONLY(msg)) {
+    pfn(&msg);
+    ifn(msg, &pfn, &len, &queueing, &priobits, &prioptr);
+  }
+  CldSwitchHandler((char *)msg, CpvAccess(CldHandlerIndex));
+  CmiSetInfo(msg,infofn);
+
+  CmiWithinNodeBroadcast(len, (char *)msg);
+}
+
 void CldEnqueueMulti(int npes, const int *pes, void *msg, int infofn)
 {
   int len, queueing, priobits,i; unsigned int *prioptr;

--- a/src/conv-ldb/cldb.neighbor.C
+++ b/src/conv-ldb/cldb.neighbor.C
@@ -397,7 +397,7 @@ void CldEnqueueWithinNode(void *msg, int infofn)
   CldInfoFn ifn = (CldInfoFn)CmiHandlerToFunction(infofn);
   CldPackFn pfn;
   ifn(msg, &pfn, &len, &queueing, &priobits, &prioptr);
-  if (pfn && !CMI_MSG_READONLY(msg)) {
+  if (pfn && !CMI_MSG_NOKEEP(msg)) {
     pfn(&msg);
     ifn(msg, &pfn, &len, &queueing, &priobits, &prioptr);
   }

--- a/src/conv-ldb/cldb.neighbor.C
+++ b/src/conv-ldb/cldb.neighbor.C
@@ -393,10 +393,14 @@ void CldEnqueueGroup(CmiGroup grp, void *msg, int infofn)
 
 void CldEnqueueWithinNode(void *msg, int infofn)
 {
-  int len, queueing, priobits,i; unsigned int *prioptr, start, size;
-  CldInfoFn ifn = (CldInfoFn)CmiHandlerToFunction(infofn);
+  int len, queueing, priobits;
+  unsigned int *prioptr;
   CldPackFn pfn;
+  CldInfoFn ifn = (CldInfoFn)CmiHandlerToFunction(infofn);
   ifn(msg, &pfn, &len, &queueing, &priobits, &prioptr);
+
+  // If message is NOKEEP, do not pack it since its pointer is just going to
+  // be shared with the other PEs on this node.
   if (pfn && !CMI_MSG_NOKEEP(msg)) {
     pfn(&msg);
     ifn(msg, &pfn, &len, &queueing, &priobits, &prioptr);

--- a/src/conv-ldb/cldb.none.C
+++ b/src/conv-ldb/cldb.none.C
@@ -29,10 +29,14 @@ void CldHandler(char *msg)
 
 void CldEnqueueWithinNode(void *msg, int infofn)
 {
-  int len, queueing, priobits,i; unsigned int *prioptr, start, size;
-  CldInfoFn ifn = (CldInfoFn)CmiHandlerToFunction(infofn);
+  int len, queueing, priobits;
+  unsigned int *prioptr;
   CldPackFn pfn;
+  CldInfoFn ifn = (CldInfoFn)CmiHandlerToFunction(infofn);
   ifn(msg, &pfn, &len, &queueing, &priobits, &prioptr);
+
+  // If message is NOKEEP, do not pack it since its pointer is just going to
+  // be shared with the other PEs on this node.
   if (pfn && !CMI_MSG_NOKEEP(msg)) {
     pfn(&msg);
     ifn(msg, &pfn, &len, &queueing, &priobits, &prioptr);

--- a/src/conv-ldb/cldb.none.C
+++ b/src/conv-ldb/cldb.none.C
@@ -27,6 +27,22 @@ void CldHandler(char *msg)
   CsdEnqueueGeneral(msg, queueing, priobits, prioptr);
 }
 
+void CldEnqueueWithinNode(void *msg, int infofn)
+{
+  int len, queueing, priobits,i; unsigned int *prioptr, start, size;
+  CldInfoFn ifn = (CldInfoFn)CmiHandlerToFunction(infofn);
+  CldPackFn pfn;
+  ifn(msg, &pfn, &len, &queueing, &priobits, &prioptr);
+  if (pfn && !CMI_MSG_READONLY(msg)) {
+    pfn(&msg);
+    ifn(msg, &pfn, &len, &queueing, &priobits, &prioptr);
+  }
+  CldSwitchHandler((char *)msg, CpvAccess(CldHandlerIndex));
+  CmiSetInfo(msg,infofn);
+
+  CmiWithinNodeBroadcast(len, (char *)msg);
+}
+
 void CldEnqueueMulti(int npes, const int *pes, void *msg, int infofn)
 {
   int len, queueing, priobits,i; unsigned int *prioptr;

--- a/src/conv-ldb/cldb.none.C
+++ b/src/conv-ldb/cldb.none.C
@@ -33,7 +33,7 @@ void CldEnqueueWithinNode(void *msg, int infofn)
   CldInfoFn ifn = (CldInfoFn)CmiHandlerToFunction(infofn);
   CldPackFn pfn;
   ifn(msg, &pfn, &len, &queueing, &priobits, &prioptr);
-  if (pfn && !CMI_MSG_READONLY(msg)) {
+  if (pfn && !CMI_MSG_NOKEEP(msg)) {
     pfn(&msg);
     ifn(msg, &pfn, &len, &queueing, &priobits, &prioptr);
   }

--- a/src/conv-ldb/cldb.prioritycentralized.C
+++ b/src/conv-ldb/cldb.prioritycentralized.C
@@ -458,10 +458,14 @@ void CldNodeEnqueue(int node, void *msg, int infofn)
 
 void CldEnqueueWithinNode(void *msg, int infofn)
 {
-  int len, queueing, priobits,i; unsigned int *prioptr, start, size;
-  CldInfoFn ifn = (CldInfoFn)CmiHandlerToFunction(infofn);
+  int len, queueing, priobits;
+  unsigned int *prioptr;
   CldPackFn pfn;
+  CldInfoFn ifn = (CldInfoFn)CmiHandlerToFunction(infofn);
   ifn(msg, &pfn, &len, &queueing, &priobits, &prioptr);
+
+  // If message is NOKEEP, do not pack it since its pointer is just going to
+  // be shared with the other PEs on this node.
   if (pfn && !CMI_MSG_NOKEEP(msg)) {
     pfn(&msg);
     ifn(msg, &pfn, &len, &queueing, &priobits, &prioptr);

--- a/src/conv-ldb/cldb.prioritycentralized.C
+++ b/src/conv-ldb/cldb.prioritycentralized.C
@@ -456,6 +456,22 @@ void CldNodeEnqueue(int node, void *msg, int infofn)
   }
 }
 
+void CldEnqueueWithinNode(void *msg, int infofn)
+{
+  int len, queueing, priobits,i; unsigned int *prioptr, start, size;
+  CldInfoFn ifn = (CldInfoFn)CmiHandlerToFunction(infofn);
+  CldPackFn pfn;
+  ifn(msg, &pfn, &len, &queueing, &priobits, &prioptr);
+  if (pfn && !CMI_MSG_READONLY(msg)) {
+    pfn(&msg);
+    ifn(msg, &pfn, &len, &queueing, &priobits, &prioptr);
+  }
+  CldSwitchHandler((char *)msg, CpvAccess(CldHandlerIndex));
+  CmiSetInfo(msg,infofn);
+
+  CmiWithinNodeBroadcast(len, (char *)msg);
+}
+
 void CldEnqueueMulti(int npes, const int *pes, void *msg, int infofn)
 {
   int len, queueing, priobits,i; 

--- a/src/conv-ldb/cldb.prioritycentralized.C
+++ b/src/conv-ldb/cldb.prioritycentralized.C
@@ -462,7 +462,7 @@ void CldEnqueueWithinNode(void *msg, int infofn)
   CldInfoFn ifn = (CldInfoFn)CmiHandlerToFunction(infofn);
   CldPackFn pfn;
   ifn(msg, &pfn, &len, &queueing, &priobits, &prioptr);
-  if (pfn && !CMI_MSG_READONLY(msg)) {
+  if (pfn && !CMI_MSG_NOKEEP(msg)) {
     pfn(&msg);
     ifn(msg, &pfn, &len, &queueing, &priobits, &prioptr);
   }

--- a/src/conv-ldb/cldb.rand.C
+++ b/src/conv-ldb/cldb.rand.C
@@ -50,10 +50,14 @@ void CldEnqueueGroup(CmiGroup grp, void *msg, int infofn)
 
 void CldEnqueueWithinNode(void *msg, int infofn)
 {
-  int len, queueing, priobits,i; unsigned int *prioptr, start, size;
-  CldInfoFn ifn = (CldInfoFn)CmiHandlerToFunction(infofn);
+  int len, queueing, priobits;
+  unsigned int *prioptr;
   CldPackFn pfn;
+  CldInfoFn ifn = (CldInfoFn)CmiHandlerToFunction(infofn);
   ifn(msg, &pfn, &len, &queueing, &priobits, &prioptr);
+
+  // If message is NOKEEP, do not pack it since its pointer is just going to
+  // be shared with the other PEs on this node.
   if (pfn && !CMI_MSG_NOKEEP(msg)) {
     pfn(&msg);
     ifn(msg, &pfn, &len, &queueing, &priobits, &prioptr);

--- a/src/conv-ldb/cldb.rand.C
+++ b/src/conv-ldb/cldb.rand.C
@@ -54,7 +54,7 @@ void CldEnqueueWithinNode(void *msg, int infofn)
   CldInfoFn ifn = (CldInfoFn)CmiHandlerToFunction(infofn);
   CldPackFn pfn;
   ifn(msg, &pfn, &len, &queueing, &priobits, &prioptr);
-  if (pfn && !CMI_MSG_READONLY(msg)) {
+  if (pfn && !CMI_MSG_NOKEEP(msg)) {
     pfn(&msg);
     ifn(msg, &pfn, &len, &queueing, &priobits, &prioptr);
   }

--- a/src/conv-ldb/cldb.rand.C
+++ b/src/conv-ldb/cldb.rand.C
@@ -48,6 +48,22 @@ void CldEnqueueGroup(CmiGroup grp, void *msg, int infofn)
   CmiSyncMulticastAndFree(grp, len, msg);
 }
 
+void CldEnqueueWithinNode(void *msg, int infofn)
+{
+  int len, queueing, priobits,i; unsigned int *prioptr, start, size;
+  CldInfoFn ifn = (CldInfoFn)CmiHandlerToFunction(infofn);
+  CldPackFn pfn;
+  ifn(msg, &pfn, &len, &queueing, &priobits, &prioptr);
+  if (pfn && !CMI_MSG_READONLY(msg)) {
+    pfn(&msg);
+    ifn(msg, &pfn, &len, &queueing, &priobits, &prioptr);
+  }
+  CldSwitchHandler((char *)msg, CpvAccess(CldHandlerIndex));
+  CmiSetInfo(msg,infofn);
+
+  CmiWithinNodeBroadcast(len, (char *)msg);
+}
+
 void CldEnqueueMulti(int npes, const int *pes, void *msg, int infofn)
 {
   int len, queueing, priobits,i; unsigned int *prioptr;

--- a/src/conv-ldb/cldb.spray.C
+++ b/src/conv-ldb/cldb.spray.C
@@ -159,6 +159,22 @@ void CldEnqueueGroup(CmiGroup grp, void *msg, int infofn)
   CmiFree(msg);
 }
 
+void CldEnqueueWithinNode(void *msg, int infofn)
+{
+  int len, queueing, priobits,i; unsigned int *prioptr, start, size;
+  CldInfoFn ifn = (CldInfoFn)CmiHandlerToFunction(infofn);
+  CldPackFn pfn;
+  ifn(msg, &pfn, &len, &queueing, &priobits, &prioptr);
+  if (pfn && !CMI_MSG_READONLY(msg)) {
+    pfn(&msg);
+    ifn(msg, &pfn, &len, &queueing, &priobits, &prioptr);
+  }
+  CldSwitchHandler((char *)msg, CpvAccess(CldHandlerIndex));
+  CmiSetInfo(msg,infofn);
+
+  CmiWithinNodeBroadcast(len, (char *)msg);
+}
+
 void CldEnqueueMulti(int npes, const int *pes, void *msg, int infofn)
 {
   int len, queueing, priobits,i; unsigned int *prioptr;

--- a/src/conv-ldb/cldb.spray.C
+++ b/src/conv-ldb/cldb.spray.C
@@ -161,10 +161,14 @@ void CldEnqueueGroup(CmiGroup grp, void *msg, int infofn)
 
 void CldEnqueueWithinNode(void *msg, int infofn)
 {
-  int len, queueing, priobits,i; unsigned int *prioptr, start, size;
-  CldInfoFn ifn = (CldInfoFn)CmiHandlerToFunction(infofn);
+  int len, queueing, priobits;
+  unsigned int *prioptr;
   CldPackFn pfn;
+  CldInfoFn ifn = (CldInfoFn)CmiHandlerToFunction(infofn);
   ifn(msg, &pfn, &len, &queueing, &priobits, &prioptr);
+
+  // If message is NOKEEP, do not pack it since its pointer is just going to
+  // be shared with the other PEs on this node.
   if (pfn && !CMI_MSG_NOKEEP(msg)) {
     pfn(&msg);
     ifn(msg, &pfn, &len, &queueing, &priobits, &prioptr);

--- a/src/conv-ldb/cldb.spray.C
+++ b/src/conv-ldb/cldb.spray.C
@@ -165,7 +165,7 @@ void CldEnqueueWithinNode(void *msg, int infofn)
   CldInfoFn ifn = (CldInfoFn)CmiHandlerToFunction(infofn);
   CldPackFn pfn;
   ifn(msg, &pfn, &len, &queueing, &priobits, &prioptr);
-  if (pfn && !CMI_MSG_READONLY(msg)) {
+  if (pfn && !CMI_MSG_NOKEEP(msg)) {
     pfn(&msg);
     ifn(msg, &pfn, &len, &queueing, &priobits, &prioptr);
   }

--- a/src/conv-ldb/cldb.test.C
+++ b/src/conv-ldb/cldb.test.C
@@ -36,7 +36,7 @@ void CldEnqueueWithinNode(void *msg, int infofn)
   CldInfoFn ifn = (CldInfoFn)CmiHandlerToFunction(infofn);
   CldPackFn pfn;
   ifn(msg, &pfn, &len, &queueing, &priobits, &prioptr);
-  if (pfn && !CMI_MSG_READONLY(msg)) {
+  if (pfn && !CMI_MSG_NOKEEP(msg)) {
     pfn(&msg);
     ifn(msg, &pfn, &len, &queueing, &priobits, &prioptr);
   }

--- a/src/conv-ldb/cldb.test.C
+++ b/src/conv-ldb/cldb.test.C
@@ -30,6 +30,22 @@ void CldHandler(char *msg)
   CsdEnqueueGeneral(msg, queueing, priobits, prioptr);
 }
 
+void CldEnqueueWithinNode(void *msg, int infofn)
+{
+  int len, queueing, priobits,i; unsigned int *prioptr, start, size;
+  CldInfoFn ifn = (CldInfoFn)CmiHandlerToFunction(infofn);
+  CldPackFn pfn;
+  ifn(msg, &pfn, &len, &queueing, &priobits, &prioptr);
+  if (pfn && !CMI_MSG_READONLY(msg)) {
+    pfn(&msg);
+    ifn(msg, &pfn, &len, &queueing, &priobits, &prioptr);
+  }
+  CldSwitchHandler((char *)msg, CpvAccess(CldHandlerIndex));
+  CmiSetInfo(msg,infofn);
+
+  CmiWithinNodeBroadcast(len, (char *)msg);
+}
+
 void CldEnqueueMulti(int npes, const int *pes, void *msg, int infofn)
 {
   int len, queueing, priobits,i; unsigned int *prioptr;

--- a/src/conv-ldb/cldb.test.C
+++ b/src/conv-ldb/cldb.test.C
@@ -32,10 +32,14 @@ void CldHandler(char *msg)
 
 void CldEnqueueWithinNode(void *msg, int infofn)
 {
-  int len, queueing, priobits,i; unsigned int *prioptr, start, size;
-  CldInfoFn ifn = (CldInfoFn)CmiHandlerToFunction(infofn);
+  int len, queueing, priobits;
+  unsigned int *prioptr;
   CldPackFn pfn;
+  CldInfoFn ifn = (CldInfoFn)CmiHandlerToFunction(infofn);
   ifn(msg, &pfn, &len, &queueing, &priobits, &prioptr);
+
+  // If message is NOKEEP, do not pack it since its pointer is just going to
+  // be shared with the other PEs on this node.
   if (pfn && !CMI_MSG_NOKEEP(msg)) {
     pfn(&msg);
     ifn(msg, &pfn, &len, &queueing, &priobits, &prioptr);

--- a/src/conv-ldb/cldb.workstealing.C
+++ b/src/conv-ldb/cldb.workstealing.C
@@ -213,6 +213,22 @@ void CldEnqueueGroup(CmiGroup grp, void *msg, int infofn)
   CmiSyncMulticastAndFree(grp, len, msg);
 }
 
+void CldEnqueueWithinNode(void *msg, int infofn)
+{
+  int len, queueing, priobits,i; unsigned int *prioptr, start, size;
+  CldInfoFn ifn = (CldInfoFn)CmiHandlerToFunction(infofn);
+  CldPackFn pfn;
+  ifn(msg, &pfn, &len, &queueing, &priobits, &prioptr);
+  if (pfn && !CMI_MSG_READONLY(msg)) {
+    pfn(&msg);
+    ifn(msg, &pfn, &len, &queueing, &priobits, &prioptr);
+  }
+  CldSwitchHandler((char *)msg, CpvAccess(CldHandlerIndex));
+  CmiSetInfo(msg,infofn);
+
+  CmiWithinNodeBroadcast(len, (char *)msg);
+}
+
 void CldEnqueueMulti(int npes, const int *pes, void *msg, int infofn)
 {
   int len, queueing, priobits,i; unsigned int *prioptr;

--- a/src/conv-ldb/cldb.workstealing.C
+++ b/src/conv-ldb/cldb.workstealing.C
@@ -215,10 +215,14 @@ void CldEnqueueGroup(CmiGroup grp, void *msg, int infofn)
 
 void CldEnqueueWithinNode(void *msg, int infofn)
 {
-  int len, queueing, priobits,i; unsigned int *prioptr, start, size;
-  CldInfoFn ifn = (CldInfoFn)CmiHandlerToFunction(infofn);
+  int len, queueing, priobits;
+  unsigned int *prioptr;
   CldPackFn pfn;
+  CldInfoFn ifn = (CldInfoFn)CmiHandlerToFunction(infofn);
   ifn(msg, &pfn, &len, &queueing, &priobits, &prioptr);
+
+  // If message is NOKEEP, do not pack it since its pointer is just going to
+  // be shared with the other PEs on this node.
   if (pfn && !CMI_MSG_NOKEEP(msg)) {
     pfn(&msg);
     ifn(msg, &pfn, &len, &queueing, &priobits, &prioptr);

--- a/src/conv-ldb/cldb.workstealing.C
+++ b/src/conv-ldb/cldb.workstealing.C
@@ -219,7 +219,7 @@ void CldEnqueueWithinNode(void *msg, int infofn)
   CldInfoFn ifn = (CldInfoFn)CmiHandlerToFunction(infofn);
   CldPackFn pfn;
   ifn(msg, &pfn, &len, &queueing, &priobits, &prioptr);
-  if (pfn && !CMI_MSG_READONLY(msg)) {
+  if (pfn && !CMI_MSG_NOKEEP(msg)) {
     pfn(&msg);
     ifn(msg, &pfn, &len, &queueing, &priobits, &prioptr);
   }

--- a/tests/charm++/Makefile
+++ b/tests/charm++/Makefile
@@ -21,6 +21,7 @@ DIRS = \
   jacobi3d \
   jacobi3d-sdag \
   zerocopy \
+  within_node_bcast \
 
 # skip sdag, megatest and commtest
 BGDIRS = \

--- a/tests/charm++/within_node_bcast/Makefile
+++ b/tests/charm++/within_node_bcast/Makefile
@@ -1,0 +1,22 @@
+-include ../../common.mk
+-include ../../../include/conv-mach-opt.mak
+CHARMC=../../../bin/charmc $(OPTS)
+
+all: within_node_bcast
+
+within_node_bcast: within_node_bcast.decl.h within_node_bcast.def.h within_node_bcast.C
+	$(CHARMC) -language charm++ within_node_bcast.C -o within_node_bcast
+
+within_node_bcast.decl.h within_node_bcast.def.h: within_node_bcast.ci
+	$(CHARMC) within_node_bcast.ci
+
+clean:
+	rm -f *.decl.h *.def.h *.o within_node_bcast charmrun
+
+test: all
+	$(call run, ./within_node_bcast +p1)
+	$(call run, ./within_node_bcast +p2)
+ifeq ($(CMK_SMP),1)
+	$(call run, ./within_node_bcast +p2 ++ppn 2)
+	$(call run, ./within_node_bcast +p4 ++ppn 2)
+endif

--- a/tests/charm++/within_node_bcast/within_node_bcast.C
+++ b/tests/charm++/within_node_bcast/within_node_bcast.C
@@ -1,0 +1,124 @@
+#include "within_node_bcast.decl.h"
+
+CProxy_TestGroup gProxy;
+CProxy_TestNodeGroup ngProxy;
+
+class TestMessage : public CMessage_TestMessage {
+public:
+  int number;
+  std::atomic<int> counter;
+  CkCallback cb;
+
+  TestMessage(int i, CkCallback c) : number(i), cb(c), counter(0) {}
+};
+
+class Main : public CBase_Main {
+private:
+  int test_num;
+  int result_count;
+  int expected_result;
+public:
+  Main(CkArgMsg* msg) : test_num(0), result_count(0), expected_result(0) {
+    delete msg;
+
+    ngProxy = CProxy_TestNodeGroup::ckNew();
+    gProxy = CProxy_TestGroup::ckNew();
+
+    thisProxy.runTests();
+  }
+
+  void runTests() {
+    CkPrintf("Starting test %i\n", test_num);
+
+    result_count = 0;
+    expected_result = 0;
+
+    CkCallback cb(CkReductionTarget(Main, testDone), thisProxy);
+    TestMessage* msg = new TestMessage(test_num, cb);
+
+    switch (test_num) {
+      case 0:
+        ngProxy.recv(msg);
+        break;
+      case 1:
+        ngProxy.recvCopy(msg);
+        break;
+      default:
+        CkPrintf("Tests complete!\n");
+        CkExit();
+    }
+  }
+
+  void testDone(int result) {
+    if (result_count == 0) {
+      result_count++;
+      expected_result = result;
+    } else if (result == expected_result) {
+      CkPrintf("Test %i PASSED!\n", test_num);
+      test_num++;
+      thisProxy.runTests();
+    } else {
+      CkPrintf("The results do not match: %i != %i\n", result, expected_result);
+      CkAbort("Failed expectations!\n");
+    }
+  }
+};
+
+class TestNodeGroup : public CBase_TestNodeGroup {
+public:
+  TestNodeGroup() {
+    CkPrintf("TestNodeGroup created on node %i\n", CkMyNode());
+  }
+
+  void recv(TestMessage* msg) {
+    // Here the expectation is that the counter is incremented once by each PE
+    // and starts at 0. So my nodes sum will be n * (n - 1) / 2.
+    int myExpectation = (CmiMyNodeSize() * (CmiMyNodeSize() - 1)) / 2;
+    contribute(sizeof(int), &myExpectation, CkReduction::sum_int, msg->cb);
+
+    CkBroadcastWithinNode(CkIndex_TestGroup::recv(NULL), msg, gProxy);
+  }
+
+  void recvCopy(TestMessage* msg) {
+    // Here, there will be one copy of the message per PE, so each PE will
+    // contribute msg->number, and my sum is therefor my size * msg->number.
+    msg->counter.store(msg->number);
+    int myExpectation = msg->number * CkMyNodeSize();
+    contribute(sizeof(int), &myExpectation, CkReduction::sum_int, msg->cb);
+
+    CkBroadcastWithinNode(CkIndex_TestGroup::recvCopy(NULL), msg, gProxy);
+  }
+};
+
+class TestGroup : public CBase_TestGroup {
+public:
+  TestGroup() {
+    CkPrintf("TestGroup created on PE %i\n", CkMyPe());
+  }
+
+  // Marked [nokeep], so I share this message with every PE on my node, and
+  // should not delete it.
+  void recv(TestMessage* msg) {
+    int val = msg->counter.fetch_add(1);
+    CkPrintf("PE %i received message #%i, with receiver counter %i\n",
+        CkMyPe(), msg->number, val);
+    contribute(sizeof(int), &val, CkReduction::sum_int, msg->cb);
+  }
+
+  // Not marked [nokeep], so I get my own copy of the message and I'm in charge
+  // of deallocation.
+  void recvCopy(TestMessage* msg) {
+    int val = msg->counter.fetch_add(1);
+    CkPrintf("PE %i received a copy of message #%i with receiver counter %i\n",
+        CkMyPe(), msg->number, val);
+
+    // The value of what I received should always be the message number since
+    // I get my own copy of the message.
+    CkAssert(val == msg->number);
+
+    contribute(sizeof(int), &val, CkReduction::sum_int, msg->cb);
+    delete msg;
+  }
+};
+
+#include "within_node_bcast.def.h"

--- a/tests/charm++/within_node_bcast/within_node_bcast.C
+++ b/tests/charm++/within_node_bcast/within_node_bcast.C
@@ -1,74 +1,43 @@
 #include "within_node_bcast.decl.h"
 
+#define ITERATIONS 100
+#define DATA_SIZE 1024
+
 CProxy_TestGroup gProxy;
 CProxy_TestNodeGroup ngProxy;
 
 class TestMessage : public CMessage_TestMessage {
 public:
-  int number;
+  int test_num;
+  int* data;
   std::atomic<int> counter;
   CkCallback cb;
 
-  TestMessage(int i, CkCallback c) : number(i), cb(c), counter(0) {}
+  TestMessage(int t, CkCallback c) : test_num(t), cb(c), counter(0) {}
 };
 
 class Main : public CBase_Main {
 private:
+  Main_SDAG_CODE
   int test_num;
-  int result_count;
-  int expected_result;
 public:
-  Main(CkArgMsg* msg) : test_num(0), result_count(0), expected_result(0) {
+  Main(CkArgMsg* msg) {
     delete msg;
 
     ngProxy = CProxy_TestNodeGroup::ckNew();
     gProxy = CProxy_TestGroup::ckNew();
 
+    // Defined as an SDAG method in the .ci file
     thisProxy.runTests();
-  }
 
-  void runTests() {
-    CkPrintf("Starting test %i\n", test_num);
-
-    result_count = 0;
-    expected_result = 0;
-
-    CkCallback cb(CkReductionTarget(Main, testDone), thisProxy);
-    TestMessage* msg = new TestMessage(test_num, cb);
-
-    switch (test_num) {
-      case 0:
-        ngProxy.recv(msg);
-        break;
-      case 1:
-        ngProxy.recvCopy(msg);
-        break;
-      default:
-        CkPrintf("Tests complete!\n");
-        CkExit();
-    }
-  }
-
-  void testDone(int result) {
-    if (result_count == 0) {
-      result_count++;
-      expected_result = result;
-    } else if (result == expected_result) {
-      CkPrintf("Test %i PASSED!\n", test_num);
-      test_num++;
-      thisProxy.runTests();
-    } else {
-      CkPrintf("The results do not match: %i != %i\n", result, expected_result);
-      CkAbort("Failed expectations!\n");
-    }
+    // Make sure QD counters are correctly updated for WNB
+    CkStartQD(CkCallback(CkCallback::ckExit));
   }
 };
 
 class TestNodeGroup : public CBase_TestNodeGroup {
 public:
-  TestNodeGroup() {
-    CkPrintf("TestNodeGroup created on node %i\n", CkMyNode());
-  }
+  TestNodeGroup() {}
 
   void recv(TestMessage* msg) {
     // Here the expectation is that the counter is incremented once by each PE
@@ -81,9 +50,9 @@ public:
 
   void recvCopy(TestMessage* msg) {
     // Here, there will be one copy of the message per PE, so each PE will
-    // contribute msg->number, and my sum is therefor my size * msg->number.
-    msg->counter.store(msg->number);
-    int myExpectation = msg->number * CkMyNodeSize();
+    // contribute msg->test_num, and my sum is therefor my size * msg->test_num.
+    msg->counter.store(msg->test_num);
+    int myExpectation = msg->test_num * CkMyNodeSize();
     contribute(sizeof(int), &myExpectation, CkReduction::sum_int, msg->cb);
 
     CkBroadcastWithinNode(CkIndex_TestGroup::recvCopy(NULL), msg, gProxy);
@@ -92,29 +61,38 @@ public:
 
 class TestGroup : public CBase_TestGroup {
 public:
-  TestGroup() {
-    CkPrintf("TestGroup created on PE %i\n", CkMyPe());
-  }
+  TestGroup() {}
 
   // Marked [nokeep], so I share this message with every PE on my node, and
   // should not delete it.
   void recv(TestMessage* msg) {
+    for (int i = 0; i < DATA_SIZE; i++) {
+      if (msg->data[i] != msg->test_num) {
+        CkPrintf("msg->data incorrect for [nokeep] test %i[%i]! (%i)\n",
+            msg->test_num, i, msg->data[i]);
+        CkAbort("Test failed in data transmission!\n");
+      }
+    }
+
     int val = msg->counter.fetch_add(1);
-    CkPrintf("PE %i received message #%i, with receiver counter %i\n",
-        CkMyPe(), msg->number, val);
     contribute(sizeof(int), &val, CkReduction::sum_int, msg->cb);
   }
 
   // Not marked [nokeep], so I get my own copy of the message and I'm in charge
   // of deallocation.
   void recvCopy(TestMessage* msg) {
-    int val = msg->counter.fetch_add(1);
-    CkPrintf("PE %i received a copy of message #%i with receiver counter %i\n",
-        CkMyPe(), msg->number, val);
+    for (int i = 0; i < DATA_SIZE; i++) {
+      if (msg->data[i] != msg->test_num) {
+        CkPrintf("msg->data incorrect for copy test %i[%i]! (%i)\n",
+            msg->test_num, i, msg->data[i]);
+        CkAbort("Test failed in data transmission!\n");
+      }
+    }
 
-    // The value of what I received should always be the message number since
+    int val = msg->counter.fetch_add(1);
+    // The value of what I received should always be the message test_num since
     // I get my own copy of the message.
-    CkAssert(val == msg->number);
+    CkAssert(val == msg->test_num);
 
     contribute(sizeof(int), &val, CkReduction::sum_int, msg->cb);
     delete msg;

--- a/tests/charm++/within_node_bcast/within_node_bcast.ci
+++ b/tests/charm++/within_node_bcast/within_node_bcast.ci
@@ -1,0 +1,25 @@
+mainmodule within_node_bcast {
+
+  message TestMessage;
+
+  readonly CProxy_TestNodeGroup ngProxy;
+  readonly CProxy_TestGroup gProxy;
+
+  mainchare Main {
+    entry Main(CkArgMsg* msg);
+    entry void runTests();
+    entry [reductiontarget] void testDone(int result);
+  };
+
+  nodegroup TestNodeGroup {
+    entry TestNodeGroup();
+    entry void recv(TestMessage* msg);
+    entry void recvCopy(TestMessage* msg);
+  };
+
+  group TestGroup {
+    entry TestGroup();
+    entry [nokeep] void recv(TestMessage* msg);
+    entry void recvCopy(TestMessage* msg);
+  };
+};

--- a/tests/charm++/within_node_bcast/within_node_bcast.ci
+++ b/tests/charm++/within_node_bcast/within_node_bcast.ci
@@ -1,14 +1,52 @@
 mainmodule within_node_bcast {
 
-  message TestMessage;
+  message TestMessage {
+    int data[];
+  };
 
   readonly CProxy_TestNodeGroup ngProxy;
   readonly CProxy_TestGroup gProxy;
 
   mainchare Main {
     entry Main(CkArgMsg* msg);
-    entry void runTests();
     entry [reductiontarget] void testDone(int result);
+    entry void runTests() {
+      serial { CkPrintf("Testing within-node broadcast\n"); }
+      for (test_num = 0; test_num < ITERATIONS; test_num++) {
+        serial {
+          CkCallback cb(CkReductionTarget(Main, testDone), thisProxy);
+          TestMessage* msg = new (DATA_SIZE) TestMessage(test_num, cb);
+          std::fill(msg->data, msg->data + DATA_SIZE, test_num);
+          ngProxy.recvCopy(msg);
+        }
+
+        when testDone(int result1), testDone(int result2) serial {
+          if (result1 != result2) {
+            CkPrintf("Results for test %i do not match! (%i, %i)\n",
+                test_num, result1, result2);
+            CkAbort("Test failed in results checking!!\n");
+          }
+        }
+      }
+
+      serial { CkPrintf("Testing [nokeep] within-node broadcast\n"); }
+      for (test_num = 0; test_num < ITERATIONS; test_num++) {
+        serial {
+          CkCallback cb(CkReductionTarget(Main, testDone), thisProxy);
+          TestMessage* msg = new (DATA_SIZE) TestMessage(test_num, cb);
+          std::fill(msg->data, msg->data + DATA_SIZE, test_num);
+          ngProxy.recv(msg);
+        }
+
+        when testDone(int result1), testDone(int result2) serial {
+          if (result1 != result2) {
+            CkPrintf("Results for test %i do not match! (%i, %i)\n",
+                test_num, result1, result2);
+            CkAbort("Test failed in results checking!!\n");
+          }
+        }
+      }
+    }
   };
 
   nodegroup TestNodeGroup {


### PR DESCRIPTION
*Original date: 2019-04-25 17:03:02*
*Original PR: https://charm.cs.illinois.edu/gerrit/5068*

---

This respects [nokeep] and therefore would allow a receiver on a node to
forward a message to all PEs on a node, without copying the message, and
automatically deallocating the message after all PEs have received it (similar
to [nokeep] array broadcasts within a PE). With more work this could be more
integrated into all broadcasts/multicasts to save copying costs for large
readonly broadcasts.

Change-Id: I04dd6867245cd6fd8cd59b6125f9e806e5c27d52