### PR TITLE
AMPI: use Ssend protocol for Node-local sends to avoid intermediate copy

### DIFF
--- a/src/libs/ck-libs/ampi/ampi.C
+++ b/src/libs/ck-libs/ampi/ampi.C
@@ -846,9 +846,9 @@ void AMPI_Setup_Switch(void) {
   }
 }
 
-int AMPI_LOCAL_THRESHOLD = AMPI_LOCAL_THRESHOLD_DEFAULT;
+int AMPI_PE_LOCAL_THRESHOLD = AMPI_PE_LOCAL_THRESHOLD_DEFAULT;
+int AMPI_NODE_LOCAL_THRESHOLD = AMPI_NODE_LOCAL_THRESHOLD_DEFAULT;
 int AMPI_RDMA_THRESHOLD = AMPI_RDMA_THRESHOLD_DEFAULT;
-int AMPI_SMP_RDMA_THRESHOLD = AMPI_SMP_RDMA_THRESHOLD_DEFAULT;
 
 static bool nodeinit_has_been_called=false;
 CtvDeclare(ampiParent*, ampiPtr);
@@ -858,6 +858,7 @@ CtvDeclare(bool, ampiFinalized);
 CkpvDeclare(Builtin_kvs, bikvs);
 CkpvDeclare(int, ampiThreadLevel);
 CkpvDeclare(AmpiMsgPool, msgPool);
+CkpvDeclare(int, ssendInfoLen);
 
 CLINKAGE
 long ampiCurrentStackUsage(void){
@@ -1023,31 +1024,40 @@ static void ampiNodeInit() noexcept
 
   /* read AMPI environment variables */
   char *value;
-  if ((value = getenv("AMPI_LOCAL_THRESHOLD"))) {
-    AMPI_LOCAL_THRESHOLD = atoi(value);
-    if (CkMyNode() == 0) {
-#if AMPI_LOCAL_IMPL
-      CkPrintf("AMPI> local messaging threshold is %d Bytes.\n", AMPI_LOCAL_THRESHOLD);
-#else
-      CkPrintf("Warning: AMPI local messaging threshold ignored since local sends are disabled.\n");
-#endif
-    }
+  bool localThresholdSet = false;
+  if ((value = getenv("AMPI_PE_LOCAL_THRESHOLD"))) {
+    AMPI_PE_LOCAL_THRESHOLD = atoi(value);
+    localThresholdSet = true;
   }
-  bool rdmaSet = false;
+  if ((value = getenv("AMPI_NODE_LOCAL_THRESHOLD"))) {
+    AMPI_NODE_LOCAL_THRESHOLD = atoi(value);
+    localThresholdSet = true;
+  }
+  if (CkMyNode() == 0 && localThresholdSet) {
+#if AMPI_LOCAL_IMPL
+#if CMK_SMP
+    CkPrintf("AMPI> PE-local messaging threshold is %d Bytes and Node-local messaging threshold is %d Bytes.\n",
+             AMPI_PE_LOCAL_THRESHOLD, AMPI_NODE_LOCAL_THRESHOLD);
+#else
+    CkPrintf("AMPI> PE-local messaging threshold is %d Bytes.\n",
+             AMPI_PE_LOCAL_THRESHOLD);
+    if (AMPI_NODE_LOCAL_THRESHOLD != AMPI_NODE_LOCAL_THRESHOLD_DEFAULT) {
+      CkPrintf("Warning: AMPI Node-local messaging threshold ignored on non-SMP build.\n");
+    }
+#endif //CMK_SMP
+#else
+    CkPrintf("Warning: AMPI local messaging threshold ignored since local sends are disabled.\n");
+#endif //AMPI_LOCAL_IMPL
+  }
   if ((value = getenv("AMPI_RDMA_THRESHOLD"))) {
     AMPI_RDMA_THRESHOLD = atoi(value);
-    rdmaSet = true;
-  }
-  if ((value = getenv("AMPI_SMP_RDMA_THRESHOLD"))) {
-    AMPI_SMP_RDMA_THRESHOLD = atoi(value);
-    rdmaSet = true;
-  }
-  if (rdmaSet && CkMyNode() == 0) {
+    if (CkMyNode() == 0) {
 #if AMPI_RDMA_IMPL
-    CkPrintf("AMPI> RDMA threshold is %d Bytes and SMP RDMA threshold is %d Bytes.\n", AMPI_RDMA_THRESHOLD, AMPI_SMP_RDMA_THRESHOLD);
+      CkPrintf("AMPI> RDMA threshold is %d Bytes.\n", AMPI_RDMA_THRESHOLD);
 #else
-    CkPrintf("Warning: AMPI RDMA threshold ignored since AMPI RDMA is disabled.\n");
+      CkPrintf("Warning: AMPI RDMA threshold ignored since AMPI RDMA is disabled.\n");
 #endif
+    }
   }
 
   AmpiReducer = CkReduction::addReducer(AmpiReducerFunc, true /*streamable*/, "AmpiReducerFunc");
@@ -1087,8 +1097,13 @@ static void ampiProcInit() noexcept {
   CkpvInitialize(Builtin_kvs, bikvs); // built-in key-values
   CkpvAccess(bikvs) = Builtin_kvs();
 
-  CkpvInitialize(AmpiMsgPool, msgPool); // pool of small AmpiMsg's
-  CkpvAccess(msgPool) = AmpiMsgPool(AMPI_MSG_POOL_SIZE, AMPI_POOLED_MSG_SIZE);
+  CkpvInitialize(AmpiMsgPool, msgPool); // pool of small AmpiMsg's, big enough for rendezvous messages
+  PUP::sizer pupSizer;
+  SsendInfo srcInfo;
+  pupSizer | srcInfo;
+  CkpvInitialize(int, ssendInfoLen);
+  CkpvAccess(ssendInfoLen) = pupSizer.size();
+  CkpvAccess(msgPool) = AmpiMsgPool(AMPI_MSG_POOL_SIZE, std::max(AMPI_POOLED_MSG_SIZE, CkpvAccess(ssendInfoLen)));
 
 #if AMPIMSGLOG
   char **argv=CkGetArgv();
@@ -3029,15 +3044,18 @@ AmpiMsg *ampi::makeBcastMsg(const void *buf,int count,MPI_Datatype type,int root
   return msg;
 }
 
-// Create an empty AmpiMsg to be matched on the recv side
-AmpiMsg *ampi::makeSyncMsg(int destRank,int t,int sRank,const void *buf,int count, MPI_Datatype type,
-                           MPI_Comm destcomm,int ssendReq,CMK_REFNUM_TYPE seq) noexcept
+// Create a AmpiMsg with a SsendInfo struct as the msg payload
+AmpiMsg *ampi::makeSyncMsg(int destRank,int t,int sRank,const void *buf,int count,
+                           MPI_Datatype type,MPI_Comm destcomm,int ssendReq,CMK_REFNUM_TYPE seq) noexcept
 {
   CkAssert(ssendReq >= 0);
   CkDDT_DataType *ddt = getDDT()->getType(type);
   int len = ddt->getSize(count);
-  AmpiMsg *msg = CkpvAccess(msgPool).newAmpiMsg(seq, ssendReq, t, sRank, 0);
+  SsendInfo srcInfo(thisIndex, count, (char*)buf, ddt);
+  AmpiMsg *msg = CkpvAccess(msgPool).newAmpiMsg(seq, ssendReq, t, sRank, CkpvAccess(ssendInfoLen));
   msg->setLength(len); // set AmpiMsg's length to be that of the real msg payload
+  PUP::toMem pupPacker(msg->getData());
+  pupPacker | srcInfo;
   return msg;
 }
 
@@ -3198,7 +3216,7 @@ MPI_Request ampi::sendLocalMsg(int tag, int srcRank, const void* buf, int size, 
     }
   }
 
-  if (size >= AMPI_LOCAL_THRESHOLD ||
+  if (size >= AMPI_PE_LOCAL_THRESHOLD ||
      (sendType == BLOCKING_SSEND || sendType == I_SSEND)) {
     // Block on the matching request to avoid making an intermediate copy
     MSG_ORDER_DEBUG(
@@ -3268,18 +3286,20 @@ MPI_Request ampi::delesend(int t, int sRank, const void* buf, int count, MPI_Dat
   if (destPtr != nullptr) {
     return sendLocalMsg(t, sRank, buf, size, type, count, rank, destcomm, seq, destPtr, sendType, reqIdx);
   }
-#endif
+#if CMK_SMP
+  if (size >= AMPI_NODE_LOCAL_THRESHOLD && destLikelyWithinProcess(arrProxy, destIdx)) {
+    return sendSyncMsg(t, sRank, buf, type, count, rank, destcomm, seq, arrProxy[destIdx], sendType, reqIdx);
+  }
+#endif //CMK_SMP
+#endif //AMPI_LOCAL_IMPL
   if (sendType == BLOCKING_SSEND || sendType == I_SSEND) {
     return sendSyncMsg(t, sRank, buf, type, count, rank, destcomm, seq, arrProxy[destIdx], sendType, reqIdx);
   }
 #if AMPI_RDMA_IMPL
-  if (ddt->isContig() &&
-      (size >= AMPI_RDMA_THRESHOLD ||
-      (size >= AMPI_SMP_RDMA_THRESHOLD && destLikelyWithinProcess(arrProxy, destIdx))))
-  {
+  if (ddt->isContig() && size >= AMPI_RDMA_THRESHOLD) {
     return sendRdmaMsg(t, sRank, buf, size, type, destIdx, rank, destcomm, seq, arrProxy, reqIdx);
   }
-#endif
+#endif //AMPI_RDMA_IMPL
   arrProxy[destIdx].generic(makeAmpiMsg(rank, t, sRank, buf, count, type, destcomm, seq));
   if (reqIdx != MPI_REQUEST_NULL) { // Persistent send request
     AmpiRequestList& reqList = parent->ampiReqs;
@@ -3303,26 +3323,31 @@ void ampi::requestSsendMsg(AmpiMsg* msg) noexcept
   thisProxy[srcIdx].ssendAck(ssendReq);
 }
 
-bool ampi::processSsendMsg(AmpiMsg* msg, int* msgLen, char** msgData) noexcept {
-  int srcRank = msg->getSrcRank();
-  int srcIdx = getIndexForRank(srcRank);
+bool ampi::processSsendMsg(AmpiMsg* msg, int* msgLen, char** msgData) noexcept
+{
+  SsendInfo srcInfo;
+  PUP::fromMem p(msg->getData());
+  p | srcInfo;
 #if AMPI_LOCAL_IMPL
-  ampi* srcPtr = thisProxy[srcIdx].ckLocal();
-  if (srcPtr != NULL) {
+  if (srcInfo.getNode() == CkMyNode()) {
+    *msgData = srcInfo.getBuf();
+    *msgLen = srcInfo.getDDT()->getSize(srcInfo.getCount());
+    int srcIdx = srcInfo.getIdx();
     MPI_Request sreqIdx = msg->getSsendReq();
-    ampiParent* srcParent = srcPtr->parent;
-    AmpiRequestList& reqs = srcParent->ampiReqs;
-    AmpiRequest& sreq = *(reqs[sreqIdx]);
-    *msgData = (char*)sreq.buf;
-    *msgLen = srcParent->myDDT.getSize(sreq.type) * sreq.count;
     MSG_ORDER_DEBUG(
       CkPrintf("AMPI vp %d in processSsendMsg, src is local so completing Ssend inline (req %d)\n", parent->thisIndex, sreqIdx);
     )
-    srcPtr->completedSend(sreqIdx);
+    ampi* srcPtr = thisProxy[srcIdx].ckLocal();
+    if (srcPtr != NULL) {
+      srcPtr->completedSend(sreqIdx);
+    }
+    else {
+      thisProxy[srcIdx].completedSend(sreqIdx);
+    }
     return true;
   }
   else
-#endif
+#endif //AMPI_LOCAL_IMPL
   {
     requestSsendMsg(msg);
     return false;

--- a/src/libs/ck-libs/ampi/ampi.ci
+++ b/src/libs/ck-libs/ampi/ampi.ci
@@ -48,6 +48,7 @@ module ampi {
     entry EXPEDITED void genericSync(AmpiMsg *);
     entry EXPEDITED void generic(AmpiMsg *);
     entry EXPEDITED void genericRdma(nocopy char buf[size], int size, CMK_REFNUM_TYPE seq, int tag, int srcRank);
+    entry EXPEDITED void completedSend(int sreqIdx);
     entry EXPEDITED_NOKEEP void completedRdmaSend(CkDataMsg *msg);
     entry EXPEDITED_REDN void barrierResult(void);
     entry EXPEDITED_REDN void ibarrierResult(void);

--- a/src/libs/ck-libs/ampi/ampiOneSided.C
+++ b/src/libs/ck-libs/ampi/ampiOneSided.C
@@ -14,7 +14,6 @@
 #define WIN_ERROR   (-1)
 
 extern int AMPI_RDMA_THRESHOLD;
-extern int AMPI_SMP_RDMA_THRESHOLD;
 
 win_obj::win_obj() noexcept {
   baseAddr = NULL;
@@ -221,9 +220,7 @@ int ampi::winPut(const void *orgaddr, int orgcnt, MPI_Datatype orgtype, int rank
                             targcnt, targtype, win->index);
     }
 #if AMPI_RDMA_IMPL
-    else if (orgtotalsize >= AMPI_RDMA_THRESHOLD ||
-            (orgtotalsize >= AMPI_SMP_RDMA_THRESHOLD && destLikelyWithinProcess(thisProxy, rank)))
-    {
+    else if (orgtotalsize >= AMPI_RDMA_THRESHOLD) {
       AmpiRequestList& reqs = getReqs();
       SendReq* ampiReq = parent->reqPool.newReq<SendReq>(orgtype, myComm.getComm(), getDDT());
       MPI_Request req = reqs.insert(ampiReq);
@@ -408,9 +405,7 @@ int ampi::winAccumulate(const void *orgaddr, int orgcnt, MPI_Datatype orgtype, i
                                    targcnt, targtype, op, win->index);
     }
 #if AMPI_RDMA_IMPL
-    else if (orgtotalsize >= AMPI_RDMA_THRESHOLD ||
-            (orgtotalsize >= AMPI_SMP_RDMA_THRESHOLD && destLikelyWithinProcess(thisProxy, rank)))
-    {
+    else if (ddt->isContig() && orgtotalsize >= AMPI_RDMA_THRESHOLD) {
       AmpiRequestList& reqs = getReqs();
       SendReq* ampiReq = parent->reqPool.newReq<SendReq>(orgtype, myComm.getComm(), getDDT());
       MPI_Request req = reqs.insert(ampiReq);
@@ -473,9 +468,7 @@ int ampi::winGetAccumulate(const void *orgaddr, int orgcnt, MPI_Datatype orgtype
       return MPI_SUCCESS;
     }
 #if AMPI_RDMA_IMPL
-    else if (orgtotalsize >= AMPI_RDMA_THRESHOLD ||
-            (orgtotalsize >= AMPI_SMP_RDMA_THRESHOLD && destLikelyWithinProcess(thisProxy, rank)))
-    {
+    else if (orgtotalsize >= AMPI_RDMA_THRESHOLD) {
       AmpiRequestList& reqs = getReqs();
       SendReq* ampiReq = parent->reqPool.newReq<SendReq>(orgtype, myComm.getComm(), getDDT());
       MPI_Request req = reqs.insert(ampiReq);


### PR DESCRIPTION
*Original date: 2019-05-03 17:26:17*
*Original PR: https://charm.cs.illinois.edu/gerrit/2562*

---

In the payload of the Ssend message we serialize an SsendInfo object
that contains the sender's information, which can be used by the recv'er
if in the same logical node (process) to directly copy the real message
payload directly from the src buffer.

Also change the existing AMPI_LOCAL_THRESHOLD to AMPI_PE_LOCAL_THRESHOLD
to distinguish it from the new AMPI_NODE_LOCAL_THRESHOLD variable.

This means that all pt2pt messages with size greater than or equal to
the AMPI_NODE_LOCAL_THRESHOLD are now 'zero-copy' if in the same node.

Change-Id: Iebe9972b630fe17f4cc5c2a7ae0aa9f4b54b295b