### PR TITLE
Respect group construction dependence in NodeGroup constructor invocation

### DIFF
--- a/src/ck-core/ck.C
+++ b/src/ck-core/ck.C
@@ -1156,6 +1156,13 @@ void _processNodeBocInitMsg(CkCoreState *ck,envelope *env)
 {
   CkGroupID groupID = env->getGroupNum();
   int epIdx = env->getEpIdx();
+  if (!env->getGroupDep().isZero()) {      // dependence
+    CkGroupID dep = env->getGroupDep();
+    IrrGroup *obj = _lookupGroupAndBufferIfNotThere(ck,env,dep);
+    if (obj == NULL) return;
+  }
+
+  ck->process();
   CkCreateLocalNodeGroup(groupID, epIdx, env);
 }
 
@@ -1238,7 +1245,9 @@ void _processHandler(void *converseMsg,CkCoreState *ck)
       break;
     case NodeBocInitMsg :
       TELLMSGTYPE(CkPrintf("proc[%d]: _processHandler with msg type: NodeBocInitMsg\n", CkMyPe());)
-      ck->process(); if(env->isPacked()) CkUnpackMessage(&env);
+      // QD processing moved inside _processBocInitMsg because it is conditional
+      //ck->process();
+      if(env->isPacked()) CkUnpackMessage(&env);
       _processNodeBocInitMsg(ck,env);
       break;
     case ForBocMsg :


### PR DESCRIPTION
*Original date: 2017-05-18 16:48:05*
*Original PR: https://charm.cs.illinois.edu/gerrit/2538*

---

Change-Id: I7f9a1b26ed58e6ccaf1c952f491a38e6c75b8019