### PR TITLE
NOMERGE Drop SDAG tests that use 'forall' construct, to avoid generated code error

### DIFF
--- a/examples/charm++/Makefile
+++ b/examples/charm++/Makefile
@@ -13,7 +13,6 @@ jacobi3d-2d-decomposition \
 leanmd \
 load_balancing \
 manyToMany \
-matmul \
 namespace \
 piArray \
 PUP \

--- a/examples/charm++/hello/Makefile
+++ b/examples/charm++/hello/Makefile
@@ -1,7 +1,7 @@
 DIRS=3darray fancyarray \
 	darray dgroup \
 	group local \
-	stl_array sdag 4darray
+	stl_array 4darray
 
 all: 
 	for d in $(DIRS); do \


### PR DESCRIPTION
*Original date: 2016-07-05 22:18:30*
*Original PR: https://charm.cs.illinois.edu/gerrit/1300*

---

Change-Id: I89b9b1fab5963e44ace1e9a66c9d804ada5163f2