### PR TITLE
NOMERGE: Pass marshalled entry method parameters by rvalue reference

### DIFF
--- a/examples/charm++/PUP/SimplePUP.h
+++ b/examples/charm++/PUP/SimplePUP.h
@@ -37,7 +37,7 @@ class SimpleArray : public CBase_SimpleArray {
 
   ~SimpleArray(){}
 
-  void acceptData(SimpleObject &inData){
+  void acceptData(SimpleObject &&inData){
 
     //do something to the object
     localCopy=inData;

--- a/src/arch/mpi-darwin-x86_64/conv-mach.sh
+++ b/src/arch/mpi-darwin-x86_64/conv-mach.sh
@@ -37,8 +37,8 @@ CMK_RANLIB="ranlib"
 
 CMK_NATIVE_CC="clang $CMK_GCC64 "
 CMK_NATIVE_LD="clang -Wl,-no_pie $CMK_GCC64 "
-CMK_NATIVE_CXX="clang++ $CMK_GCC64 "
-CMK_NATIVE_LDXX="clang++ -Wl,-no_pie $CMK_GCC64 "
+CMK_NATIVE_CXX="clang++ $CMK_GCC64 -stdlib=libc++ "
+CMK_NATIVE_LDXX="clang++ -Wl,-no_pie $CMK_GCC64 -stdlib=libc++ "
 CMK_NATIVE_LIBS=""
 
 CMK_CF90=`which f95 2>/dev/null`
@@ -56,11 +56,11 @@ else
 fi
 
 # setting for shared lib
-# need -lstdc++ for c++ reference, and it needs to be put at very last 
+# need -lc++ for c++ reference, and it needs to be put at very last 
 # of command line.
 # Mac environment variable
 test -z "$MACOSX_DEPLOYMENT_TARGET" && export MACOSX_DEPLOYMENT_TARGET=10.5
 CMK_SHARED_SUF="dylib"
 CMK_LD_SHARED=" -dynamic -dynamiclib -undefined dynamic_lookup "
-CMK_LD_SHARED_LIBS="-lstdc++"
+CMK_LD_SHARED_LIBS="-lc++"
 CMK_LD_SHARED_ABSOLUTE_PATH=true

--- a/src/arch/multicore-darwin-x86_64/conv-mach.sh
+++ b/src/arch/multicore-darwin-x86_64/conv-mach.sh
@@ -6,9 +6,9 @@ CMK_CPP_CHARM="/usr/bin/cpp -P "
 CMK_CPP_C="clang -arch x86_64 -m64 -fPIC -E -mmacosx-version-min=10.7 "
 CMK_CC="clang -arch x86_64 -m64 -dynamic -fno-common -mmacosx-version-min=10.7 $CMK_DEFS "
 CMK_LD="clang -mmacosx-version-min=10.7 -Wl,-no_pie "
-CMK_CXX="clang++ -arch x86_64 -m64 -fPIC -dynamic -fno-common -mmacosx-version-min=10.7 $CMK_DEFS "
-CMK_CXXPP="clang++ -arch x86_64 -m64 -x clang++ -E -mmacosx-version-min=10.7 "
-CMK_LDXX="$CMK_CXX -multiply_defined suppress -mmacosx-version-min=10.7 -Wl,-no_pie $CMK_DEFS "
+CMK_CXX="clang++ -arch x86_64 -m64 -fPIC -dynamic -fno-common -mmacosx-version-min=10.7 $CMK_DEFS -stdlib=libc++ "
+CMK_CXXPP="clang++ -arch x86_64 -m64 -x clang++ -E -mmacosx-version-min=10.7 -stdlib=libc++ "
+CMK_LDXX="$CMK_CXX -multiply_defined suppress -mmacosx-version-min=10.7 -Wl,-no_pie $CMK_DEFS -stdlib=libc++ "
 CMK_XIOPTS=""
 CMK_QT="generic64-light"
 CMK_LIBS="-lckqt"
@@ -19,11 +19,11 @@ CMK_CF77="g77 -mmacosx-version-min=10.7"
 CMK_CF90="g90 -mmacosx-version-min=10.7"
 
 # setting for shared lib
-# need -lstdc++ for c++ reference, and it needs to be put at very last
+# need -lc++ for c++ reference, and it needs to be put at very last
 # of command line.
 # Mac environment variable
 test -z "$MACOSX_DEPLOYMENT_TARGET" && export MACOSX_DEPLOYMENT_TARGET=10.5
 CMK_SHARED_SUF="dylib"
 CMK_LD_SHARED=" -dynamic -dynamiclib -undefined dynamic_lookup "
-CMK_LD_SHARED_LIBS="-lstdc++"
+CMK_LD_SHARED_LIBS="-lc++"
 CMK_LD_SHARED_ABSOLUTE_PATH=true

--- a/src/arch/net-darwin-x86_64/conv-mach.sh
+++ b/src/arch/net-darwin-x86_64/conv-mach.sh
@@ -5,9 +5,9 @@ CMK_CPP_CHARM="/usr/bin/cpp -P"
 CMK_CPP_C="clang -m64 -fPIC -E -mmacosx-version-min=10.7 "
 CMK_CC="clang -m64 -dynamic -fno-common -mmacosx-version-min=10.7 "
 CMK_LD="clang -mmacosx-version-min=10.7 -Wl,-no_pie "
-CMK_CXX="clang++ -m64 -fPIC -dynamic -fno-common -mmacosx-version-min=10.7 "
-CMK_CXXPP="clang++ -m64 -x clang++ -E -mmacosx-version-min=10.7 "
-CMK_LDXX="clang++ -multiply_defined suppress -mmacosx-version-min=10.7 -Wl,-no_pie "
+CMK_CXX="clang++ -m64 -fPIC -dynamic -fno-common -mmacosx-version-min=10.7 -stdlib=libc++ "
+CMK_CXXPP="clang++ -m64 -x clang++ -E -mmacosx-version-min=10.7 -stdlib=libc++ "
+CMK_LDXX="clang++ -multiply_defined suppress -mmacosx-version-min=10.7 -Wl,-no_pie -stdlib=libc++ "
 CMK_XIOPTS=""
 CMK_QT="generic64-light"
 CMK_LIBS="-lckqt"
@@ -18,11 +18,11 @@ CMK_CF77="g95 -arch x86_64 -mmacosx-version-min=10.7"
 CMK_CF90="g95 -arch x86_64 -mmacosx-version-min=10.7"
 
 # setting for shared lib
-# need -lstdc++ for c++ reference, and it needs to be put at very last 
+# need -lc++ for c++ reference, and it needs to be put at very last 
 # of command line.
 # Mac environment variable
 test -z "$MACOSX_DEPLOYMENT_TARGET" && export MACOSX_DEPLOYMENT_TARGET=10.5
 CMK_SHARED_SUF="dylib"
 CMK_LD_SHARED=" -dynamic -dynamiclib -undefined dynamic_lookup "
-CMK_LD_SHARED_LIBS="-lstdc++"
+CMK_LD_SHARED_LIBS="-lc++"
 CMK_LD_SHARED_ABSOLUTE_PATH=true

--- a/src/arch/netlrts-darwin-x86_64/conv-mach.sh
+++ b/src/arch/netlrts-darwin-x86_64/conv-mach.sh
@@ -5,9 +5,9 @@ CMK_CPP_CHARM="/usr/bin/cpp -P"
 CMK_CPP_C="clang -m64 -fPIC -E -mmacosx-version-min=10.7 "
 CMK_CC="clang -m64 -dynamic -fno-common -mmacosx-version-min=10.7 "
 CMK_LD="clang -mmacosx-version-min=10.7 -Wl,-no_pie "
-CMK_CXX="clang++ -m64 -fPIC -dynamic -fno-common -mmacosx-version-min=10.7 "
-CMK_CXXPP="clang++ -m64 -x clang++ -E -mmacosx-version-min=10.7 "
-CMK_LDXX="clang++ -multiply_defined suppress -mmacosx-version-min=10.7 -Wl,-no_pie "
+CMK_CXX="clang++ -m64 -fPIC -dynamic -fno-common -mmacosx-version-min=10.7 -stdlib=libc++ "
+CMK_CXXPP="clang++ -m64 -x clang++ -E -mmacosx-version-min=10.7 -stdlib=libc++ "
+CMK_LDXX="clang++ -multiply_defined suppress -mmacosx-version-min=10.7 -Wl,-no_pie -stdlib=libc++ "
 CMK_XIOPTS=""
 CMK_QT="generic64-light"
 CMK_LIBS="-lckqt"
@@ -18,11 +18,11 @@ CMK_CF77="g95 -arch x86_64 -mmacosx-version-min=10.7"
 CMK_CF90="g95 -arch x86_64 -mmacosx-version-min=10.7"
 
 # setting for shared lib
-# need -lstdc++ for c++ reference, and it needs to be put at very last 
+# need -lc++ for c++ reference, and it needs to be put at very last 
 # of command line.
 # Mac environment variable
 test -z "$MACOSX_DEPLOYMENT_TARGET" && export MACOSX_DEPLOYMENT_TARGET=10.5
 CMK_SHARED_SUF="dylib"
 CMK_LD_SHARED=" -dynamic -dynamiclib -undefined dynamic_lookup "
-CMK_LD_SHARED_LIBS="-lstdc++"
+CMK_LD_SHARED_LIBS="-lc++"
 CMK_LD_SHARED_ABSOLUTE_PATH=true

--- a/src/ck-core/charm++.h
+++ b/src/ck-core/charm++.h
@@ -3,6 +3,7 @@
 
 #include <stdlib.h>
 #include <memory.h>
+#include <utility>
 
 #include "charm.h"
 #include "middle.h"

--- a/src/ck-core/ckarray.C
+++ b/src/ck-core/ckarray.C
@@ -919,8 +919,8 @@ void _ckArrayInit(void)
   ckArrayCreationHdl = CkRegisterHandler(CkCreateArrayAsync);
 }
 
-CkArray::CkArray(CkArrayOptions &opts,
-		 CkMarshalledMessage &initMsg,
+CkArray::CkArray(CkArrayOptions &&opts,
+		 CkMarshalledMessage &&initMsg,
 		 CkNodeGroupID nodereductionID)
   : CkReductionMgr(nodereductionID),
     locMgr(CProxy_CkLocMgr::ckLocalBranch(opts.getLocationManager())),

--- a/src/ck-core/ckarray.h
+++ b/src/ck-core/ckarray.h
@@ -700,7 +700,7 @@ private:
 
 public:
 //Array Creation:
-  CkArray(CkArrayOptions &c,CkMarshalledMessage &initMsg,CkNodeGroupID nodereductionProxy);
+  CkArray(CkArrayOptions &&c,CkMarshalledMessage &&initMsg,CkNodeGroupID nodereductionProxy);
   CkArray(CkMigrateMessage *m);
   ~CkArray();
   CkGroupID &getGroupID(void) {return thisgroup;}

--- a/src/ck-core/ckcallback.C
+++ b/src/ck-core/ckcallback.C
@@ -35,7 +35,7 @@ public:
 	ckcallback_group() { /*empty*/ }
 	ckcallback_group(CkMigrateMessage *m) { /*empty*/ }
 	void registerCcsCallback(const char *name,const CkCallback &cb);
-	void call(CkCallback &c,CkMarshalledMessage &msg) {
+	void call(CkCallback &&c,CkMarshalledMessage &&msg) {
 		c.send(msg.getMessage());
 	}
 };

--- a/src/ck-core/ckcheckpoint.C
+++ b/src/ck-core/ckcheckpoint.C
@@ -142,13 +142,13 @@ private:
 public:
 	CkCheckpointMgr() { }
 	CkCheckpointMgr(CkMigrateMessage *m):CBase_CkCheckpointMgr(m) { }
-	void Checkpoint(const char *dirname,CkCallback& cb, bool requestStatus = false);
+	void Checkpoint(const char *dirname,CkCallback&& cb, bool requestStatus = false);
 	void SendRestartCB(CkReductionMsg *m);
 	void pup(PUP::er& p){ p|restartCB; }
 };
 
 // broadcast
-void CkCheckpointMgr::Checkpoint(const char *dirname, CkCallback& cb, bool _requestStatus){
+void CkCheckpointMgr::Checkpoint(const char *dirname, CkCallback&& cb, bool _requestStatus){
 	chkptStartTimer = CmiWallTimer();
 	requestStatus = _requestStatus;
 	// make dir on all PEs in case it is a local directory

--- a/src/ck-core/ckmemcheckpoint.C
+++ b/src/ck-core/ckmemcheckpoint.C
@@ -504,7 +504,7 @@ void CkMemCheckPT::recoverEntry(CkArrayCheckPTMessage *msg)
 
 // loop through my checkpoint table and ask checkpointed array elements
 // to send me checkpoint data.
-void CkMemCheckPT::doItNow(int starter, CkCallback &cb)
+void CkMemCheckPT::doItNow(int starter, CkCallback &&cb)
 {
   checkpointed = 1;
   cpCallback = cb;
@@ -1206,7 +1206,7 @@ void CkMemCheckPT::finishUp()
 }
 
 // called only on 0
-void CkMemCheckPT::quiescence(CkCallback &cb)
+void CkMemCheckPT::quiescence(CkCallback &&cb)
 {
   static int pe_count = 0;
   pe_count ++;

--- a/src/ck-core/ckmemcheckpoint.h
+++ b/src/ck-core/ckmemcheckpoint.h
@@ -145,7 +145,7 @@ public:
   virtual ~CkMemCheckPT();
   void pup(PUP::er& p);
   inline int BuddyPE(int pe);
-  void doItNow(int sp, CkCallback &);
+  void doItNow(int sp, CkCallback &&);
   void restart(int diePe);
   void removeArrayElements();
   void createEntry(CkArrayID aid, CkGroupID loc, CkArrayIndex index, int buddy);
@@ -158,7 +158,7 @@ public:
   void recoverBuddies();
   void recoverEntry(CkArrayCheckPTMessage *msg);
   void recoverArrayElements();
-  void quiescence(CkCallback &);
+  void quiescence(CkCallback &&);
   void resetReductionMgr();
   void finishUp();
   void gotReply();

--- a/src/ck-ldb/CentralLB.C
+++ b/src/ck-ldb/CentralLB.C
@@ -542,7 +542,7 @@ void CentralLB::depositData(CLBStatsMsg *m)
   delete m;
 }
 
-void CentralLB::ReceiveStats(CkMarshalledCLBStatsMessage &msg)
+void CentralLB::ReceiveStats(CkMarshalledCLBStatsMessage &&msg)
 {
 #if CMK_LBDB_ON
   if (statsMsgsList == NULL) {
@@ -629,7 +629,7 @@ void CentralLB::ReceiveStats(CkMarshalledCLBStatsMessage &msg)
 }
 
 /** added by Abhinav for receiving msgs via spanning tree */
-void CentralLB::ReceiveStatsViaTree(CkMarshalledCLBStatsMessage &msg)
+void CentralLB::ReceiveStatsViaTree(CkMarshalledCLBStatsMessage &&msg)
 {
 #if CMK_LBDB_ON
 	CmiAssert(CkMyPe() != 0);

--- a/src/ck-ldb/CentralLB.h
+++ b/src/ck-ldb/CentralLB.h
@@ -97,8 +97,8 @@ public:
                             // making projections output look funny
   void SendStats();
   void ReceiveCounts(CkReductionMsg *);
-  void ReceiveStats(CkMarshalledCLBStatsMessage &msg);	// Receive stats on PE 0
-  void ReceiveStatsViaTree(CkMarshalledCLBStatsMessage &msg); // Receive stats using a tree structure  
+  void ReceiveStats(CkMarshalledCLBStatsMessage &&msg);	// Receive stats on PE 0
+  void ReceiveStatsViaTree(CkMarshalledCLBStatsMessage &&msg); // Receive stats using a tree structure
   
   void depositData(CLBStatsMsg *m);
   void LoadBalance(void); 

--- a/src/ck-ldb/HybridBaseLB.C
+++ b/src/ck-ldb/HybridBaseLB.C
@@ -225,7 +225,7 @@ CLBStatsMsg* HybridBaseLB::AssembleStats()
 #endif
 }
 
-void HybridBaseLB::ReceiveStats(CkMarshalledCLBStatsMessage &data, int fromlevel)
+void HybridBaseLB::ReceiveStats(CkMarshalledCLBStatsMessage &&data, int fromlevel)
 {
 #if CMK_LBDB_ON
   FindNeighbors();
@@ -733,7 +733,7 @@ void HybridBaseLB::CreateMigrationOutObjs(int atlevel, LDStats* stats,
 }
 
 // objects arrives with only objdata
-void HybridBaseLB::ObjsMigrated(CkVec<LDObjData>& datas, int m,
+void HybridBaseLB::ObjsMigrated(CkVec<LDObjData>&& datas, int m,
     LDCommData *cdata, int n, int atlevel)
 {
   int i;

--- a/src/ck-ldb/HybridBaseLB.h
+++ b/src/ck-ldb/HybridBaseLB.h
@@ -303,7 +303,7 @@ public:
   void AtSync(void); // Everything is at the PE barrier
   void ProcessAtSync(void);
 
-  void ReceiveStats(CkMarshalledCLBStatsMessage &m, int fromlevel); 
+  void ReceiveStats(CkMarshalledCLBStatsMessage &&m, int fromlevel);
   void ResumeClients(CkReductionMsg *msg);
   void ResumeClients(int balancing);
   void ReceiveMigration(LBMigrateMsg *); 	// Receive migration data
@@ -318,7 +318,7 @@ public:
   void Migrated(LDObjHandle h, int waitBarrier);
 
   void ObjMigrated(LDObjData data, LDCommData *cdata, int n, int level);
-  void ObjsMigrated(CkVec<LDObjData>& data, int m, LDCommData *cdata, int n, int level);
+  void ObjsMigrated(CkVec<LDObjData>&& data, int m, LDCommData *cdata, int n, int level);
   void VectorDone(int atlevel);
   void MigrationDone(int balancing);  // Call when migration is complete
   void StatsDone(int level);  // Call when LDStats migration is complete

--- a/src/ck-ldb/NborBaseLB.C
+++ b/src/ck-ldb/NborBaseLB.C
@@ -232,7 +232,7 @@ void NborBaseLB::Migrated(LDObjHandle h, int waitBarrier)
   }
 }
 
-void NborBaseLB::ReceiveStats(CkMarshalledNLBStatsMessage &data)
+void NborBaseLB::ReceiveStats(CkMarshalledNLBStatsMessage &&data)
 {
 #if CMK_LBDB_ON
   NLBStatsMsg *m = data.getMessage();

--- a/src/ck-ldb/NborBaseLB.h
+++ b/src/ck-ldb/NborBaseLB.h
@@ -31,7 +31,7 @@ public:
   static void staticAtSync(void*);
   void AtSync(void); // Everything is at the PE barrier
 
-  void ReceiveStats(CkMarshalledNLBStatsMessage &m); 		// Receive stats on PE 0
+  void ReceiveStats(CkMarshalledNLBStatsMessage &&m); 		// Receive stats on PE 0
   void ResumeClients(CkReductionMsg *msg);
   void ResumeClients(int balancing);
   void ReceiveMigration(LBMigrateMsg *); 	// Receive migration data

--- a/src/libs/ck-libs/cache/CkCache.h
+++ b/src/libs/ck-libs/cache/CkCache.h
@@ -304,7 +304,7 @@ class CkCacheManager : public CBase_CkCacheManager<CkCacheKey> {
       finished their computation */
 
   /** Collect the statistics for the latest iteration */
-  void collectStatistics(CkCallback& cb);
+  void collectStatistics(CkCallback&& cb);
   std::map<CkCacheKey,CkCacheEntry<CkCacheKey>*> *getCache();
 
 };
@@ -626,7 +626,7 @@ inline void CkCacheManager<CkCacheKey>::recvData(CkCacheKey key, void *data, CkC
   }
   
   template<class CkCacheKey>
-  void CkCacheManager<CkCacheKey>::collectStatistics(CkCallback &cb) {
+  void CkCacheManager<CkCacheKey>::collectStatistics(CkCallback &&cb) {
 #if COSMO_STATS > 0
     CkCacheStatistics cs(dataArrived, dataTotalArrived,
         dataMisses, dataLocal, dataError, totalDataRequested,

--- a/src/libs/ck-libs/multicast/ckmulticast.C
+++ b/src/libs/ck-libs/multicast/ckmulticast.C
@@ -824,7 +824,7 @@ void CkMulticastMgr::sendToSection(CkDelegateData *pd,int ep,void *m, CkSectionI
 #endif
 }
 
-void CkMulticastMgr::recvPacket(CkSectionInfo &_cookie, int offset, int n, char *data, int seqno, int count, int totalsize, int fromBuffer)
+void CkMulticastMgr::recvPacket(CkSectionInfo &&_cookie, int offset, int n, char *data, int seqno, int count, int totalsize, int fromBuffer)
 {
   int i;
   mCastEntry *entry = (mCastEntry *)_cookie.get_val();

--- a/src/libs/ck-libs/multicast/ckmulticast.h
+++ b/src/libs/ck-libs/multicast/ckmulticast.h
@@ -82,7 +82,7 @@ class CkMulticastMgr: public CkDelegateMgr
         /// entry
         void sendToLocal(multicastGrpMsg *m);
         /// entry
-        void recvPacket(CkSectionInfo &_cookie, int offset, int n, char *data, int seqno, int count, int totalsize, int fromBuffer);
+        void recvPacket(CkSectionInfo &&_cookie, int offset, int n, char *data, int seqno, int count, int totalsize, int fromBuffer);
         // ------------------------- Reductions ------------------------
         /// entry Accept a redn msg from a child in the spanning tree
         void recvRedMsg(CkReductionMsg *msg);

--- a/src/xlat-i/xi-Parameter.C
+++ b/src/xlat-i/xi-Parameter.C
@@ -455,7 +455,7 @@ void ParamList::unmarshall(XStr &str, int isFirst)  //Pass-by-value
 {
     	if (isFirst && isMessage()) str<<"("<<param->type<<")impl_msg";
     	else if (!isVoid()) {
-    		str<<param->getName();
+		str << "std::move(" << param->getName() << ")";
 		if (next) {
     			str<<", ";
     			next->unmarshall(str, 0);

--- a/tests/charm++/megatest/marshall.C
+++ b/tests/charm++/megatest/marshall.C
@@ -271,9 +271,9 @@ public:
 	}
        next();
     }
-    void flatRef(flatStruct &s) {s.check(); next();}
-    void pupped(pupStruct &s) {s.check(); next();}
-    void puppedSubclass(pupStruct &s) {
+    void flatRef(flatStruct &&s) {s.check(); next();}
+    void pupped(pupStruct &&s) {s.check(); next();}
+    void puppedSubclass(pupStruct &&s) {
 	s.check(); 
 	checkChild(s.getSubclass());
 	next();
@@ -295,7 +295,7 @@ public:
         checkArr(&arr2[1],4,arr1[0]-1+n);
         next();
     }
-    void msgQ(int n,msgQ_t &q) {
+    void msgQ(int n,msgQ_t &&q) {
     	if (n!=q.length()) CkAbort("Message queue length corrupted during marshalling");
 	for (int i=0;i<n;i++)
 		checkMsg(q.deq(),5,13+2*i);


### PR DESCRIPTION
*Original date: 2016-01-15 18:07:14*
*Original PR: https://charm.cs.illinois.edu/gerrit/1004*

---

Advantages:

- This enhances efficiency when MoveConstructible types are taken by
  value in the definition of an entry method, since they will no
  longer be copied.
- It makes explicit that those objects are temporary values that
  user code can safely move from explicitly.

Disadvantages:

- Existing entry method definitions that take arguments by lvalue
  reference will now fail to compile.
- Required support for C++11 is increased.

Change-Id: I5c31c0b13caf1ccbd62a86b1844d3afedcb08748