### PR TITLE
Cleanup #1982: Use C++ STL data structures in conv-conds

### DIFF
--- a/src/conv-core/conv-conds.C
+++ b/src/conv-core/conv-conds.C
@@ -5,6 +5,10 @@
 #include "converse.h"
 #include "charm-api.h"
 
+#include <vector>
+#include <deque>
+#include <queue>
+
 #if CMK_ERROR_CHECKING
 CpvDeclare(double, idleBeginWalltime); // used for determining the conditon for long idle
 #endif
@@ -12,54 +16,49 @@ CpvDeclare(double, idleBeginWalltime); // used for determining the conditon for 
 /**
  * Structure to hold the requisites for a conditional callback
  */
-typedef struct _ccd_cond_callback {
+struct ccd_cond_callback {
   CcdCondFn fn;
   void *arg;
   int pe;			/* the pe that sets the callback */
-} ccd_cond_callback;
 
+  ccd_cond_callback(CcdCondFn f, void *a, int p)
+    : fn{f}, arg{a}, pe{p}
+  { }
+};
 
 
 /**
  * Structure to hold the requisites for a periodic callback
  */
-typedef struct _ccd_periodic_callback {
+struct ccd_periodic_callback {
   CcdVoidFn fn;
   void *arg;
   int pe;			/* the pe that sets the callback */
-} ccd_periodic_callback;
 
-
-
-/**
- * An element (a single callback) in a list of callbacks
- */
-typedef struct _ccd_cblist_elem {
-  ccd_cond_callback cb;
-  short int next;
-  short int prev;
-} ccd_cblist_elem;
-
+  ccd_periodic_callback(CcdVoidFn f, void *a, int p)
+    : fn{f}, arg{a}, pe{p}
+  { }
+};
 
 
 /**
- * A list of callbacks stored as an array and handled like a list
+ * A list of cond callbacks
  */
-typedef struct _ccd_cblist {
-  unsigned short int len, maxlen;
-  short int first, last, first_free;
-  bool flag;
-  ccd_cblist_elem *elems;
-} ccd_cblist;
+struct ccd_cblist {
+  std::deque<ccd_cond_callback> elems{};
+  bool flag = false;
+};
+
 
 
 /*Make sure this matches the CcdPERIODIC_* list in converse.h*/
 #define CCD_PERIODIC_MAX (CcdPERIODIC_LAST - CcdPERIODIC_FIRST)
-const static double periodicCallInterval[CCD_PERIODIC_MAX]=
+
+static constexpr double periodicCallInterval[CCD_PERIODIC_MAX] =
 {0.001, 0.010, 0.100, 1.0, 5.0, 10.0, 60.0, 2*60.0, 5*60.0, 10*60.0, 3600.0, 12*3600.0, 24*3600.0};
 
-/** The number of timer-based condition callbacks */
-CpvDeclare(int, _ccd_num_timed_cond_cbs);
+/** The number of timer-based conditional callbacks */
+CpvStaticDeclare(int, _ccd_num_timed_cond_cbs);
 
 /* Cond callbacks that use the above time intervals for their condition are considered "timed" */
 static bool isTimed(int condnum) {
@@ -67,109 +66,39 @@ static bool isTimed(int condnum) {
 }
 
 
-/** Initialize a list of callbacks. Alloc memory, set counters etc. */
-static void init_cblist(ccd_cblist *l, unsigned int ml)
-{
-  int i;
-  l->elems = (ccd_cblist_elem*) malloc(ml*sizeof(ccd_cblist_elem));
-  _MEMCHECK(l->elems);
-  for(i=0;i<ml;i++) {
-    l->elems[i].next = i+1;
-    l->elems[i].prev = i-1;
-  }
-  l->elems[ml-1].next = -1;
-  l->len = 0;
-  l->maxlen = ml;
-  l->first = l->last = -1;
-  l->first_free = 0;
-  l->flag = false;
-}
-
-
-
-/** Expand the callback list to a max length of ml */
-static void expand_cblist(ccd_cblist *l, unsigned int ml)
-{
-  ccd_cblist_elem *old_elems = l->elems;
-  int i = 0;
-  l->elems = (ccd_cblist_elem*) malloc(ml*sizeof(ccd_cblist_elem));
-  _MEMCHECK(l->elems);
-  for(i=0;i<(l->len);i++)
-    l->elems[i] = old_elems[i];
-  free(old_elems);
-  for(i=l->len;i<ml;i++) {
-    l->elems[i].next = i+1;
-    l->elems[i].prev = i-1;
-  }
-  l->elems[ml-1].next = -1;
-  l->elems[l->len].prev = -1;
-  l->maxlen = ml;
-  l->first_free = l->len;
-}
-
-
-
 /** Remove element referred to by given list index idx. */
-static void remove_elem(ccd_cblist *l, int condnum, int idx)
+static inline void remove_elem(ccd_cblist & l, int condnum, int idx)
 {
-  ccd_cblist_elem *e = l->elems;
-  /* remove lidx from the busy list */
-  if(e[idx].next != (-1))
-    e[e[idx].next].prev = e[idx].prev;
-  if(e[idx].prev != (-1))
-    e[e[idx].prev].next = e[idx].next;
-  if(idx==(l->first)) 
-    l->first = e[idx].next;
-  if(idx==(l->last)) 
-    l->last = e[idx].prev;
-  /* put lidx in the free list */
-  e[idx].prev = -1;
-  e[idx].next = l->first_free;
-  if(e[idx].next != (-1))
-    e[e[idx].next].prev = idx;
-  l->first_free = idx;
-  l->len--;
-  if (isTimed(condnum)) CpvAccess(_ccd_num_timed_cond_cbs)--;
+  if (isTimed(condnum))
+    CpvAccess(_ccd_num_timed_cond_cbs)--;
+
+  l.elems.erase(l.elems.begin() + idx);
 }
 
 
 
 /** Remove n elements from the beginning of the list. */
-static void remove_n_elems(ccd_cblist *l, int condnum, int n)
+static inline void remove_n_elems(ccd_cblist & l, int condnum, size_t n)
 {
-  int i;
-  if(n==0 || (l->len < n))
+  if (n == 0 || l.elems.size() < n)
     return;
-  for(i=0;i<n;i++) {
-    remove_elem(l, condnum, l->first);
-  }
+
+  if (isTimed(condnum))
+    CpvAccess(_ccd_num_timed_cond_cbs) -= n;
+
+  l.elems.erase(l.elems.begin(), l.elems.begin() + n);
 }
 
 
 
 /** Append callback to the given cblist, and return the index. */
-static int append_elem(ccd_cblist *l, int condnum, CcdCondFn fn, void *arg, int pe)
+static inline int append_elem(ccd_cblist & l, int condnum, CcdCondFn fn, void *arg, int pe)
 {
-  int idx;
-  ccd_cblist_elem *e;
-  if(l->len == l->maxlen)
-    expand_cblist(l, l->maxlen*2);
-  idx = l->first_free;
-  e = l->elems;
-  l->first_free = e[idx].next;
-  e[idx].next = -1;
-  e[idx].prev = l->last;
-  if(l->first == (-1))
-    l->first = idx;
-  if(l->last != (-1))
-    e[l->last].next = idx;
-  l->last = idx;
-  e[idx].cb.fn = fn;
-  e[idx].cb.arg = arg;
-  e[idx].cb.pe = pe;
-  l->len++;
-  if (isTimed(condnum)) CpvAccess(_ccd_num_timed_cond_cbs)++;
-  return idx;
+  if (isTimed(condnum))
+    CpvAccess(_ccd_num_timed_cond_cbs)++;
+
+  l.elems.emplace_back(fn, arg, pe);
+  return l.elems.size()-1;
 }
 
 
@@ -182,13 +111,18 @@ static int append_elem(ccd_cblist *l, int condnum, CcdCondFn fn, void *arg, int 
  * registered from other callbacks) are ignored. 
  * @note: It is illegal to cancel callbacks from within ccd callbacks.
  */
-static void call_cblist_keep(ccd_cblist *l)
+static void call_cblist_keep(const ccd_cblist & l)
 {
-  for (int i = 0, idx = l->first; i < l->len; i++) {
-    int old = CmiSwitchToPE(l->elems[idx].cb.pe);
-    (*(l->elems[idx].cb.fn))(l->elems[idx].cb.arg);
+  // save the length in case callbacks are added during execution
+  const size_t len = l.elems.size();
+
+  // we must iterate this way because insertion invalidates deque iterators
+  for (size_t i = 0; i < len; ++i)
+  {
+    const ccd_cond_callback & cb = l.elems[i];
+    int old = CmiSwitchToPE(cb.pe);
+    (*(cb.fn))(cb.arg);
     int unused = CmiSwitchToPE(old);
-    idx = l->elems[idx].next;
   }
 }
 
@@ -202,20 +136,28 @@ static void call_cblist_keep(ccd_cblist *l)
  * registered from other callbacks) are ignored. 
  * @note: It is illegal to cancel callbacks from within ccd callbacks.
  */
-static void call_cblist_remove(ccd_cblist *l, int condnum)
+static void call_cblist_remove(ccd_cblist & l, int condnum)
 {
-  int len = l->len;
+  // save the length in case callbacks are added during execution
+  const size_t len = l.elems.size();
+
   /* reentrant */
-  if (len == 0 || l->flag) return;
-  l->flag = true;
-  for (int i = 0, idx = l->first; i < len; i++) {
-    int old = CmiSwitchToPE(l->elems[idx].cb.pe);
-    (*(l->elems[idx].cb.fn))(l->elems[idx].cb.arg);
+  if (len == 0 || l.flag)
+    return;
+  l.flag = true;
+
+  // we must iterate this way because insertion invalidates deque iterators
+  // i < len is correct. after i==0, unsigned underflow will wrap to SIZE_MAX
+  for (size_t i = len-1; i < len; --i)
+  {
+    const ccd_cond_callback & cb = l.elems[i];
+    int old = CmiSwitchToPE(cb.pe);
+    (*(cb.fn))(cb.arg);
     int unused = CmiSwitchToPE(old);
-    idx = l->elems[idx].next;
   }
-  remove_n_elems(l,condnum,len);
-  l->flag = false;
+
+  remove_n_elems(l, condnum, len);
+  l.flag = false;
 }
 
 
@@ -226,10 +168,10 @@ static void call_cblist_remove(ccd_cblist *l, int condnum)
 /**
  * Lists of conditional callbacks that are maintained by the scheduler
  */
-typedef struct {
+struct ccd_cond_callbacks {
   ccd_cblist condcb[MAXNUMCONDS];
   ccd_cblist condcb_keep[MAXNUMCONDS];
-} ccd_cond_callbacks;
+};
 
 /***/
 CpvStaticDeclare(ccd_cond_callbacks, conds);   
@@ -238,15 +180,17 @@ CpvStaticDeclare(ccd_cond_callbacks, conds);
 // Default resolution of .005 seconds aka 5 milliseconds
 #define CCD_DEFAULT_RESOLUTION 5.0e-3
 
+
 /**
  * List of periodic callbacks maintained by the scheduler
  */
-typedef struct {
+struct ccd_periodic_callbacks {
 	int nSkip;/*Number of opportunities to skip*/
 	double lastCheck;/*Time of last check*/
 	double resolution;
 	double nextCall[CCD_PERIODIC_MAX];
-} ccd_periodic_callbacks;
+};
+
 
 /** */
 CpvStaticDeclare(ccd_periodic_callbacks, pcb);
@@ -254,27 +198,28 @@ CpvDeclare(int, _ccd_numchecks);
 
 
 
-#define MAXTIMERHEAPENTRIES       128
-
 /**
- * Structure used to manage callbacks in a heap
+ * Structure used to manage periodic callbacks in a heap
  */
-typedef struct {
-    double time;
-    ccd_periodic_callback cb;
-} ccd_heap_elem;
+struct ccd_heap_elem {
+  double time;
+  ccd_periodic_callback cb;
+
+  ccd_heap_elem(double t, CcdVoidFn fn, void *arg, int pe)
+    : time{t}, cb{fn, arg, pe}
+  { }
+
+  bool operator>(const ccd_heap_elem & rhs) const
+  {
+    return this->time > rhs.time;
+  }
+};
 
 
-/* Note : The heap is only stored in elements ccd_heap[0] to 
- * ccd_heap[_ccd_heaplen]
- */
 
-/** An array of time-scheduled callbacks managed as a heap */
-CpvStaticDeclare(ccd_heap_elem*, ccd_heap); 
-/** The length of the callback heap */
-CpvDeclare(int, _ccd_heaplen);
-/** The max allowed length of the callback heap */
-CpvStaticDeclare(int, ccd_heapmaxlen);
+/** periodic callbacks */
+using ccd_heap_type = std::priority_queue<ccd_heap_elem, std::vector<ccd_heap_elem>, std::greater<ccd_heap_elem>>;
+CpvStaticDeclare(ccd_heap_type, ccd_heap);
 
 
 /**
@@ -282,115 +227,17 @@ CpvStaticDeclare(int, ccd_heapmaxlen);
  * if it needs to call CcdCallBacks or not.
  */
 int CcdNumTimerCBs(void) {
-  return (CpvAccess(_ccd_heaplen) + CpvAccess(_ccd_num_timed_cond_cbs));
+  return (CpvAccess(ccd_heap).size() + CpvAccess(_ccd_num_timed_cond_cbs));
 }
-
-
-/** Swap two elements on the heap */
-static void ccd_heap_swap(int index1, int index2)
-{
-  ccd_heap_elem *h = CpvAccess(ccd_heap);
-  ccd_heap_elem temp;
-  
-  temp = h[index1];
-  h[index1] = h[index2];
-  h[index2] = temp;
-}
-
-
-
-/**
- * Expand the ccd_heap to make more room.
- *
- * Double the heap size and copy everything over. Initial 128 is reasonably 
- * big, so expanding won't happen often.
- *
- * Had a bug previously due to late expansion, should work now - Gengbin 12/4/03
-*/
-static void expand_ccd_heap(void)
-{
-  int i;
-  int oldlen = CpvAccess(ccd_heapmaxlen);
-  int newlen = oldlen*2;
-  ccd_heap_elem *newheap;
-
-  CmiPrintf("[%d] Warning: ccd_heap expand from %d to %d\n", CmiMyPe(),oldlen, newlen);
-
-  newheap = (ccd_heap_elem*) malloc(sizeof(ccd_heap_elem)*2*(newlen+1));
-  _MEMCHECK(newheap);
-  /* need to copy the second half part ??? */
-  for (i=0; i<=oldlen; i++) {
-    newheap[i] = CpvAccess(ccd_heap)[i];
-    newheap[i+newlen] = CpvAccess(ccd_heap)[i+oldlen];
-  }
-  free(CpvAccess(ccd_heap));
-  CpvAccess(ccd_heap) = newheap;
-  CpvAccess(ccd_heapmaxlen) = newlen;
-}
-
 
 
 /**
  * Insert a new callback into the heap
  */
-static void ccd_heap_insert(double t, CcdVoidFn fnp, void *arg, int pe)
+static inline void ccd_heap_insert(double t, CcdVoidFn fnp, void *arg, int pe)
 {
-  int child, parent;
-  ccd_heap_elem *h;
-  
-  if(CpvAccess(_ccd_heaplen) >= CpvAccess(ccd_heapmaxlen)) {
-/* CmiAbort("Heap overflow (InsertInHeap), exiting...\n"); */
-    expand_ccd_heap();
-  } 
-
-  h = CpvAccess(ccd_heap);
-
-  {
-    ccd_heap_elem *e = &(h[++CpvAccess(_ccd_heaplen)]);
-    e->time = t;
-    e->cb.fn = fnp;
-    e->cb.arg = arg;
-    e->cb.pe = pe;
-    child  = CpvAccess(_ccd_heaplen);
-    parent = child / 2;
-    while((parent>0) && (h[child].time<h[parent].time)) {
-	    ccd_heap_swap(child, parent);
-	    child  = parent;
-	    parent = parent / 2;
-    }
-  }
-}
-
-
-
-/**
- * Remove the top of the heap
- */
-static void ccd_heap_remove(void)
-{
-  int parent,child;
-  ccd_heap_elem *h = CpvAccess(ccd_heap);
-  
-  parent = 1;
-  if(CpvAccess(_ccd_heaplen)>0) {
-    /* put deleted value at end of heap */
-    ccd_heap_swap(1,CpvAccess(_ccd_heaplen));
-    CpvAccess(_ccd_heaplen)--;
-    if(CpvAccess(_ccd_heaplen)) {
-      /* if any left, then bubble up values */
-	    child = 2 * parent;
-	    while(child <= CpvAccess(_ccd_heaplen)) {
-	      if(((child + 1) <= CpvAccess(_ccd_heaplen))  &&
-		       (h[child].time > h[child+1].time))
-                child++; /* use the smaller of the two */
-	      if(h[parent].time <= h[child].time) 
-		      break;
-	      ccd_heap_swap(parent,child);
-	      parent  = child;      /* go down the tree one more step */
-	      child  = 2 * child;
-      }
-    }
-  } 
+  auto & h = CpvAccess(ccd_heap);
+  h.emplace(t, fnp, arg, pe);
 }
 
 
@@ -401,26 +248,32 @@ static void ccd_heap_remove(void)
  */
 static void ccd_heap_update(double curWallTime)
 {
-  ccd_heap_elem *h = CpvAccess(ccd_heap);
-  ccd_heap_elem *e = h+CpvAccess(ccd_heapmaxlen);
-  int i,ne=0;
+  auto & h = CpvAccess(ccd_heap);
+
+  std::vector<ccd_periodic_callback> expired;
+
   /* Pull out all expired heap entries */
-  while ((CpvAccess(_ccd_heaplen)>0) && (h[1].time<curWallTime)) {
-    e[ne++]=h[1];
-    ccd_heap_remove();
+  while (!h.empty())
+  {
+    const ccd_heap_elem & e = h.top();
+
+    if (e.time >= curWallTime)
+      break;
+
+    expired.emplace_back(std::move(e.cb));
+
+    h.pop();
   }
+
   /* Now execute those heap entries.  This must be
      separated from the removal phase because executing
      an entry may change the heap. 
   */
-  for (i=0;i<ne;i++) {
-/*
-      ccd_heap_elem *h = CpvAccess(ccd_heap);
-      ccd_heap_elem *e = h+CpvAccess(ccd_heapmaxlen);
-*/
-      int old = CmiSwitchToPE(e[i].cb.pe);
-      (*(e[i].cb.fn))(e[i].cb.arg,curWallTime);
-      int unused = CmiSwitchToPE(old);
+  for (const ccd_periodic_callback & cb : expired)
+  {
+    int old = CmiSwitchToPE(cb.pe);
+    (*(cb.fn))(cb.arg, curWallTime);
+    int unused = CmiSwitchToPE(old);
   }
 }
 
@@ -433,35 +286,22 @@ CLINKAGE void CcdCallBacksReset(void *ignored);
  */
 void CcdModuleInit(char **ignored)
 {
-   int i;
-   double curTime;
-   CpvInitialize(ccd_heap_elem*, ccd_heap);
+   CpvInitialize(ccd_heap_type, ccd_heap);
    CpvInitialize(ccd_cond_callbacks, conds);
    CpvInitialize(ccd_periodic_callbacks, pcb);
-   CpvInitialize(int, _ccd_heaplen);
-   CpvInitialize(int, _ccd_num_timed_cond_cbs);
-   CpvInitialize(int, ccd_heapmaxlen);
    CpvInitialize(int, _ccd_numchecks);
+   CpvInitialize(int, _ccd_num_timed_cond_cbs);
 
-   CpvAccess(_ccd_heaplen) = 0;
-   CpvAccess(_ccd_num_timed_cond_cbs) = 0;
-   CpvAccess(ccd_heapmaxlen) = MAXTIMERHEAPENTRIES;
-   CpvAccess(ccd_heap) = 
-     (ccd_heap_elem*) malloc(sizeof(ccd_heap_elem)*2*(MAXTIMERHEAPENTRIES + 1));
-   _MEMCHECK(CpvAccess(ccd_heap));
-   for(i=0;i<MAXNUMCONDS;i++) {
-     init_cblist(&(CpvAccess(conds).condcb[i]), CBLIST_INIT_LEN);
-     init_cblist(&(CpvAccess(conds).condcb_keep[i]), CBLIST_INIT_LEN);
-   }
    CpvAccess(_ccd_numchecks) = 1;
+   CpvAccess(_ccd_num_timed_cond_cbs) = 0;
    CpvAccess(pcb).nSkip = 1;
-   curTime=CmiWallTimer();
+   double curTime = CmiWallTimer();
    CpvAccess(pcb).lastCheck = curTime;
-   for (i=0;i<CCD_PERIODIC_MAX;i++)
-	   CpvAccess(pcb).nextCall[i]=curTime+periodicCallInterval[i];
+   for (int i=0; i<CCD_PERIODIC_MAX; i++)
+	   CpvAccess(pcb).nextCall[i] = curTime + periodicCallInterval[i];
    CpvAccess(pcb).resolution = CCD_DEFAULT_RESOLUTION;
-   CcdCallOnConditionKeep(CcdPROCESSOR_BEGIN_IDLE,CcdCallBacksReset,0);
-   CcdCallOnConditionKeep(CcdPROCESSOR_END_IDLE,CcdCallBacksReset,0);
+   CcdCallOnConditionKeep(CcdPROCESSOR_BEGIN_IDLE, CcdCallBacksReset, 0);
+   CcdCallOnConditionKeep(CcdPROCESSOR_END_IDLE, CcdCallBacksReset, 0);
 
 #if CMK_ERROR_CHECKING
    CpvInitialize(double, idleBeginWalltime); //used for LONG_IDLE
@@ -477,7 +317,7 @@ void CcdModuleInit(char **ignored)
 int CcdCallOnCondition(int condnum, CcdCondFn fnp, void *arg)
 {
   CmiAssert(condnum < MAXNUMCONDS);
-  return append_elem(&(CpvAccess(conds).condcb[condnum]), condnum, fnp, arg, CcdIGNOREPE);
+  return append_elem(CpvAccess(conds).condcb[condnum], condnum, fnp, arg, CcdIGNOREPE);
 } 
 
 /** 
@@ -487,7 +327,7 @@ int CcdCallOnCondition(int condnum, CcdCondFn fnp, void *arg)
 int CcdCallOnConditionOnPE(int condnum, CcdCondFn fnp, void *arg, int pe)
 {
   CmiAssert(condnum < MAXNUMCONDS);
-  return append_elem(&(CpvAccess(conds).condcb[condnum]), condnum, fnp, arg, pe);
+  return append_elem(CpvAccess(conds).condcb[condnum], condnum, fnp, arg, pe);
 } 
 
 /**
@@ -497,7 +337,7 @@ int CcdCallOnConditionOnPE(int condnum, CcdCondFn fnp, void *arg, int pe)
 int CcdCallOnConditionKeep(int condnum, CcdCondFn fnp, void *arg)
 {
   CmiAssert(condnum < MAXNUMCONDS);
-  return append_elem(&(CpvAccess(conds).condcb_keep[condnum]), condnum, fnp, arg, CcdIGNOREPE);
+  return append_elem(CpvAccess(conds).condcb_keep[condnum], condnum, fnp, arg, CcdIGNOREPE);
 } 
 
 /**
@@ -507,7 +347,7 @@ int CcdCallOnConditionKeep(int condnum, CcdCondFn fnp, void *arg)
 int CcdCallOnConditionKeepOnPE(int condnum, CcdCondFn fnp, void *arg, int pe)
 {
   CmiAssert(condnum < MAXNUMCONDS);
-  return append_elem(&(CpvAccess(conds).condcb_keep[condnum]), condnum, fnp, arg, pe);
+  return append_elem(CpvAccess(conds).condcb_keep[condnum], condnum, fnp, arg, pe);
 } 
 
 
@@ -517,7 +357,7 @@ int CcdCallOnConditionKeepOnPE(int condnum, CcdCondFn fnp, void *arg, int pe)
 void CcdCancelCallOnCondition(int condnum, int idx)
 {
   CmiAssert(condnum < MAXNUMCONDS);
-  remove_elem(&(CpvAccess(conds).condcb[condnum]), condnum, idx);
+  remove_elem(CpvAccess(conds).condcb[condnum], condnum, idx);
 }
 
 
@@ -527,7 +367,7 @@ void CcdCancelCallOnCondition(int condnum, int idx)
 void CcdCancelCallOnConditionKeep(int condnum, int idx)
 {
   CmiAssert(condnum < MAXNUMCONDS);
-  remove_elem(&(CpvAccess(conds).condcb_keep[condnum]), condnum, idx);
+  remove_elem(CpvAccess(conds).condcb_keep[condnum], condnum, idx);
 }
 
 
@@ -559,8 +399,8 @@ void CcdCallFnAfter(CcdVoidFn fnp, void *arg, double deltaT)
 void CcdRaiseCondition(int condnum)
 {
   CmiAssert(condnum < MAXNUMCONDS);
-  call_cblist_remove(&CpvAccess(conds).condcb[condnum],condnum);
-  call_cblist_keep(&CpvAccess(conds).condcb_keep[condnum]);
+  call_cblist_remove(CpvAccess(conds).condcb[condnum], condnum);
+  call_cblist_keep(CpvAccess(conds).condcb_keep[condnum]);
 }
 
 

--- a/src/conv-core/conv-conds.C
+++ b/src/conv-core/conv-conds.C
@@ -250,9 +250,7 @@ static void ccd_heap_update(double curWallTime)
 {
   auto & h = CpvAccess(ccd_heap);
 
-  std::vector<ccd_periodic_callback> expired;
-
-  /* Pull out all expired heap entries */
+  // Execute all expired heap entries
   while (!h.empty())
   {
     const ccd_heap_elem & e = h.top();
@@ -260,17 +258,10 @@ static void ccd_heap_update(double curWallTime)
     if (e.time >= curWallTime)
       break;
 
-    expired.emplace_back(std::move(e.cb));
+    const ccd_periodic_callback cb = std::move(e.cb);
 
     h.pop();
-  }
 
-  /* Now execute those heap entries.  This must be
-     separated from the removal phase because executing
-     an entry may change the heap. 
-  */
-  for (const ccd_periodic_callback & cb : expired)
-  {
     int old = CmiSwitchToPE(cb.pe);
     (*(cb.fn))(cb.arg, curWallTime);
     int unused = CmiSwitchToPE(old);

--- a/src/conv-core/conv-conds.C
+++ b/src/conv-core/conv-conds.C
@@ -538,7 +538,7 @@ void CcdCancelCallOnConditionKeep(int condnum, int idx)
 void CcdCallFnAfterOnPE(CcdVoidFn fnp, void *arg, double deltaT, int pe)
 {
     double ctime  = CmiWallTimer();
-    double tcall = ctime + deltaT/1000.0;
+    double tcall = ctime + deltaT * (1.0/1000.0);
     ccd_heap_insert(tcall, fnp, arg, pe);
 } 
 

--- a/src/conv-core/converse.h
+++ b/src/conv-core/converse.h
@@ -1103,8 +1103,6 @@ extern void  CcdCallBacks(void);
 #else
 extern int CcdNumTimerCBs(void);
 CpvExtern(int, _ccd_numchecks);
-CpvExtern(int, _ccd_heaplen);
-CpvExtern(int, _ccd_num_timed_cond_cbs);
 #define CsdPeriodic() \
   do{ \
     if ((CcdNumTimerCBs() > 0) && (CpvAccess(_ccd_numchecks)-- <= 0)) { \

--- a/tests/charm++/varTRAM/vartest.C
+++ b/tests/charm++/varTRAM/vartest.C
@@ -67,7 +67,8 @@ public:
   void simulate() {
     for (int j = 0;j != N-1;++j) {
       for (int k = 0;k != msgcount;++k) {
-        auto temp = rand();
+        std::vector<int> temp;
+        randvec(temp);
         thisProxy[(thisIndex+j+1)%N].ping(temp);
         result1 = std::accumulate(temp.begin(),temp.end(),result1);
       }
@@ -75,7 +76,7 @@ public:
     contribute(sizeof(int), &result1, CkReduction::sum_int, CkCallback(CkReductionTarget(main,startsum), mainProxy));
   }
 
-  void ping(std::vector<int> val) {
+  void ping(const std::vector<int>& val) {
     result2 = std::accumulate(val.begin(),val.end(),result2);
     ++iter;
     if (iter == (N-1)*msgcount) {
@@ -83,17 +84,15 @@ public:
     }
   }
 
-  std::vector<int> rand() {
+  void randvec(std::vector<int>& gener) {
     //int length=lambda/4;
     std::uniform_int_distribution<> gen1(lambda/8,3*lambda/8);
     int length = gen1(mt);
+    gener.resize(length);
     std::uniform_int_distribution<> gen2(0,373);
-    std::vector<int> gener(gen1(mt));
-    gener.reserve(gen1(mt));
     for(auto& g : gener) {
       g = gen2(mt);
     }
-    return gener;
   }
 };
 

--- a/tests/charm++/varTRAM/vartest.ci
+++ b/tests/charm++/varTRAM/vartest.ci
@@ -11,6 +11,6 @@ mainmodule vartest {
     entry engine();
     entry engine(int,int,int);
     entry void simulate();
-    entry [aggregate(bufferSize : 2048, numDimensions : 2, thresholdNumer : 1, thresholdDenom : 2, cutoffNumer : 1, cutoffDenom : 2)] void ping(std::vector<int>);
+    entry [aggregate(bufferSize : 2048, numDimensions : 2, thresholdNumer : 1, thresholdDenom : 2, cutoffNumer : 1, cutoffDenom : 2)] void ping(const std::vector<int>&);
   };
 };


### PR DESCRIPTION
*Original date: 2019-04-26 04:00:57*
*Original PR: https://charm.cs.illinois.edu/gerrit/4932*

---

Change-Id: Ie533057d1dba8db277388affce245dc8d2cb50e6