### PR TITLE
NO MERGE YET - Extend TopoManager to provide ordered list.

### DIFF
--- a/src/arch/util/machine-common-core.c
+++ b/src/arch/util/machine-common-core.c
@@ -740,6 +740,10 @@ if (  MSG_STATISTIC)
 extern void createCustomPartitions(int numparts, int *partitionSize, int *nodeMap);
 extern void setDefaultPartitionParams();
 
+int CmiGetPartitionSize(int partition) {
+  return CmiPartitionSize(partition);
+}
+
 void create_topoaware_partitions() {
   int i, j, numparts_bak;
   Partition_Type type_bak;
@@ -762,7 +766,7 @@ void create_topoaware_partitions() {
   if(_partitionInfo.scheme == 100) {
     createCustomPartitions(numparts_bak, _partitionInfo.partitionSize, _partitionInfo.nodeMap);       
   } else {
-    TopoManager_createPartitions(_partitionInfo.scheme, numparts_bak, _partitionInfo.nodeMap);
+    TopoManager_createPartitions(_partitionInfo.scheme, numparts_bak, CmiGetPartitionSize, NULL, _partitionInfo.nodeMap);
   }
   TopoManager_free();
   

--- a/src/util/partitioning_strategies.h
+++ b/src/util/partitioning_strategies.h
@@ -1,6 +1,7 @@
 #ifndef _PARTITIONING_STRATEGIES_H
 #define _PARTITIONING_STRATEGIES_H
 
+#include "TopoManager.h"
 /** \brief A function to traverse the given processors, and get a hilbert list
  */
 extern void getHilbertList(int * procList);
@@ -11,6 +12,11 @@ extern void getPlanarList(int *procList);
 
 /** \brief A function to traverse the given processors, and get a recursive bisection list
  */
-extern void getRecursiveBisectionList(int numparts, int *procList);
+extern void getRecursiveBisectionList(int numparts, 
+    TopoManager_getPartitionSize getSize, int *procList);
 
+/** \brief A function to traverse the given processors, and get a blocked list
+ */
+extern void getBlockedTraversalList(int numparts, 
+    TopoManager_getPartitionSize getSize, void *blocked_dims, int *procList);
 #endif

--- a/src/util/topomanager/TopoManager.h
+++ b/src/util/topomanager/TopoManager.h
@@ -25,6 +25,15 @@
 extern "C" {
 #endif
 
+typedef int (* TopoManager_getPartitionSize)(int partition);
+typedef enum {
+  TOPOMANAGER_LINEAR_ORDER = 0,
+  TOPOMANAGER_PLANAR_ORDER,
+  TOPOMANAGER_HILBERT_ORDER,
+  TOPOMANAGER_RECURSIVE_BISECTION,
+  TOPOMANAGER_BLOCK_ORDER
+} TopoManager_ordering_scheme;
+
 /** basic initialization */
 #ifndef __TPM_STANDALONE__
 void TopoManager_init();
@@ -54,7 +63,12 @@ void TopoManager_getPeRank(int *rank, int *coords);
 void TopoManager_getHopsBetweenPeRanks(int pe1, int pe2, int *hops);
 #ifndef __TPM_STANDALONE__
 /** topoaware partition using scheme s */
-void TopoManager_createPartitions(int scheme, int numparts, int *nodeMap);
+void TopoManager_createPartitions(TopoManager_ordering_scheme scheme, 
+  int numparts, TopoManager_getPartitionSize getSize, void *opaque_data, 
+  int *nodeMap);
+void TopoManager_createPePartitions(TopoManager_ordering_scheme scheme, 
+  int numparts, TopoManager_getPartitionSize getSize, void *opaque_data, 
+  int *peMap);
 #endif
 
 #if defined(__cplusplus)


### PR DESCRIPTION
*Original date: 2017-03-21 16:00:11*
*Original PR: https://charm.cs.illinois.edu/gerrit/1179*

---

FEEDBACK REQUESTED

TopoManager_createPartitions is being extended to get an ordered list of nodes
for easy partitioning of available nodes. TopoManager_createPePartitions is
being added as a convenience function if PE list is desired, though the size
of partitions is still determined by the number of Charm++ processes/nodes.
Blockeed traversal scheme is being copied over from OpenAtom; OA will be
modified to use this API.

Change-Id: If0ae535ce6120bdeb13b2066d2d35b4798a60102