### PR TITLE
For net layers, allow restart when a node loses connectivity

### DIFF
--- a/src/arch/netlrts/machine.C
+++ b/src/arch/netlrts/machine.C
@@ -1083,6 +1083,12 @@ void charmrun_realloc(const char *s)
 
 #ifdef __FAULT__
 #include "machine-recover.c"
+CMI_EXTERNC
+void notify_charmrun_crash(int crashed_pe)
+{
+  ChMessageInt_t crashed_pe_msg = ChMessageInt_new(crashed_pe);
+  ctrl_sendone_nolock("crash", (const char *)&crashed_pe_msg, sizeof(ChMessageInt_t), NULL, 0);
+}
 #endif
 
 static void node_addresses_store(ChMessage *msg);

--- a/src/arch/verbs/machine.C
+++ b/src/arch/verbs/machine.C
@@ -1029,6 +1029,12 @@ CmiPrintStackTrace(0);
 
 #ifdef __FAULT__
 #include "machine-recover.c"
+CMI_EXTERNC
+void notify_charmrun_crash(int crashed_pe)
+{
+  ChMessageInt_t crashed_pe_msg = ChMessageInt_new(crashed_pe);
+  ctrl_sendone_nolock("crash", (const char *)&crashed_pe_msg, sizeof(ChMessageInt_t), NULL, 0);
+}
 #endif
 
 static void node_addresses_store(ChMessage *msg);

--- a/src/util/charmrun-src/charmrun.C
+++ b/src/util/charmrun-src/charmrun.C
@@ -2481,6 +2481,37 @@ static int req_handle_crashack(ChMessage *msg, SOCKET fd)
   return 0;
 }
 
+static int req_handle_crashnotify(ChMessage *msg, nodetab_process & buddy)
+{
+  int crashed_pe = ChMessageInt(*(ChMessageInt_t *)(msg->data));
+  printf("Charmrun> req_handle_crashnotify: PE %d failed\n", crashed_pe);
+  fflush(stdout);
+
+  nodetab_process & p = *pe_to_process_map[crashed_pe];
+
+  const SOCKET fd = p.req_client;
+
+#if (!defined(_FAULT_MLOG_) && !defined(_FAULT_CAUSAL_))
+  skt_close(fd);
+#endif
+
+  // should also send a message to all the other processes telling them that this one has crashed
+  // announce_crash(p);
+
+  restart_node(p);
+
+  // After the crashed processor has been recreated
+  // it connects to Charmrun. That data must now be filled
+  // into the node table.
+  reconnect_crashed_client(p);
+
+#if (defined(_FAULT_MLOG_) || defined(_FAULT_CAUSAL_))
+  skt_close(fd);
+#endif
+
+  return REQ_OK;
+}
+
 #ifdef HSTART
 /* send initnode to root*/
 static int set_crashed_socket_id(ChMessage *msg, SOCKET fd)
@@ -2615,6 +2646,8 @@ static int req_handler_dispatch(ChMessage *msg, nodetab_process & p)
     return REQ_FAILED;
   }
 #ifdef __FAULT__
+  else if (strcmp(cmd,"crash") == 0)
+    return req_handle_crashnotify(msg, p);
   else if (strcmp(cmd, "crash_ack") == 0)
     return req_handle_crashack(msg, replyFd);
 #ifdef HSTART


### PR DESCRIPTION
*Original date: 2018-11-09 20:51:24*
*Original PR: https://charm.cs.illinois.edu/gerrit/3387*

---

(due to cable being unplugged, restart, etc)

Co-authored-by: Evan Ramos <evan@hpccharm.com>

Change-Id: I4bc88407d5a61454647d20877de3e7108e5ad66e