### PR TITLE
TRAM: Reduce default flush interval to 1ms

### DIFF
--- a/src/ck-core/ckarray.C
+++ b/src/ck-core/ckarray.C
@@ -1386,15 +1386,15 @@ void CProxy_ArrayBase::ckBroadcast(CkArrayMessage *msg, int ep, int opts) const
 	  ckDelegatedTo()->ArrayBroadcast(ckDelegatedPtr(),ep,msg,_aid);
 	else 
 	{ //Broadcast message via serializer node
+	  CProxy_CkArray ap(_aid);
 	  _TRACE_CREATION_DETAILED(UsrToEnv(msg), ep);
  	  int skipsched = opts & CK_MSG_EXPEDITED; 
 	  //int serializer=0;//1623802937%CkNumPes();
 #if (defined(_FAULT_MLOG_) || defined(_FAULT_CAUSAL_))
-                CProxy_CkArray ap(_aid);
                 ap[CpvAccess(serializer)].sendBroadcast(msg);
                 CkGroupID _id = _aid;
 //              printf("[%d] At ckBroadcast in CProxy_ArrayBase id %d epidx %d \n",CkMyPe(),_id.idx,ep);
-#else
+#elif 0
 	  if (CkMyPe()==CpvAccess(serializer))
 	  {
 		DEBB((AA "Sending array broadcast\n" AB));
@@ -1404,12 +1404,13 @@ void CProxy_ArrayBase::ckBroadcast(CkArrayMessage *msg, int ep, int opts) const
 			CProxy_CkArray(_aid).recvBroadcast(msg);
 	  } else {
 		DEBB((AA "Forwarding array broadcast to serializer node %d\n" AB,CpvAccess(serializer)));
-		CProxy_CkArray ap(_aid);
 		if (skipsched)
 			ap[CpvAccess(serializer)].sendExpeditedBroadcast(msg);
 		else
 			ap[CpvAccess(serializer)].sendBroadcast(msg);
 	  }
+#else
+	  ap.recvBroadcast(msg);
 #endif
 	}
 }

--- a/src/ck-core/cklocation.C
+++ b/src/ck-core/cklocation.C
@@ -2725,8 +2725,7 @@ void CkLocMgr::sendMsg(CkArrayMessage *msg, CkArrayID mgr, const CkArrayIndex &i
 
   checkInBounds(idx);
 
-  if (type==CkDeliver_queue)
-    _TRACE_CREATION_DETAILED(env, msg->array_ep());
+  _TRACE_CREATION_DETAILED(env, msg->array_ep());
 
   CmiUInt8 id;
   if (lookupID(idx, id)) {

--- a/src/xlat-i/xi-Entry.C
+++ b/src/xlat-i/xi-Entry.C
@@ -1006,7 +1006,7 @@ void Entry::genTramInstantiation(XStr& str) {
           << "    CProxy_" << container->tramInstances[i].type.c_str()
           << " tramProxy =\n"
           << "    CProxy_" << container->tramInstances[i].type.c_str()
-          << "::ckNew(2, dims, gId, itemsPerBuffer, false, 10.0);\n"
+          << "::ckNew(2, dims, gId, itemsPerBuffer, false, 1.0);\n"
           << "    tramProxy.enablePeriodicFlushing();\n"
           << "  }\n";
     }


### PR DESCRIPTION
*Original date: 2017-06-02 22:51:18*
*Original PR: https://charm.cs.illinois.edu/gerrit/2582*

---

Change-Id: Ie4fe17cd5c11af6b5164a8550f22a0384e92385f