### PR TITLE
AMPI: maintain a free list of CkNcpyBuffer objects on each PE

### DIFF
--- a/src/conv-core/converse.h
+++ b/src/conv-core/converse.h
@@ -131,6 +131,15 @@
 #  endif
 # endif
 
+// must be placed before return type and at both declaration and definition
+#if defined __GNUC__ && __GNUC__ >= 4
+# define CMI_WARN_UNUSED_RESULT __attribute__ ((warn_unused_result))
+#elif defined _MSC_VER && _MSC_VER >= 1700
+# define CMI_WARN_UNUSED_RESULT _Check_return_
+#else
+# define CMI_WARN_UNUSED_RESULT
+#endif
+
 /* Paste the tokens x and y together, without any space between them.
    The ANSI C way to do this is the bizarre ## "token-pasting" 
    preprocessor operator.

--- a/src/libs/ck-libs/ampi/ampi.C
+++ b/src/libs/ck-libs/ampi/ampi.C
@@ -846,8 +846,10 @@ void AMPI_Setup_Switch(void) {
   }
 }
 
+int AMPI_LOCAL_THRESHOLD = AMPI_LOCAL_THRESHOLD_DEFAULT;
 int AMPI_RDMA_THRESHOLD = AMPI_RDMA_THRESHOLD_DEFAULT;
 int AMPI_SMP_RDMA_THRESHOLD = AMPI_SMP_RDMA_THRESHOLD_DEFAULT;
+
 static bool nodeinit_has_been_called=false;
 CtvDeclare(ampiParent*, ampiPtr);
 CtvDeclare(bool, ampiInitDone);
@@ -935,6 +937,16 @@ static void ampiNodeInit() noexcept
 
   /* read AMPI environment variables */
   char *value;
+  if ((value = getenv("AMPI_LOCAL_THRESHOLD"))) {
+    AMPI_LOCAL_THRESHOLD = atoi(value);
+    if (CkMyNode() == 0) {
+#if AMPI_LOCAL_IMPL
+      CkPrintf("AMPI> local messaging threshold is %d Bytes.\n", AMPI_LOCAL_THRESHOLD);
+#else
+      CkPrintf("Warning: AMPI local messaging threshold ignored since local sends are disabled.\n");
+#endif
+    }
+  }
   bool rdmaSet = false;
   if ((value = getenv("AMPI_RDMA_THRESHOLD"))) {
     AMPI_RDMA_THRESHOLD = atoi(value);
@@ -2625,13 +2637,13 @@ void ampi::ssendAck(int sreqIdx) noexcept
   AmpiRequestList& reqs = getReqs();
   SsendReq& sreq = (SsendReq&)*reqs[sreqIdx];
   int destIdx = getIndexForRank(sreq.destRank);
+  CMK_REFNUM_TYPE seq = getSeqNo(sreq.destRank, sreq.comm, sreq.tag);
 
 #if AMPI_RDMA_IMPL
   CkDDT_DataType* ddt = getDDT()->getType(sreq.type);
   if (ddt->isContig()) {
     int size = ddt->getSize(sreq.count);
     if (size >= AMPI_RDMA_THRESHOLD) {
-      int seq = getSeqNo(sreq.destRank, sreq.comm, sreq.tag);
       CkCallback completedSendCB(CkIndex_ampi::completedRdmaSend(NULL), thisProxy[thisIndex], true/*inline*/);
       completedSendCB.setRefnum(sreqIdx);
       thisProxy[destIdx].genericRdma(CkSendBuffer(sreq.buf, completedSendCB), size, seq, sreq.tag, sreq.src);
@@ -2640,7 +2652,7 @@ void ampi::ssendAck(int sreqIdx) noexcept
   }
 #endif //AMPI_RDMA_IMPL
 
-  thisProxy[destIdx].generic(makeAmpiMsg(sreq.destRank, sreq.tag, sreq.src, sreq.buf, sreq.count, sreq.type, sreq.comm));
+  thisProxy[destIdx].generic(makeAmpiMsg(sreq.destRank, sreq.tag, sreq.src, sreq.buf, sreq.count, sreq.type, sreq.comm, seq));
 
   sreq.complete = true;
   handleBlockedReq(&sreq);
@@ -2653,9 +2665,9 @@ void ampi::genericSync(AmpiMsg* msg) noexcept
 {
   MSG_ORDER_DEBUG(
     CkPrintf("AMPI vp %d sync arrival: tag=%d, src=%d, comm=%d, ssendReq=%d (seq %d) resumeOnRecv %d\n",
-             thisIndex, msg->getTag(), msg->getSrcRank(), getComm(), CkGetRefNum(msg), msg->getSeq(), parent->resumeOnRecv);
+             thisIndex, msg->getTag(), msg->getSrcRank(), getComm(), msg->getSsendReq(), msg->getSeq(), parent->resumeOnRecv);
   )
-  CkAssert(CkGetRefNum(msg));
+  CkAssert(msg->isSsend());
 #if CMK_BIGSIM_CHARM
   TRACE_BG_ADD_TAG("AMPI_generic");
   msg->event = NULL;
@@ -2663,8 +2675,7 @@ void ampi::genericSync(AmpiMsg* msg) noexcept
 
   if(msg->getSeq() != 0) {
     int seqIdx = msg->getSeqIdx();
-    int n=oorder.put(seqIdx,msg);
-    if (n>0) { // This message was in-order
+    if (oorder.put(seqIdx,msg) > 0) { // This message was in-order
       inorder(msg);
       // Sync messages don't immediately get processed:
       // if in-order, the recv'er will invoke ampi::ssendAck to get the real payload back
@@ -2696,8 +2707,7 @@ void ampi::generic(AmpiMsg* msg) noexcept
   if(msg->getSeq() != 0) {
     int seqIdx = msg->getSeqIdx();
     int n=oorder.put(seqIdx,msg);
-    if (n>0) { // This message was in-order
-      inorder(msg);
+    if (n>0 && inorder(msg)) { // This message was in-order
       if (n>1) { // It enables other, previously out-of-order messages
         while((msg=oorder.getOutOfOrder(seqIdx))!=0) {
           if (!inorder(msg)) break; // Returns false if msg is a sync message
@@ -2837,7 +2847,7 @@ void ampi::genericRdma(char* buf, int size, CMK_REFNUM_TYPE seq, int tag, int sr
 
   if (seq != 0) {
     int seqIdx = srcRank;
-    int n = oorder.isInOrder(seqIdx, seq);
+    int n = oorder.putIfInOrder(seqIdx, seq);
     if (n > 0) { // This message was in-order
       inorderRdma(buf, size, seq, tag, srcRank);
       if (n > 1) { // It enables other, previously out-of-order messages
@@ -2876,24 +2886,29 @@ void ampi::inorderRdma(char* buf, int size, CMK_REFNUM_TYPE seq, int tag, int sr
   }
 }
 
-// Callback from ampi::genericRdma() signaling that the send buffer is now safe to re-use
+// Callback signaling that the send buffer is now safe to re-use
+void ampi::completedSend(MPI_Request reqIdx) noexcept
+{
+   MSG_ORDER_DEBUG(
+     CkPrintf("[%d] send completed on vp %d, reqIdx = %d\n",
+              CkMyPe(), parent->thisIndex, reqIdx);
+  )
+
+  AmpiRequestList& reqList = getReqs();
+  AmpiRequest& sreq = (*reqList[reqIdx]);
+  sreq.complete = true;
+
+  handleBlockedReq(&sreq);
+  resumeThreadIfReady();
+}
+
+// Callback signaling that the send buffer is now safe to re-use
 void ampi::completedRdmaSend(CkDataMsg *msg) noexcept
 {
   // refnum is the index into reqList for this SendReq
   int reqIdx = CkGetRefNum(msg);
-
-  MSG_ORDER_DEBUG(
-    CkPrintf("[%d] in ampi::completedRdmaSend on index %d, reqIdx = %d\n",
-             CkMyPe(), parent->thisIndex, reqIdx);
-  )
-
-  AmpiRequestList& reqList = getReqs();
-  AmpiRequest* sreq = reqList[reqIdx];
-  sreq->complete = true;
-
-  handleBlockedReq(sreq);
-  resumeThreadIfReady();
-  // CkDataMsg is allocated & freed by the runtime, so do not delete msg
+  completedSend(reqIdx);
+  // [nokeep] entry method, so do not delete msg
 }
 
 void handle_MPI_BOTTOM(void* &buf, MPI_Datatype type) noexcept
@@ -2942,9 +2957,15 @@ AmpiMsg *ampi::makeSyncMsg(int destRank,int t,int sRank,const void *buf,int coun
 AmpiMsg *ampi::makeAmpiMsg(int destRank,int t,int sRank,const void *buf,int count,
                            MPI_Datatype type,MPI_Comm destcomm) noexcept
 {
+  CMK_REFNUM_TYPE seq = getSeqNo(destRank, destcomm, t);
+  return makeAmpiMsg(destRank, t, sRank, buf, count, type, destcomm, seq);
+}
+
+AmpiMsg *ampi::makeAmpiMsg(int destRank,int t,int sRank,const void *buf,int count,
+                           MPI_Datatype type,MPI_Comm destcomm,CMK_REFNUM_TYPE seq) noexcept
+{
   CkDDT_DataType *ddt = getDDT()->getType(type);
   int len = ddt->getSize(count);
-  CMK_REFNUM_TYPE seq = getSeqNo(destRank, destcomm, t);
   AmpiMsg *msg = CkpvAccess(msgPool).newAmpiMsg(seq, MPI_REQUEST_NULL, t, sRank, len);
   ddt->serialize((char*)buf, msg->getData(), count, msg->getLength(), PACK);
   return msg;
@@ -3004,10 +3025,9 @@ CMK_REFNUM_TYPE ampi::getSeqNo(int destRank, MPI_Comm destcomm, int tag) noexcep
 }
 
 MPI_Request ampi::sendRdmaMsg(int t, int sRank, const void* buf, int size, MPI_Datatype type, int destIdx,
-                              int destRank, MPI_Comm destcomm, CProxy_ampi arrProxy, MPI_Request reqIdx) noexcept
+                              int destRank, MPI_Comm destcomm, CMK_REFNUM_TYPE seq, CProxy_ampi arrProxy,
+                              MPI_Request reqIdx) noexcept
 {
-  CMK_REFNUM_TYPE seq = getSeqNo(destRank, destcomm, t);
-
   // Set up a SendReq to track completion of the send buffer
   if (reqIdx == MPI_REQUEST_NULL) {
     reqIdx = postReq(parent->reqPool.newReq<SendReq>(type, destcomm, getDDT()));
@@ -3019,30 +3039,103 @@ MPI_Request ampi::sendRdmaMsg(int t, int sRank, const void* buf, int size, MPI_D
   return reqIdx;
 }
 
-// Call genericRdma inline on the local destination object
-MPI_Request ampi::sendLocalMsg(int t, int sRank, const void* buf, int size, MPI_Datatype type, int destRank,
-                               MPI_Comm destcomm, ampi* destPtr, AmpiSendType sendType, MPI_Request reqIdx) noexcept
+// Local version of ampi::generic but assumes msg is in-order & ireq is the matching recv req
+void ampi::localInorder(char* buf, int size, int seqIdx, CMK_REFNUM_TYPE seq, int tag,
+                        int srcRank, IReq* ireq) noexcept
 {
-  CMK_REFNUM_TYPE seq = getSeqNo(destRank, destcomm, t);
+  MSG_ORDER_DEBUG(
+    CkPrintf("[%d] in ampi::localInorder on index %d, size=%d, seq=%d, srcRank=%d, tag=%d, comm=%d\n",
+             CkMyPe(), getIndexForRank(getRank()), size, seq, srcRank, tag, getComm());
+  )
 
-  destPtr->genericRdma((char*)buf, size, seq, t, sRank);
-
-  if (sendType == BLOCKING_SEND) {
-    return MPI_REQUEST_NULL;
+  if (seq != 0) {
+    int n = oorder.putIfInOrder(seqIdx, seq);
+    CkAssert(n > 0); // This message must be in-order
+    handleBlockedReq(ireq);
+    ireq->receiveRdma(this, buf, size, srcRank);
+    if (n > 1) { // It enables other, previously out-of-order messages
+      AmpiMsg *msg = NULL;
+      while ((msg = oorder.getOutOfOrder(seqIdx)) != 0) {
+        if (!inorder(msg)) break;
+      }
+    }
+  } else { // Cross-world or system messages are unordered
+    handleBlockedReq(ireq);
+    ireq->receiveRdma(this, buf, size, srcRank);
   }
-  else if (reqIdx != MPI_REQUEST_NULL) {
+
+  resumeThreadIfReady();
+}
+
+// Call genericRdma inline on the local destination object
+MPI_Request ampi::sendLocalMsg(int tag, int srcRank, const void* buf, int size, MPI_Datatype type,
+                               int count, int destRank, MPI_Comm destComm, CMK_REFNUM_TYPE seq,
+                               ampi* destPtr, AmpiSendType sendType, MPI_Request reqIdx) noexcept
+{
+  int seqIdx = srcRank;
+
+  if (seq == 0 || destPtr->isInOrder(seqIdx, seq)) {
+    IReq* ireq = (IReq*)destPtr->postedReqs.get(tag, srcRank);
+    if (ireq != nullptr) { // Found a matching preposted request in the destination rank's queue
+      MSG_ORDER_DEBUG(
+        CkPrintf("[%d] AMPI vp %d sending local, in-order, matched msg inline to vp %d\n",
+                 CkMyPe(), parent->thisIndex, destPtr->parent->thisIndex);
+      )
+      CkDDT_DataType* sddt = getDDT()->getType(type);
+      if (sddt->isContig()) {
+        destPtr->localInorder((char*)buf, size, seqIdx, seq, tag, srcRank, ireq);
+      }
+      else {
+        vector<char> sbuf(size);
+        sddt->serialize((char*)buf, sbuf.data(), count, size, PACK); // intermediate copy for noncontig DDTs
+        destPtr->localInorder(sbuf.data(), size, seqIdx, seq, tag, srcRank, ireq);
+      }
+
+      if (reqIdx != MPI_REQUEST_NULL) { // Persistent Send request
+        AmpiRequestList& reqList = getReqs();
+        AmpiRequest& sreq = *(reqList[reqIdx]);
+        CkAssert(sreq.isPersistent());
+        sreq.complete = true;
+        return reqIdx;
+      }
+      else if (sendType == BLOCKING_SEND || sendType == BLOCKING_SSEND) {
+        return MPI_REQUEST_NULL;
+      }
+      else if (sendType == I_SEND || sendType == BLOCKING_SEND) {
+        return postReq(parent->reqPool.newReq<SendReq>(type, destComm, getDDT(), AMPI_REQ_COMPLETED));
+      }
+      else {
+        CkAssert(sendType == I_SSEND);
+        return postReq(parent->reqPool.newReq<SsendReq>(type, destComm, getDDT(), AMPI_REQ_COMPLETED));
+      }
+    }
+  }
+
+  if (size >= AMPI_LOCAL_THRESHOLD ||
+     (sendType == BLOCKING_SSEND || sendType == I_SSEND)) {
+    // Block on the matching request to avoid making an intermediate copy
+    MSG_ORDER_DEBUG(
+      CkPrintf("[%d] AMPI vp %d sending local, out-of-order/unexpected msg inline using a Sync send from to vp %d\n",
+               CkMyPe(), parent->thisIndex, destPtr->parent->thisIndex);
+    )
+    if (reqIdx == MPI_REQUEST_NULL) {
+      reqIdx = postReq(parent->reqPool.newReq<SsendReq>(buf, count, type, destRank, tag, destComm, srcRank, getDDT(),
+                                                        (sendType == BLOCKING_SSEND) ?
+                                                        AMPI_REQ_BLOCKED : AMPI_REQ_PENDING));
+    }
+    destPtr->genericSync(makeSyncMsg(destRank, tag, srcRank, buf, count, type, destComm, reqIdx, seq));
     return reqIdx;
   }
   else { // SendReq is pre-completed since we directly copied the send buffer
-    return postReq(parent->reqPool.newReq<SendReq>(type, destcomm, getDDT(), AMPI_REQ_COMPLETED));
+    destPtr->generic(makeAmpiMsg(destRank, tag, srcRank, buf, count, type, destComm, seq));
+    return MPI_REQUEST_NULL;
   }
 }
 
 MPI_Request ampi::sendSyncMsg(int t, int sRank, const void* buf, MPI_Datatype type, int count,
-                              int rank, MPI_Comm destcomm, CProxyElement_ampi destElem,
+                              int rank, MPI_Comm destcomm, CMK_REFNUM_TYPE seq, CProxyElement_ampi destElem,
                               AmpiSendType sendType, MPI_Request reqIdx) noexcept
 {
-  int seq = getSeqNo(rank, destcomm, t);
   if (reqIdx == MPI_REQUEST_NULL) {
     reqIdx = postReq(parent->reqPool.newReq<SsendReq>(buf, count, type, rank, t, destcomm, sRank, getDDT(),
                                                       (sendType == BLOCKING_SSEND) ?
@@ -3075,47 +3168,40 @@ MPI_Request ampi::delesend(int t, int sRank, const void* buf, int count, MPI_Dat
   } else {
     destIdx = dest.getIndexForRank(rank);
   }
+  CMK_REFNUM_TYPE seq = getSeqNo(rank, destcomm, t);
 
   MSG_ORDER_DEBUG(
-    CkPrintf("AMPI vp %d send: tag=%d, src=%d, comm=%d (to %d)\n",parent->thisIndex,t,sRank,destcomm,destIdx);
+    CkPrintf("AMPI vp %d send: tag=%d, src=%d, comm=%d, seq=%d (to %d)\n",parent->thisIndex,t,sRank,destcomm,seq,destIdx);
   )
 
-  if (sendType == BLOCKING_SSEND || sendType == I_SSEND) {
-    return sendSyncMsg(t, sRank, buf, type, count, rank, destcomm, arrProxy[destIdx], sendType, reqIdx);
-  }
-  ampi *destPtr = arrProxy[destIdx].ckLocal();
   CkDDT_DataType *ddt = getDDT()->getType(type);
   int size = ddt->getSize(count);
-  if (ddt->isContig()) {
 #if AMPI_LOCAL_IMPL
-    if (destPtr != NULL) {
-      return sendLocalMsg(t, sRank, buf, size, type, rank, destcomm, destPtr, sendType, reqIdx);
-    }
+  ampi *destPtr = arrProxy[destIdx].ckLocal();
+  if (destPtr != nullptr) {
+    return sendLocalMsg(t, sRank, buf, size, type, count, rank, destcomm, seq, destPtr, sendType, reqIdx);
+  }
 #endif
+  if (sendType == BLOCKING_SSEND || sendType == I_SSEND) {
+    return sendSyncMsg(t, sRank, buf, type, count, rank, destcomm, seq, arrProxy[destIdx], sendType, reqIdx);
+  }
 #if AMPI_RDMA_IMPL
-    if (size >= AMPI_RDMA_THRESHOLD ||
-       (size >= AMPI_SMP_RDMA_THRESHOLD && destLikelyWithinProcess(arrProxy, destIdx)))
-    {
-      return sendRdmaMsg(t, sRank, buf, size, type, destIdx, rank, destcomm, arrProxy, reqIdx);
-    }
-#endif
-  }
-#if AMPI_LOCAL_IMPL
-  if (destPtr != NULL) {
-    destPtr->generic(makeAmpiMsg(rank, t, sRank, buf, count, type, destcomm));
-    return MPI_REQUEST_NULL;
-  } else
-#endif
+  if (ddt->isContig() &&
+      (size >= AMPI_RDMA_THRESHOLD ||
+      (size >= AMPI_SMP_RDMA_THRESHOLD && destLikelyWithinProcess(arrProxy, destIdx))))
   {
-    arrProxy[destIdx].generic(makeAmpiMsg(rank, t, sRank, buf, count, type, destcomm));
-    if (reqIdx != MPI_REQUEST_NULL) {
-      AmpiRequestList& reqList = parent->ampiReqs;
-      AmpiRequest& sreq = (*reqList[reqIdx]);
-      sreq.complete = true;
-      return reqIdx;
-    }
-    return MPI_REQUEST_NULL;
+    return sendRdmaMsg(t, sRank, buf, size, type, destIdx, rank, destcomm, seq, arrProxy, reqIdx);
   }
+#endif
+  arrProxy[destIdx].generic(makeAmpiMsg(rank, t, sRank, buf, count, type, destcomm, seq));
+  if (reqIdx != MPI_REQUEST_NULL) { // Persistent send request
+    AmpiRequestList& reqList = parent->ampiReqs;
+    AmpiRequest& sreq = (*reqList[reqIdx]);
+    CkAssert(sreq.isPersistent());
+    sreq.complete = true;
+    return reqIdx;
+  }
+  return MPI_REQUEST_NULL;
 }
 
 // Ask the sender to send us the real message back
@@ -3130,15 +3216,45 @@ void ampi::requestSsendMsg(AmpiMsg* msg) noexcept
   thisProxy[srcIdx].ssendAck(ssendReq);
 }
 
-bool ampi::processAmpiMsg(AmpiMsg *msg, void* buf, MPI_Datatype type, int count) noexcept
-{
-  if (msg->isSsend()) { // this is a sync msg, send an ack to sender to get the real one
+bool ampi::processSsendMsg(AmpiMsg* msg, int* msgLen, char** msgData) noexcept {
+  int srcRank = msg->getSrcRank();
+  int srcIdx = getIndexForRank(srcRank);
+#if AMPI_LOCAL_IMPL
+  ampi* srcPtr = thisProxy[srcIdx].ckLocal();
+  if (srcPtr != NULL) {
+    MPI_Request sreqIdx = msg->getSsendReq();
+    ampiParent* srcParent = srcPtr->parent;
+    AmpiRequestList& reqs = srcParent->ampiReqs;
+    AmpiRequest& sreq = *(reqs[sreqIdx]);
+    *msgData = (char*)sreq.buf;
+    *msgLen = srcParent->myDDT.getSize(sreq.type) * sreq.count;
+    MSG_ORDER_DEBUG(
+      CkPrintf("AMPI vp %d in processSsendMsg, src is local so completing Ssend inline (req %d)\n", parent->thisIndex, sreqIdx);
+    )
+    srcPtr->completedSend(sreqIdx);
+    return true;
+  }
+  else
+#endif
+  {
     requestSsendMsg(msg);
     return false;
   }
+}
+
+bool ampi::processAmpiMsg(AmpiMsg *msg, void* buf, MPI_Datatype type, int count) noexcept
+{
+  char* msgData = msg->getData();
+  int msgLen = msg->getLength();
+
+  if (msg->isSsend()) { // this is a sync msg, send an ack to sender to get the real one
+    if (!processSsendMsg(msg, &msgLen, &msgData)) {
+      return false;
+    }
+  }
 
   CkDDT_DataType *ddt = getDDT()->getType(type);
-  ddt->serialize((char*)buf, msg->getData(), count, msg->getLength(), UNPACK);
+  ddt->serialize((char*)buf, msgData, count, msgLen, UNPACK);
   return true;
 }
 

--- a/src/libs/ck-libs/ampi/ampi.C
+++ b/src/libs/ck-libs/ampi/ampi.C
@@ -2614,22 +2614,72 @@ CMI_WARN_UNUSED_RESULT ampi* ampi::static_blockOnColl(ampi *dis) noexcept {
   return dis;
 }
 
-void ampi::ssend_ack(int sreq_idx) noexcept {
-  if (sreq_idx == 1)
-    thread->resume();           // MPI_Ssend
-  else {
-    sreq_idx -= 2;              // start from 2
-    AmpiRequestList& reqs = getReqs();
-    AmpiRequest *sreq = reqs[sreq_idx];
-    sreq->complete = true;
-    handleBlockedReq(sreq);
-    resumeThreadIfReady();
+// The recv'er invokes this on the sender when it has matched the sync message and
+// wants the sender to now send over the real message payload
+void ampi::ssendAck(int sreqIdx) noexcept
+{
+  MSG_ORDER_DEBUG(
+    CkPrintf("AMPI vp %d in ssendAck for reqIdx %d\n", parent->thisIndex, sreqIdx);
+  )
+
+  AmpiRequestList& reqs = getReqs();
+  SsendReq& sreq = (SsendReq&)*reqs[sreqIdx];
+  int destIdx = getIndexForRank(sreq.destRank);
+
+#if AMPI_RDMA_IMPL
+  CkDDT_DataType* ddt = getDDT()->getType(sreq.type);
+  if (ddt->isContig()) {
+    int size = ddt->getSize(sreq.count);
+    if (size >= AMPI_RDMA_THRESHOLD) {
+      int seq = getSeqNo(sreq.destRank, sreq.comm, sreq.tag);
+      CkCallback completedSendCB(CkIndex_ampi::completedRdmaSend(NULL), thisProxy[thisIndex], true/*inline*/);
+      completedSendCB.setRefnum(sreqIdx);
+      thisProxy[destIdx].genericRdma(CkSendBuffer(sreq.buf, completedSendCB), size, seq, sreq.tag, sreq.src);
+      return;
+    }
   }
+#endif //AMPI_RDMA_IMPL
+
+  thisProxy[destIdx].generic(makeAmpiMsg(sreq.destRank, sreq.tag, sreq.src, sreq.buf, sreq.count, sreq.type, sreq.comm));
+
+  sreq.complete = true;
+  handleBlockedReq(&sreq);
+  resumeThreadIfReady();
+}
+
+// Only "sync" messages (the first message in the rendezvous protocol)
+// from (I)Ssend are delivered here
+void ampi::genericSync(AmpiMsg* msg) noexcept
+{
+  MSG_ORDER_DEBUG(
+    CkPrintf("AMPI vp %d sync arrival: tag=%d, src=%d, comm=%d, ssendReq=%d (seq %d) resumeOnRecv %d\n",
+             thisIndex, msg->getTag(), msg->getSrcRank(), getComm(), CkGetRefNum(msg), msg->getSeq(), parent->resumeOnRecv);
+  )
+  CkAssert(CkGetRefNum(msg));
+#if CMK_BIGSIM_CHARM
+  TRACE_BG_ADD_TAG("AMPI_generic");
+  msg->event = NULL;
+#endif
+
+  if(msg->getSeq() != 0) {
+    int seqIdx = msg->getSeqIdx();
+    int n=oorder.put(seqIdx,msg);
+    if (n>0) { // This message was in-order
+      inorder(msg);
+      // Sync messages don't immediately get processed:
+      // if in-order, the recv'er will invoke ampi::ssendAck to get the real payload back
+    }
+  } else { //Cross-world or system messages are unordered
+    inorder(msg);
+  }
+  // msg may be free'ed from calling inorder()
+
+  resumeThreadIfReady();
 }
 
 void ampi::injectMsg(int size, char* buf) noexcept
 {
-  generic(makeAmpiMsg(thisIndex, 0, thisIndex, (void*)buf, size, MPI_CHAR, MPI_COMM_WORLD, 0));
+  generic(makeAmpiMsg(thisIndex, 0, thisIndex, (void*)buf, size, MPI_CHAR, MPI_COMM_WORLD));
 }
 
 void ampi::generic(AmpiMsg* msg) noexcept
@@ -2650,7 +2700,7 @@ void ampi::generic(AmpiMsg* msg) noexcept
       inorder(msg);
       if (n>1) { // It enables other, previously out-of-order messages
         while((msg=oorder.getOutOfOrder(seqIdx))!=0) {
-          inorder(msg);
+          if (!inorder(msg)) break; // Returns false if msg is a sync message
         }
       }
     }
@@ -2707,7 +2757,7 @@ void AmpiRequestList::free(AmpiRequestPool &reqPool, int idx, CkDDT *ddt) noexce
   startIdx = std::min(idx, startIdx);
 }
 
-void ampi::inorder(AmpiMsg* msg) noexcept
+bool ampi::inorder(AmpiMsg* msg) noexcept
 {
   MSG_ORDER_DEBUG(
     CkPrintf("AMPI vp %d inorder: tag=%d, src=%d, comm=%d (seq %d)\n",
@@ -2722,13 +2772,25 @@ void ampi::inorder(AmpiMsg* msg) noexcept
   //Check posted recvs:
   int tag = msg->getTag();
   int srcRank = msg->getSrcRank();
-  AmpiRequest* req = postedReqs.get(tag, srcRank);
-  if (req) { // receive posted
-    handleBlockedReq(req);
-    req->receive(this, msg);
+  AmpiRequest* ireq = postedReqs.get(tag, srcRank);
+  if (ireq) { // receive posted
+    bool resetNumBlockedReqs = false;
+    if (ireq->isBlocked() && parent->numBlockedReqs != 0) {
+      resetNumBlockedReqs = true;
+      parent->numBlockedReqs--;
+    }
+    if (!ireq->receive(this, msg)) { // Returns false if msg is a sync message
+      // Repost the req for the real message, undo any state changed by the SyncMsg
+      postedReqs.put(tag, srcRank, ireq);
+      if (resetNumBlockedReqs) {
+        parent->numBlockedReqs++;
+      }
+      return false;
+    }
   } else {
     unexpectedMsgs.put(msg);
   }
+  return true;
 }
 
 void ampi::inorderBcast(AmpiMsg* msg, bool deleteMsg) noexcept
@@ -2757,61 +2819,59 @@ void ampi::inorderBcast(AmpiMsg* msg, bool deleteMsg) noexcept
   }
 }
 
-static inline AmpiMsg* rdma2AmpiMsg(char *buf, int size, CMK_REFNUM_TYPE seq, int tag, int srcRank,
-                                    int ssendReq) noexcept
+static inline AmpiMsg* rdma2AmpiMsg(char *buf, int size, CMK_REFNUM_TYPE seq, int tag, int srcRank) noexcept
 {
   // Convert an Rdma message (parameter marshalled buffer) to an AmpiMsg
-  AmpiMsg* msg = new (size, 0) AmpiMsg(seq, ssendReq, tag, srcRank, size);
-  memcpy(msg->data, buf, size); // Assumes the buffer is contiguous
+  AmpiMsg* msg = new (size, 0) AmpiMsg(seq, MPI_REQUEST_NULL, tag, srcRank, size);
+  memcpy(msg->getData(), buf, size); // Assumes the buffer is contiguous
   return msg;
 }
 
 // RDMA version of ampi::generic
-void ampi::genericRdma(char* buf, int size, CMK_REFNUM_TYPE seq, int tag, int srcRank, MPI_Comm destcomm, int ssendReq) noexcept
+void ampi::genericRdma(char* buf, int size, CMK_REFNUM_TYPE seq, int tag, int srcRank) noexcept
 {
   MSG_ORDER_DEBUG(
-    CkPrintf("[%d] in ampi::genericRdma on index %d, size=%d, seq=%d, srcRank=%d, tag=%d, comm=%d, ssendReq=%d\n",
-             CkMyPe(), getIndexForRank(getRank()), size, seq, srcRank, tag, destcomm, ssendReq);
+    CkPrintf("[%d] in ampi::genericRdma on index %d, size=%d, seq=%d, srcRank=%d, tag=%d, comm=%d\n",
+             CkMyPe(), getIndexForRank(getRank()), size, seq, srcRank, tag, getComm());
   )
 
   if (seq != 0) {
     int seqIdx = srcRank;
     int n = oorder.isInOrder(seqIdx, seq);
     if (n > 0) { // This message was in-order
-      inorderRdma(buf, size, seq, tag, srcRank, destcomm, ssendReq);
+      inorderRdma(buf, size, seq, tag, srcRank);
       if (n > 1) { // It enables other, previously out-of-order messages
         AmpiMsg *msg = NULL;
         while ((msg = oorder.getOutOfOrder(seqIdx)) != 0) {
-          inorder(msg);
+          if (!inorder(msg)) break; // Returns false if msg is a sync message
         }
       }
     } else { // This message was out-of-order: stash it (as an AmpiMsg)
-      AmpiMsg *msg = rdma2AmpiMsg(buf, size, seq, tag, srcRank, ssendReq);
+      AmpiMsg *msg = rdma2AmpiMsg(buf, size, seq, tag, srcRank);
       oorder.putOutOfOrder(seqIdx, msg);
     }
   } else { // Cross-world or system messages are unordered
-    inorderRdma(buf, size, seq, tag, srcRank, destcomm, ssendReq);
+    inorderRdma(buf, size, seq, tag, srcRank);
   }
 
   resumeThreadIfReady();
 }
 
 // RDMA version of ampi::inorder
-void ampi::inorderRdma(char* buf, int size, CMK_REFNUM_TYPE seq, int tag, int srcRank,
-                       MPI_Comm comm, int ssendReq) noexcept
+void ampi::inorderRdma(char* buf, int size, CMK_REFNUM_TYPE seq, int tag, int srcRank) noexcept
 {
   MSG_ORDER_DEBUG(
     CkPrintf("AMPI vp %d inorderRdma: tag=%d, src=%d, comm=%d  (seq %d)\n",
-             thisIndex, tag, srcRank, comm, seq);
+             thisIndex, tag, srcRank, getComm(), seq);
   )
 
   //Check posted recvs:
-  AmpiRequest* req = postedReqs.get(tag, srcRank);
-  if (req) { // receive posted
-    handleBlockedReq(req);
-    req->receiveRdma(this, buf, size, ssendReq, srcRank, comm);
+  AmpiRequest* ireq = postedReqs.get(tag, srcRank);
+  if (ireq) { // receive posted
+    handleBlockedReq(ireq);
+    ireq->receiveRdma(this, buf, size, srcRank);
   } else {
-    AmpiMsg* msg = rdma2AmpiMsg(buf, size, seq, tag, srcRank, ssendReq);
+    AmpiMsg* msg = rdma2AmpiMsg(buf, size, seq, tag, srcRank);
     unexpectedMsgs.put(msg);
   }
 }
@@ -2867,19 +2927,43 @@ AmpiMsg *ampi::makeBcastMsg(const void *buf,int count,MPI_Datatype type,int root
   return msg;
 }
 
+// Create an empty AmpiMsg to be matched on the recv side
+AmpiMsg *ampi::makeSyncMsg(int destRank,int t,int sRank,const void *buf,int count, MPI_Datatype type,
+                           MPI_Comm destcomm,int ssendReq,CMK_REFNUM_TYPE seq) noexcept
+{
+  CkAssert(ssendReq >= 0);
+  CkDDT_DataType *ddt = getDDT()->getType(type);
+  int len = ddt->getSize(count);
+  AmpiMsg *msg = CkpvAccess(msgPool).newAmpiMsg(seq, ssendReq, t, sRank, 0);
+  msg->setLength(len); // set AmpiMsg's length to be that of the real msg payload
+  return msg;
+}
+
 AmpiMsg *ampi::makeAmpiMsg(int destRank,int t,int sRank,const void *buf,int count,
-                           MPI_Datatype type,MPI_Comm destcomm, int ssendReq/*=0*/) noexcept
+                           MPI_Datatype type,MPI_Comm destcomm) noexcept
 {
   CkDDT_DataType *ddt = getDDT()->getType(type);
   int len = ddt->getSize(count);
   CMK_REFNUM_TYPE seq = getSeqNo(destRank, destcomm, t);
-  AmpiMsg *msg = CkpvAccess(msgPool).newAmpiMsg(seq, ssendReq, t, sRank, len);
+  AmpiMsg *msg = CkpvAccess(msgPool).newAmpiMsg(seq, MPI_REQUEST_NULL, t, sRank, len);
   ddt->serialize((char*)buf, msg->getData(), count, msg->getLength(), PACK);
   return msg;
 }
 
+void ampi::waitOnBlockingSend(MPI_Request* req, AmpiSendType sendType) noexcept
+{
+  if (*req != MPI_REQUEST_NULL && (sendType == BLOCKING_SEND || sendType == BLOCKING_SSEND)) {
+    AmpiRequestList& reqList = getReqs();
+    AmpiRequest& sreq = *reqList[*req];
+    sreq.wait(MPI_STATUS_IGNORE);
+    reqList.free(parent->reqPool, *req, parent->getDDT());
+    *req = MPI_REQUEST_NULL;
+  }
+}
+
 MPI_Request ampi::send(int t, int sRank, const void* buf, int count, MPI_Datatype type,
-                       int rank, MPI_Comm destcomm, int ssendReq/*=0*/, AmpiSendType sendType/*=BLOCKING_SEND*/) noexcept
+                       int rank, MPI_Comm destcomm, AmpiSendType sendType/*=BLOCKING_SEND*/,
+                       MPI_Request reqIdx/*=MPI_REQUEST_NULL*/) noexcept
 {
 #if CMK_TRACE_IN_CHARM
   TRACE_BG_AMPI_BREAK(thread->getThread(), "AMPI_SEND", NULL, 0, 1);
@@ -2892,31 +2976,19 @@ MPI_Request ampi::send(int t, int sRank, const void* buf, int count, MPI_Datatyp
 #endif
 
   const ampiCommStruct &dest=comm2CommStruct(destcomm);
-  MPI_Request req = delesend(t,sRank,buf,count,type,rank,destcomm,dest.getProxy(),ssendReq,sendType);
-  if (sendType == BLOCKING_SEND && req != MPI_REQUEST_NULL) {
-    AmpiRequestList& reqList = getReqs();
-    AmpiRequest *sreq = reqList[req];
-    sreq->wait(MPI_STATUS_IGNORE);
-    reqList.free(parent->reqPool, req, parent->getDDT());
-    req = MPI_REQUEST_NULL;
-  }
+  MPI_Request req = delesend(t,sRank,buf,count,type,rank,destcomm,dest.getProxy(),sendType,reqIdx);
+  waitOnBlockingSend(&req, sendType);
 
 #if CMK_TRACE_IN_CHARM
   TRACE_BG_AMPI_BREAK(thread->getThread(), "AMPI_SEND_END", NULL, 0, 1);
 #endif
-
-  if (ssendReq == 1) {
-    // waiting for receiver side
-    parent->resumeOnRecv = false;            // so no one else awakes it
-    parent = parent->block();
-  }
 
   return req;
 }
 
 void ampi::sendraw(int t, int sRank, void* buf, int len, CkArrayID aid, int idx) noexcept
 {
-  AmpiMsg *msg = new (len, 0) AmpiMsg(0, 0, t, sRank, len);
+  AmpiMsg *msg = new (len, 0) AmpiMsg(0, MPI_REQUEST_NULL, t, sRank, len);
   memcpy(msg->getData(), buf, len);
   CProxy_ampi pa(aid);
   pa[idx].generic(msg);
@@ -2932,43 +3004,66 @@ CMK_REFNUM_TYPE ampi::getSeqNo(int destRank, MPI_Comm destcomm, int tag) noexcep
 }
 
 MPI_Request ampi::sendRdmaMsg(int t, int sRank, const void* buf, int size, MPI_Datatype type, int destIdx,
-                              int destRank, MPI_Comm destcomm, CProxy_ampi arrProxy, int ssendReq) noexcept
+                              int destRank, MPI_Comm destcomm, CProxy_ampi arrProxy, MPI_Request reqIdx) noexcept
 {
   CMK_REFNUM_TYPE seq = getSeqNo(destRank, destcomm, t);
 
-  if (ssendReq) { // Using a SsendReq to track matching receive, so no need for SendReq here
-    arrProxy[destIdx].genericRdma(CkSendBuffer(buf), size, seq, t, sRank, destcomm, ssendReq);
-    return MPI_REQUEST_NULL;
+  // Set up a SendReq to track completion of the send buffer
+  if (reqIdx == MPI_REQUEST_NULL) {
+    reqIdx = postReq(parent->reqPool.newReq<SendReq>(type, destcomm, getDDT()));
   }
-  else { // Set up a SendReq to track completion of the send buffer
-    MPI_Request req = postReq(parent->reqPool.newReq<SendReq>(type, destcomm, getDDT()));
-    CkCallback completedSendCB(CkIndex_ampi::completedRdmaSend(NULL), thisProxy[thisIndex], true/*inline*/);
-    completedSendCB.setRefnum(req);
+  CkCallback completedSendCB(CkIndex_ampi::completedRdmaSend(NULL), thisProxy[thisIndex], true/*inline*/);
+  completedSendCB.setRefnum(reqIdx);
 
-    arrProxy[destIdx].genericRdma(CkSendBuffer(buf, completedSendCB), size, seq, t, sRank, destcomm, ssendReq);
-    return req;
-  }
+  arrProxy[destIdx].genericRdma(CkSendBuffer(buf, completedSendCB), size, seq, t, sRank);
+  return reqIdx;
 }
 
 // Call genericRdma inline on the local destination object
 MPI_Request ampi::sendLocalMsg(int t, int sRank, const void* buf, int size, MPI_Datatype type, int destRank,
-                               MPI_Comm destcomm, ampi* destPtr, int ssendReq, AmpiSendType sendType) noexcept
+                               MPI_Comm destcomm, ampi* destPtr, AmpiSendType sendType, MPI_Request reqIdx) noexcept
 {
   CMK_REFNUM_TYPE seq = getSeqNo(destRank, destcomm, t);
 
-  destPtr->genericRdma((char*)buf, size, seq, t, sRank, destcomm, ssendReq);
+  destPtr->genericRdma((char*)buf, size, seq, t, sRank);
 
-  if (ssendReq || sendType == BLOCKING_SEND) {
+  if (sendType == BLOCKING_SEND) {
     return MPI_REQUEST_NULL;
+  }
+  else if (reqIdx != MPI_REQUEST_NULL) {
+    return reqIdx;
   }
   else { // SendReq is pre-completed since we directly copied the send buffer
     return postReq(parent->reqPool.newReq<SendReq>(type, destcomm, getDDT(), AMPI_REQ_COMPLETED));
   }
 }
 
+MPI_Request ampi::sendSyncMsg(int t, int sRank, const void* buf, MPI_Datatype type, int count,
+                              int rank, MPI_Comm destcomm, CProxyElement_ampi destElem,
+                              AmpiSendType sendType, MPI_Request reqIdx) noexcept
+{
+  int seq = getSeqNo(rank, destcomm, t);
+  if (reqIdx == MPI_REQUEST_NULL) {
+    reqIdx = postReq(parent->reqPool.newReq<SsendReq>(buf, count, type, rank, t, destcomm, sRank, getDDT(),
+                                                      (sendType == BLOCKING_SSEND) ?
+                                                      AMPI_REQ_BLOCKED : AMPI_REQ_PENDING));
+  }
+  // All sync messages go thru ampi::genericSync (not generic or genericRdma)
+#if AMPI_LOCAL_IMPL
+  ampi* destPtr = destElem.ckLocal();
+  if (destPtr != nullptr) {
+    destPtr->genericSync(makeSyncMsg(rank, t, sRank, buf, count, type, destcomm, reqIdx, seq));
+  } else
+#endif
+  {
+    destElem.genericSync(makeSyncMsg(rank, t, sRank, buf, count, type, destcomm, reqIdx, seq));
+  }
+  return reqIdx;
+}
+
 MPI_Request ampi::delesend(int t, int sRank, const void* buf, int count, MPI_Datatype type,
-                           int rank, MPI_Comm destcomm, CProxy_ampi arrProxy, int ssendReq,
-                           AmpiSendType sendType) noexcept
+                           int rank, MPI_Comm destcomm, CProxy_ampi arrProxy, AmpiSendType sendType,
+                           MPI_Request reqIdx) noexcept
 {
   if (rank==MPI_PROC_NULL) return MPI_REQUEST_NULL;
   const ampiCommStruct &dest=comm2CommStruct(destcomm);
@@ -2982,61 +3077,75 @@ MPI_Request ampi::delesend(int t, int sRank, const void* buf, int count, MPI_Dat
   }
 
   MSG_ORDER_DEBUG(
-    CkPrintf("AMPI vp %d send: tag=%d, src=%d, comm=%d (to %d)\n",thisIndex,t,sRank,destcomm,destIdx);
+    CkPrintf("AMPI vp %d send: tag=%d, src=%d, comm=%d (to %d)\n",parent->thisIndex,t,sRank,destcomm,destIdx);
   )
 
+  if (sendType == BLOCKING_SSEND || sendType == I_SSEND) {
+    return sendSyncMsg(t, sRank, buf, type, count, rank, destcomm, arrProxy[destIdx], sendType, reqIdx);
+  }
   ampi *destPtr = arrProxy[destIdx].ckLocal();
   CkDDT_DataType *ddt = getDDT()->getType(type);
   int size = ddt->getSize(count);
   if (ddt->isContig()) {
 #if AMPI_LOCAL_IMPL
     if (destPtr != NULL) {
-      return sendLocalMsg(t, sRank, buf, size, type, rank, destcomm, destPtr, ssendReq, sendType);
+      return sendLocalMsg(t, sRank, buf, size, type, rank, destcomm, destPtr, sendType, reqIdx);
     }
 #endif
 #if AMPI_RDMA_IMPL
     if (size >= AMPI_RDMA_THRESHOLD ||
        (size >= AMPI_SMP_RDMA_THRESHOLD && destLikelyWithinProcess(arrProxy, destIdx)))
     {
-      return sendRdmaMsg(t, sRank, buf, size, type, destIdx, rank, destcomm, arrProxy, ssendReq);
+      return sendRdmaMsg(t, sRank, buf, size, type, destIdx, rank, destcomm, arrProxy, reqIdx);
     }
 #endif
   }
 #if AMPI_LOCAL_IMPL
   if (destPtr != NULL) {
-    destPtr->generic(makeAmpiMsg(rank, t, sRank, buf, count, type, destcomm, ssendReq));
+    destPtr->generic(makeAmpiMsg(rank, t, sRank, buf, count, type, destcomm));
     return MPI_REQUEST_NULL;
   } else
 #endif
   {
-    arrProxy[destIdx].generic(makeAmpiMsg(rank, t, sRank, buf, count, type, destcomm, ssendReq));
+    arrProxy[destIdx].generic(makeAmpiMsg(rank, t, sRank, buf, count, type, destcomm));
+    if (reqIdx != MPI_REQUEST_NULL) {
+      AmpiRequestList& reqList = parent->ampiReqs;
+      AmpiRequest& sreq = (*reqList[reqIdx]);
+      sreq.complete = true;
+      return reqIdx;
+    }
     return MPI_REQUEST_NULL;
   }
 }
 
-void ampi::processAmpiMsg(AmpiMsg *msg, void* buf, MPI_Datatype type, int count) noexcept
+// Ask the sender to send us the real message back
+void ampi::requestSsendMsg(AmpiMsg* msg) noexcept
 {
   int ssendReq = msg->getSsendReq();
-  if (ssendReq > 0) { // send an ack to sender
-    int srcRank = msg->getSrcRank();
-    int srcIdx = getIndexForRank(srcRank);
-    thisProxy[srcIdx].ssend_ack(ssendReq);
+  CkAssert(ssendReq >= 0);
+  MSG_ORDER_DEBUG(
+    CkPrintf("AMPI vp %d calling ssendAck with sreqIdx %d\n", parent->thisIndex, ssendReq);
+  )
+  int srcIdx = getIndexForRank(msg->getSrcRank());
+  thisProxy[srcIdx].ssendAck(ssendReq);
+}
+
+bool ampi::processAmpiMsg(AmpiMsg *msg, void* buf, MPI_Datatype type, int count) noexcept
+{
+  if (msg->isSsend()) { // this is a sync msg, send an ack to sender to get the real one
+    requestSsendMsg(msg);
+    return false;
   }
 
   CkDDT_DataType *ddt = getDDT()->getType(type);
-
   ddt->serialize((char*)buf, msg->getData(), count, msg->getLength(), UNPACK);
+  return true;
 }
 
 // RDMA version of ampi::processAmpiMsg
-void ampi::processRdmaMsg(const void *sbuf, int slength, int ssendReq, int srank, void* rbuf,
+void ampi::processRdmaMsg(const void *sbuf, int slength, int srank, void* rbuf,
                           int rcount, MPI_Datatype rtype, MPI_Comm comm) noexcept
 {
-  if (ssendReq > 0) { // send an ack to sender
-    int srcIdx = getIndexForRank(srank);
-    thisProxy[srcIdx].ssend_ack(ssendReq);
-  }
-
   CkDDT_DataType *ddt = getDDT()->getType(rtype);
 
   ddt->serialize((char*)rbuf, (char*)sbuf, rcount, slength, UNPACK);
@@ -3184,6 +3293,27 @@ void ampi::processGathervMsg(CkReductionMsg *msg, void* buf, MPI_Datatype type,
   delete [] results;
 }
 
+ampi* ampi::blockOnIReq(void* buf, int count, MPI_Datatype type, int src,
+                        int tag, MPI_Comm comm, MPI_Status* sts) noexcept
+{
+  MPI_Request request = postReq(parent->reqPool.newReq<IReq>(buf, count, type, src, tag, comm, getDDT(),
+                                                             AMPI_REQ_BLOCKED));
+  CkAssert(parent->numBlockedReqs == 0);
+  parent->numBlockedReqs = 1;
+  ampi* dis = blockOnRecv(); // "dis" is updated in case an ampi thread is migrated
+  AmpiRequestList& reqs = dis->getReqs();
+  if (sts != MPI_STATUS_IGNORE) {
+    AmpiRequest& req = *reqs[request];
+    sts->MPI_SOURCE = req.src;
+    sts->MPI_TAG    = req.tag;
+    sts->MPI_COMM   = req.comm;
+    sts->MPI_LENGTH = req.getNumReceivedBytes(dis->getDDT());
+    sts->MPI_CANCEL = 0;
+  }
+  reqs.freeNonPersReq(request);
+  return dis;
+}
+
 static inline void clearStatus(MPI_Status *sts) noexcept {
   if (sts != MPI_STATUS_IGNORE) {
     sts->MPI_TAG    = MPI_ANY_TAG;
@@ -3242,28 +3372,19 @@ int ampi::static_recv(ampi *dis, int t, int s, void* buf, int count, MPI_Datatyp
       sts->MPI_LENGTH = msg->getLength();
       sts->MPI_CANCEL = 0;
     }
-    dis->processAmpiMsg(msg, buf, type, count);
 #if CMK_BIGSIM_CHARM
-    TRACE_BG_AMPI_BREAK(thread->getThread(), "RECV_RESUME", NULL, 0, 0);
+    TRACE_BG_AMPI_BREAK(dis->thread->getThread(), "RECV_RESUME", NULL, 0, 0);
     if (msg->eventPe == CkMyPe()) _TRACE_BG_ADD_BACKWARD_DEP(msg->event);
 #endif
-    CkpvAccess(msgPool).deleteAmpiMsg(msg);
+    if (dis->processAmpiMsg(msg, buf, type, count)) {
+      CkpvAccess(msgPool).deleteAmpiMsg(msg);
+    }
+    else { // msg was a sync msg, so now block on the real msg
+      dis = dis->blockOnIReq(buf, count, type, s, t, comm, sts);
+    }
   }
   else { // post a request and block until the matching message arrives
-    int request = dis->postReq(dis->parent->reqPool.newReq<IReq>(buf, count, type, s, t, comm, dis->getDDT(), AMPI_REQ_BLOCKED));
-    CkAssert(dis->parent->numBlockedReqs == 0);
-    dis->parent->numBlockedReqs = 1;
-    dis = dis->blockOnRecv(); // "dis" is updated in case an ampi thread is migrated while waiting for a message
-    AmpiRequestList& reqs = dis->parent->getReqs();
-    if (sts != MPI_STATUS_IGNORE) {
-      AmpiRequest& req = *reqs[request];
-      sts->MPI_SOURCE = req.src;
-      sts->MPI_TAG    = req.tag;
-      sts->MPI_COMM   = req.comm;
-      sts->MPI_LENGTH = req.getNumReceivedBytes(dis->getDDT());
-      sts->MPI_CANCEL = 0;
-    }
-    reqs.freeNonPersReq(request);
+    dis = dis->blockOnIReq(buf, count, type, s, t, comm, sts);
   }
 
 #if (defined(_FAULT_MLOG_) || defined(_FAULT_CAUSAL_))
@@ -3491,7 +3612,7 @@ int ampi::intercomm_ibcast(int root, void* buf, int count, MPI_Datatype type, MP
 
 void ampi::bcastraw(void* buf, int len, CkArrayID aid) noexcept
 {
-  AmpiMsg *msg = new (len, 0) AmpiMsg(0, 0, MPI_BCAST_TAG, 0, len);
+  AmpiMsg *msg = new (len, 0) AmpiMsg(0, MPI_REQUEST_NULL, MPI_BCAST_TAG, 0, len);
   memcpy(msg->getData(), buf, len);
   CProxy_ampi pa(aid);
   pa.generic(msg);
@@ -3532,7 +3653,7 @@ int ampi::intercomm_iscatter(int root, const void *sendbuf, int sendcount, MPI_D
     ATAReq *newreq = new ATAReq(remote_size);
     for(int i = 0; i < remote_size; i++) {
       newreq->reqs[i] = send(MPI_SCATTER_TAG, getRank(), ((char*)sendbuf)+(itemsize*i),
-                             sendcount, sendtype, i, intercomm, 0, I_SEND);
+                             sendcount, sendtype, i, intercomm, I_SEND);
     }
     *request = postReq(newreq);
   }
@@ -3581,7 +3702,7 @@ int ampi::intercomm_iscatterv(int root, const void* sendbuf, const int* sendcoun
     ATAReq *newreq = new ATAReq(remote_size);
     for (int i = 0; i < remote_size; i++) {
       newreq->reqs[i] = send(MPI_SCATTER_TAG, getRank(), ((char*)sendbuf)+(itemsize*displs[i]),
-                             sendcounts[i], sendtype, i, intercomm, 0, I_SEND);
+                             sendcounts[i], sendtype, i, intercomm, I_SEND);
     }
     *request = postReq(newreq);
   }
@@ -4197,7 +4318,7 @@ AMPI_API_IMPL(int, MPI_Ssend, const void *msg, int count, MPI_Datatype type,
 #endif
 
   ampi *ptr = getAmpiInstance(comm);
-  ptr->send(tag, ptr->getRank(), msg, count, type, dest, comm, 1);
+  ptr->send(tag, ptr->getRank(), msg, count, type, dest, comm, BLOCKING_SSEND);
 
   return MPI_SUCCESS;
 }
@@ -4226,12 +4347,8 @@ AMPI_API_IMPL(int, MPI_Issend, const void *buf, int count, MPI_Datatype type, in
 #endif
 
   USER_CALL_DEBUG("AMPI_Issend("<<type<<","<<dest<<","<<tag<<","<<comm<<")");
-  ampiParent* pptr = getAmpiParent();
-  ampi *ptr = getAmpiInstance(comm);
-  *request = ptr->postReq(pptr->reqPool.newReq<SsendReq>(type, comm, pptr->getDDT()));
-  // 1:  blocking now  - used by MPI_Ssend
-  // >=2:  the index of the requests - used by MPI_Issend
-  ptr->send(tag, ptr->getRank(), buf, count, type, dest, comm, *request+2, I_SEND);
+  ampi* ptr = getAmpiInstance(comm);
+  *request = ptr->send(tag, ptr->getRank(), buf, count, type, dest, comm, I_SSEND);
 
 #if AMPIMSGLOG
   if(msgLogWrite && record_msglog(pptr->thisIndex)){
@@ -4469,7 +4586,7 @@ void ampi::sendrecv(const void *sbuf, int scount, MPI_Datatype stype, int dest, 
   MPI_Request reqs[2];
   irecv(rbuf, rcount, rtype, src, rtag, comm, &reqs[0]);
 
-  reqs[1] = send(stag, getRank(), sbuf, scount, stype, dest, comm, 0, I_SEND);
+  reqs[1] = send(stag, getRank(), sbuf, scount, stype, dest, comm, I_SEND);
 
   if (sts == MPI_STATUS_IGNORE) {
     MPI_Waitall(2, reqs, MPI_STATUSES_IGNORE);
@@ -4522,7 +4639,7 @@ void ampi::sendrecv_replace(void* buf, int count, MPI_Datatype datatype,
   irecv(buf, count, datatype, source, recvtag, comm, &reqs[0]);
 
   // FIXME: this send may do a copy internally! If we knew now that it would, we could avoid double copying:
-  reqs[1] = send(sendtag, getRank(), tmpBuf.data(), count, datatype, dest, comm, 0, I_SEND);
+  reqs[1] = send(sendtag, getRank(), tmpBuf.data(), count, datatype, dest, comm, I_SEND);
 
   if (status == MPI_STATUS_IGNORE) {
     MPI_Waitall(2, reqs, MPI_STATUSES_IGNORE);
@@ -5055,7 +5172,7 @@ AMPI_API_IMPL(int, MPI_Reduce, const void *inbuf, void *outbuf, int count, MPI_D
     ptr = ptr->blockOnColl();
 
 #if AMPI_SYNC_REDUCE
-    AmpiMsg *msg = new (0, 0) AmpiMsg(0, 0, MPI_REDN_TAG, -1, rootIdx, 0);
+    AmpiMsg *msg = new (0, 0) AmpiMsg(0, MPI_REQUEST_NULL, MPI_REDN_TAG, -1, rootIdx, 0);
     CProxy_ampi pa(ptr->getProxy());
     pa.generic(msg);
 #endif
@@ -5522,7 +5639,7 @@ void SendReq::start(MPI_Request reqIdx) noexcept {
   CkAssert(persistent);
   complete = false;
   ampi* ptr = getAmpiInstance(comm);
-  ptr->send(tag, ptr->getRank(), buf, count, type, src /*really, the destination*/, comm);
+  ptr->send(tag, ptr->getRank(), buf, count, type, src /*really, the destination*/, comm, I_SEND, reqIdx);
   complete = true;
 }
 
@@ -5530,7 +5647,7 @@ void SsendReq::start(MPI_Request reqIdx) noexcept {
   CkAssert(persistent);
   complete = false;
   ampi* ptr = getAmpiInstance(comm);
-  ptr->send(tag, ptr->getRank(), buf, count, type, src /*really, the destination*/, comm, reqIdx+2, I_SEND);
+  ptr->send(tag, ptr->getRank(), buf, count, type, src /*really, the destination*/, comm, I_SSEND, reqIdx);
 }
 
 int IReq::wait(MPI_Status *sts) noexcept {
@@ -5691,11 +5808,15 @@ int SendReq::wait(MPI_Status *sts) noexcept {
 }
 
 int SsendReq::wait(MPI_Status *sts) noexcept {
-  ampiParent *parent = getAmpiParent();
+  ampiParent *disParent = getAmpiParent();
   while (!complete) {
-    // "dis" is updated in case an ampi thread is migrated while waiting for a message
-    parent = parent->blockOnRecv();
+    disParent->resumeOnRecv = true;
+    disParent->numBlockedReqs = 1;
+    setBlocked(true);
+    disParent = disParent->block();
+    setBlocked(false);
   }
+  disParent->resumeOnRecv = false;
   if (sts != MPI_STATUS_IGNORE) {
     sts->MPI_COMM = comm;
     sts->MPI_CANCEL = 0;
@@ -6098,9 +6219,12 @@ bool ATAReq::test(MPI_Status *sts/*=MPI_STATUS_IGNORE*/) noexcept {
   return complete;
 }
 
-void IReq::receive(ampi *ptr, AmpiMsg *msg, bool deleteMsg/*=true*/) noexcept
+bool IReq::receive(ampi *ptr, AmpiMsg *msg, bool deleteMsg/*=true*/) noexcept
 {
-  ptr->processAmpiMsg(msg, buf, type, count);
+  if (!ptr->processAmpiMsg(msg, buf, type, count)) { // Returns false if msg is a sync message
+    CkpvAccess(msgPool).deleteAmpiMsg(msg);
+    return false;
+  }
   complete = true;
   length = msg->getLength();
   this->tag = msg->getTag(); // Although not required, we also extract tag from msg
@@ -6115,14 +6239,15 @@ void IReq::receive(ampi *ptr, AmpiMsg *msg, bool deleteMsg/*=true*/) noexcept
   if (deleteMsg) {
     CkpvAccess(msgPool).deleteAmpiMsg(msg);
   }
+  return true;
 }
 
-void IReq::receiveRdma(ampi *ptr, char *sbuf, int slength, int ssendReq, int srcRank, MPI_Comm scomm) noexcept
+void IReq::receiveRdma(ampi *ptr, char *sbuf, int slength, int srcRank) noexcept
 {
-  ptr->processRdmaMsg(sbuf, slength, ssendReq, srcRank, buf, count, type, scomm);
+  ptr->processRdmaMsg(sbuf, slength, srcRank, buf, count, type, ptr->getComm());
   complete = true;
   length = slength;
-  comm = scomm;
+  comm = ptr->getComm();
   // ampi::genericRdma is parameter marshalled, so there is no msg to delete
 }
 
@@ -6893,7 +7018,7 @@ AMPI_API_IMPL(int, MPI_Isend, const void *buf, int count, MPI_Datatype type, int
   USER_CALL_DEBUG("AMPI_Isend("<<type<<","<<dest<<","<<tag<<","<<comm<<")");
 
   ampi *ptr = getAmpiInstance(comm);
-  *request = ptr->send(tag, ptr->getRank(), buf, count, type, dest, comm, 0, I_SEND);
+  *request = ptr->send(tag, ptr->getRank(), buf, count, type, dest, comm, I_SEND);
 
 #if AMPIMSGLOG
   if(msgLogWrite && record_msglog(pptr->thisIndex)){
@@ -6965,7 +7090,9 @@ void ampi::irecv(void *buf, int count, MPI_Datatype type, int src,
   AmpiMsg* msg = unexpectedMsgs.get(tag, src);
   // if msg has already arrived, do the receive right away
   if (msg) {
-    newreq->receive(this, msg);
+    if (!newreq->receive(this, msg)) { // Returns false if msg is a sync message
+      postedReqs.put(tag, src, newreq);
+    }
   }
   else { // ... otherwise post the receive
     postedReqs.put(newreq);
@@ -7731,7 +7858,7 @@ AMPI_API_IMPL(int, MPI_Iscatter, const void *sendbuf, int sendcount, MPI_Datatyp
     for(i=0;i<size;i++) {
       if (i != rank) {
         newreq->reqs[i] = ptr->send(MPI_SCATTER_TAG, rank, (char*)sendbuf+(itemextent*i),
-                                    sendcount, sendtype, i, comm, 0, I_SEND);
+                                    sendcount, sendtype, i, comm, I_SEND);
       }
     }
     newreq->reqs[rank] = MPI_REQUEST_NULL;
@@ -7889,7 +8016,7 @@ AMPI_API_IMPL(int, MPI_Iscatterv, const void *sendbuf, const int *sendcounts, co
     for(i=0;i<size;i++) {
       if (i != rank) {
         newreq->reqs[i] = ptr->send(MPI_SCATTER_TAG, rank, ((char*)sendbuf)+(itemextent*displs[i]),
-                                    sendcounts[i], sendtype, i, comm, 0, I_SEND);
+                                    sendcounts[i], sendtype, i, comm, I_SEND);
       }
     }
     newreq->reqs[rank] = MPI_REQUEST_NULL;
@@ -7982,7 +8109,7 @@ AMPI_API_IMPL(int, MPI_Alltoall, const void *sendbuf, int sendcount, MPI_Datatyp
     for (int i=0; i<size; i++) {
       int dst = (rank+i) % size;
       reqs[size+i] = ptr->send(MPI_ATA_TAG, rank, ((char*)sendbuf)+(itemextent*dst),
-                               sendcount, sendtype, dst, comm, 0, I_SEND);
+                               sendcount, sendtype, dst, comm, I_SEND);
     }
     MPI_Waitall(reqs.size(), reqs.data(), MPI_STATUSES_IGNORE);
   }
@@ -8085,7 +8212,7 @@ AMPI_API_IMPL(int, MPI_Ialltoall, const void *sendbuf, int sendcount, MPI_Dataty
   for (int i=0; i<size; i++) {
     int dst = (rank+i) % size;
     newreq->reqs[size+i] = ptr->send(MPI_ATA_TAG, rank, ((char*)sendbuf)+(itemsize*dst), sendcount,
-                                     sendtype, dst, comm, 0, I_SEND);
+                                     sendtype, dst, comm, I_SEND);
   }
   *request = ptr->postReq(newreq);
 
@@ -8153,7 +8280,7 @@ AMPI_API_IMPL(int, MPI_Alltoallv, const void *sendbuf, const int *sendcounts, co
     for (int i=0; i<size; i++) {
       int dst = (rank+i) % size;
       reqs[size+i] = ptr->send(MPI_ATA_TAG, rank, ((char*)sendbuf)+(itemextent*sdispls[dst]),
-                               sendcounts[dst], sendtype, dst, comm, 0, I_SEND);
+                               sendcounts[dst], sendtype, dst, comm, I_SEND);
     }
     MPI_Waitall(size*2, reqs.data(), MPI_STATUSES_IGNORE);
   }
@@ -8230,7 +8357,7 @@ AMPI_API_IMPL(int, MPI_Ialltoallv, void *sendbuf, int *sendcounts, int *sdispls,
   for (int i=0; i<size; i++) {
     int dst = (rank+i) % size;
     newreq->reqs[size+i] = ptr->send(MPI_ATA_TAG, rank, ((char*)sendbuf)+(itemextent*sdispls[dst]),
-                                     sendcounts[dst], sendtype, dst, comm, 0, I_SEND);
+                                     sendcounts[dst], sendtype, dst, comm, I_SEND);
   }
   *request = ptr->postReq(newreq);
 
@@ -8302,7 +8429,7 @@ AMPI_API_IMPL(int, MPI_Alltoallw, const void *sendbuf, const int *sendcounts, co
     for (int i=0; i<size; i++) {
       int dst = (rank+i) % size;
       reqs[size+i] = ptr->send(MPI_ATA_TAG, rank, ((char*)sendbuf)+sdispls[dst],
-                               sendcounts[dst], sendtypes[dst], dst, comm, 0, I_SEND);
+                               sendcounts[dst], sendtypes[dst], dst, comm, I_SEND);
     }
     MPI_Waitall(size*2, reqs.data(), MPI_STATUSES_IGNORE);
   }
@@ -8384,7 +8511,7 @@ AMPI_API_IMPL(int, MPI_Ialltoallw, const void *sendbuf, const int *sendcounts, c
   for (int i=0; i<size; i++) {
     int dst = (rank+i) % size;
     newreq->reqs[i] = ptr->send(MPI_ATA_TAG, rank, (char*)sendbuf+sdispls[dst],
-                                sendcounts[dst], sendtypes[dst], dst, comm, 0, I_SEND);
+                                sendcounts[dst], sendtypes[dst], dst, comm, I_SEND);
   }
   *request = ptr->postReq(newreq);
 
@@ -8432,7 +8559,7 @@ AMPI_API_IMPL(int, MPI_Neighbor_alltoall, const void* sendbuf, int sendcount, MP
 
   for (int i=0; i<num_neighbors; i++) {
     reqs[num_neighbors+i] = ptr->send(MPI_NBOR_TAG, rank_in_comm, (void*)((char*)sendbuf+(itemsize*i)),
-                                      sendcount, sendtype, neighbors[i], comm, 0, I_SEND);
+                                      sendcount, sendtype, neighbors[i], comm, I_SEND);
   }
 
   MPI_Waitall(reqs.size(), reqs.data(), MPI_STATUSES_IGNORE);
@@ -8489,7 +8616,7 @@ AMPI_API_IMPL(int, MPI_Ineighbor_alltoall, const void* sendbuf, int sendcount, M
 
   for (int i=0; i<num_neighbors; i++) {
     newreq->reqs[num_neighbors+i] = ptr->send(MPI_ATA_TAG, rank_in_comm, ((char*)sendbuf)+(i*itemsize),
-                                              sendcount, sendtype, neighbors[i], comm, 0, I_SEND);
+                                              sendcount, sendtype, neighbors[i], comm, I_SEND);
   }
   *request = ptr->postReq(newreq);
 
@@ -8537,7 +8664,7 @@ AMPI_API_IMPL(int, MPI_Neighbor_alltoallv, const void* sendbuf, const int *sendc
 
   for (int i=0; i<num_neighbors; i++) {
     reqs[num_neighbors+i] = ptr->send(MPI_NBOR_TAG, rank_in_comm, (void*)((char*)sendbuf+(itemsize*sdispls[i])),
-                                      sendcounts[i], sendtype, neighbors[i], comm, 0, I_SEND);
+                                      sendcounts[i], sendtype, neighbors[i], comm, I_SEND);
   }
 
   MPI_Waitall(reqs.size(), reqs.data(), MPI_STATUSES_IGNORE);
@@ -8595,7 +8722,7 @@ AMPI_API_IMPL(int, MPI_Ineighbor_alltoallv, const void* sendbuf, const int *send
 
   for (int i=0; i<num_neighbors; i++) {
     newreq->reqs[num_neighbors+i] = ptr->send(MPI_NBOR_TAG, rank_in_comm, (char*)sendbuf+(itemsize*sdispls[i]),
-                                              sendcounts[i], sendtype, neighbors[i], comm, 0, I_SEND);
+                                              sendcounts[i], sendtype, neighbors[i], comm, I_SEND);
   }
   *request = ptr->postReq(newreq);
 
@@ -8641,7 +8768,7 @@ AMPI_API_IMPL(int, MPI_Neighbor_alltoallw, const void* sendbuf, const int *sendc
 
   for (int i=0; i<num_neighbors; i++) {
     reqs[num_neighbors+i] = ptr->send(MPI_NBOR_TAG, rank_in_comm, (void*)((char*)sendbuf+sdispls[i]),
-                                      sendcounts[i], sendtypes[i], neighbors[i], comm, 0, I_SEND);
+                                      sendcounts[i], sendtypes[i], neighbors[i], comm, I_SEND);
   }
 
   MPI_Waitall(reqs.size(), reqs.data(), MPI_STATUSES_IGNORE);
@@ -8697,7 +8824,7 @@ AMPI_API_IMPL(int, MPI_Ineighbor_alltoallw, const void* sendbuf, const int *send
 
   for (int i=0; i<num_neighbors; i++) {
     newreq->reqs[num_neighbors+i] = ptr->send(MPI_NBOR_TAG, rank_in_comm, (void*)((char*)sendbuf+sdispls[i]),
-                                              sendcounts[i], sendtypes[i], neighbors[i], comm, 0, I_SEND);
+                                              sendcounts[i], sendtypes[i], neighbors[i], comm, I_SEND);
   }
   *request = ptr->postReq(newreq);
 
@@ -8744,7 +8871,7 @@ AMPI_API_IMPL(int, MPI_Neighbor_allgather, const void* sendbuf, int sendcount, M
 
   for (int i=0; i<num_neighbors; i++) {
     reqs[num_neighbors+i] = ptr->send(MPI_NBOR_TAG, rank_in_comm, sendbuf, sendcount,
-                                      sendtype, neighbors[i], comm, 0, I_SEND);
+                                      sendtype, neighbors[i], comm, I_SEND);
   }
 
   MPI_Waitall(reqs.size(), reqs.data(), MPI_STATUSES_IGNORE);
@@ -8800,7 +8927,7 @@ AMPI_API_IMPL(int, MPI_Ineighbor_allgather, const void* sendbuf, int sendcount, 
 
   for (int i=0; i<num_neighbors; i++) {
     newreq->reqs[num_neighbors+i] = ptr->send(MPI_NBOR_TAG, rank_in_comm, sendbuf, sendcount,
-                                              sendtype, neighbors[i], comm, 0, I_SEND);
+                                              sendtype, neighbors[i], comm, I_SEND);
   }
   *request = ptr->postReq(newreq);
 
@@ -8845,7 +8972,7 @@ AMPI_API_IMPL(int, MPI_Neighbor_allgatherv, const void* sendbuf, int sendcount, 
   }
   for (int i=0; i<num_neighbors; i++) {
     reqs[num_neighbors+i] = ptr->send(MPI_NBOR_TAG, rank_in_comm, sendbuf, sendcount,
-                                      sendtype, neighbors[i], comm, 0, I_SEND);
+                                      sendtype, neighbors[i], comm, I_SEND);
   }
 
   MPI_Waitall(reqs.size(), reqs.data(), MPI_STATUSES_IGNORE);
@@ -8901,7 +9028,7 @@ AMPI_API_IMPL(int, MPI_Ineighbor_allgatherv, const void* sendbuf, int sendcount,
 
   for (int i=0; i<num_neighbors; i++) {
     newreq->reqs[num_neighbors+i] = ptr->send(MPI_NBOR_TAG, rank_in_comm, sendbuf, sendcount,
-                                              sendtype, neighbors[i], comm, 0, I_SEND);
+                                              sendtype, neighbors[i], comm, I_SEND);
   }
   *request = ptr->postReq(newreq);
 
@@ -9124,7 +9251,7 @@ AMPI_API_IMPL(int, MPI_Intercomm_merge, MPI_Comm intercomm, int high, MPI_Comm *
   first = 0;
 
   if(lrank==0){
-    MPI_Request req = ptr->send(MPI_ATA_TAG, ptr->getRank(), &lhigh, 1, MPI_INT, 0, intercomm, 0, I_SEND);
+    MPI_Request req = ptr->send(MPI_ATA_TAG, ptr->getRank(), &lhigh, 1, MPI_INT, 0, intercomm, I_SEND);
     if(-1==ptr->recv(MPI_ATA_TAG,0,&rhigh,1,MPI_INT,intercomm))
       CkAbort("AMPI> Error in MPI_Intercomm_create");
     MPI_Wait(&req, MPI_STATUS_IGNORE);

--- a/src/libs/ck-libs/ampi/ampi.C
+++ b/src/libs/ck-libs/ampi/ampi.C
@@ -849,6 +849,7 @@ void AMPI_Setup_Switch(void) {
 int AMPI_PE_LOCAL_THRESHOLD = AMPI_PE_LOCAL_THRESHOLD_DEFAULT;
 int AMPI_NODE_LOCAL_THRESHOLD = AMPI_NODE_LOCAL_THRESHOLD_DEFAULT;
 int AMPI_RDMA_THRESHOLD = AMPI_RDMA_THRESHOLD_DEFAULT;
+int AMPI_SSEND_THRESHOLD = AMPI_SSEND_THRESHOLD_DEFAULT;
 
 static bool nodeinit_has_been_called=false;
 CtvDeclare(ampiParent*, ampiPtr);
@@ -947,8 +948,8 @@ static void ampiNodeInit() noexcept
     localThresholdSet = true;
   }
   if (CkMyNode() == 0 && localThresholdSet) {
-#if AMPI_LOCAL_IMPL
-#if CMK_SMP
+#if AMPI_PE_LOCAL_IMPL
+#if AMPI_NODE_LOCAL_IMPL
     CkPrintf("AMPI> PE-local messaging threshold is %d Bytes and Node-local messaging threshold is %d Bytes.\n",
              AMPI_PE_LOCAL_THRESHOLD, AMPI_NODE_LOCAL_THRESHOLD);
 #else
@@ -957,10 +958,10 @@ static void ampiNodeInit() noexcept
     if (AMPI_NODE_LOCAL_THRESHOLD != AMPI_NODE_LOCAL_THRESHOLD_DEFAULT) {
       CkPrintf("Warning: AMPI Node-local messaging threshold ignored on non-SMP build.\n");
     }
-#endif //CMK_SMP
+#endif
 #else
     CkPrintf("Warning: AMPI local messaging threshold ignored since local sends are disabled.\n");
-#endif //AMPI_LOCAL_IMPL
+#endif //AMPI_PE_LOCAL_IMPL
   }
   if ((value = getenv("AMPI_RDMA_THRESHOLD"))) {
     AMPI_RDMA_THRESHOLD = atoi(value);
@@ -970,6 +971,12 @@ static void ampiNodeInit() noexcept
 #else
       CkPrintf("Warning: AMPI RDMA threshold ignored since AMPI RDMA is disabled.\n");
 #endif
+    }
+  }
+  if ((value = getenv("AMPI_SSEND_THRESHOLD"))) {
+    AMPI_SSEND_THRESHOLD = atoi(value);
+    if (CkMyNode() == 0) {
+      CkPrintf("AMPI> Synchronous messaging threshold is %d Bytes.\n", AMPI_SSEND_THRESHOLD);
     }
   }
 
@@ -2932,10 +2939,11 @@ AmpiMsg *ampi::makeBcastMsg(const void *buf,int count,MPI_Datatype type,int root
 //       within, meaning we have to handle that case in ampi::processSsendNcpyShmMsg().
 AmpiMsg *ampi::makeSyncMsg(int t,int sRank,const void *buf,int count,
                            MPI_Datatype type,CProxy_ampi destProxy,
-                           int destIdx, int ssendReq,CMK_REFNUM_TYPE seq) noexcept
+                           int destIdx, int ssendReq,CMK_REFNUM_TYPE seq,
+                           ampi* destPtr) noexcept
 {
   CkAssert(ssendReq >= 0);
-  if (destLikelyWithinProcess(destProxy, destIdx)) {
+  if (destLikelyWithinProcess(destProxy, destIdx, destPtr)) {
     return makeNcpyShmMsg(t, sRank, buf, count, type, ssendReq, seq);
   }
   else {
@@ -3120,56 +3128,16 @@ void ampi::localInorder(char* buf, int size, int seqIdx, CMK_REFNUM_TYPE seq, in
 }
 
 // Call genericRdma inline on the local destination object
-MPI_Request ampi::sendLocalInOrderMsg(int tag, int srcRank, const void* buf, int size, MPI_Datatype type,
-                                      int count, int destRank, MPI_Comm destComm, CMK_REFNUM_TYPE seq,
-                                      ampi* destPtr, AmpiSendType sendType, MPI_Request reqIdx) noexcept
+MPI_Request ampi::sendLocalMsg(int tag, int srcRank, const void* buf, int size, MPI_Datatype type,
+                               int count, int destRank, MPI_Comm destComm, CMK_REFNUM_TYPE seq,
+                               ampi* destPtr, AmpiSendType sendType, MPI_Request reqIdx) noexcept
 {
   int seqIdx = srcRank;
 
-  if (seq == 0 || destPtr->isInOrder(seqIdx, seq)) {
-    IReq* ireq = (IReq*)destPtr->postedReqs.get(tag, srcRank);
-    if (ireq != nullptr) { // Found a matching preposted request in the destination rank's queue
-      MSG_ORDER_DEBUG(
-        CkPrintf("[%d] AMPI vp %d sending local, in-order, matched msg inline to vp %d\n",
-                 CkMyPe(), parent->thisIndex, destPtr->parent->thisIndex);
-      )
-      CkDDT_DataType* sddt = getDDT()->getType(type);
-      if (sddt->isContig()) {
-        destPtr->localInorder((char*)buf, size, seqIdx, seq, tag, srcRank, ireq);
-      }
-      else {
-        // NOTE: Intermediate copy here could be avoided if DDT
-        // could copy directly b/w two non-contiguous datatypes
-        vector<char> sbuf(size);
-        sddt->serialize((char*)buf, sbuf.data(), count, size, PACK); // intermediate copy for noncontig DDTs
-        destPtr->localInorder(sbuf.data(), size, seqIdx, seq, tag, srcRank, ireq);
-      }
-
-      if (reqIdx != MPI_REQUEST_NULL) { // Persistent Send request
-        AmpiRequestList& reqList = getReqs();
-        AmpiRequest& sreq = (*reqList[reqIdx]);
-        CkAssert(sreq.isPersistent());
-        sreq.complete = true;
-        return reqIdx;
-      }
-      else if (sendType == BLOCKING_SEND || sendType == BLOCKING_SSEND) {
-        return MPI_REQUEST_NULL;
-      }
-      else if (sendType == I_SEND || sendType == BLOCKING_SEND) {
-        return postReq(parent->reqPool.newReq<SendReq>(type, destComm, getDDT(), AMPI_REQ_COMPLETED));
-      }
-      else {
-        CkAssert(sendType == I_SSEND);
-        return postReq(parent->reqPool.newReq<SsendReq>(type, destComm, getDDT(), AMPI_REQ_COMPLETED));
-      }
-    }
-  }
-
-  if (size >= AMPI_PE_LOCAL_THRESHOLD ||
-     (sendType == BLOCKING_SSEND || sendType == I_SSEND)) {
+  if (size >= AMPI_PE_LOCAL_THRESHOLD || (sendType == BLOCKING_SSEND || sendType == I_SSEND)) {
     // Block on the matching request to avoid making an intermediate copy
     MSG_ORDER_DEBUG(
-      CkPrintf("[%d] AMPI vp %d sending local, out-of-order/unexpected msg inline using a Sync send from to vp %d\n",
+      CkPrintf("[%d] AMPI vp %d sending local msg inline using a Sync send to vp %d\n",
                CkMyPe(), parent->thisIndex, destPtr->parent->thisIndex);
     )
     if (reqIdx == MPI_REQUEST_NULL) {
@@ -3177,10 +3145,14 @@ MPI_Request ampi::sendLocalInOrderMsg(int tag, int srcRank, const void* buf, int
                                                         (sendType == BLOCKING_SSEND) ?
                                                         AMPI_REQ_BLOCKED : AMPI_REQ_PENDING));
     }
-    destPtr->genericSync(makeSyncMsg(tag, srcRank, buf, count, type, destPtr->thisProxy, destPtr->thisIndex, reqIdx, seq));
+    destPtr->genericSync(makeSyncMsg(tag, srcRank, buf, count, type, destPtr->thisProxy, destPtr->thisIndex, reqIdx, seq, destPtr));
     return reqIdx;
   }
-  else { // SendReq is pre-completed since we directly copied the send buffer
+  else {
+    MSG_ORDER_DEBUG(
+      CkPrintf("[%d] AMPI vp %d sending local msg inline to vp %d\n",
+               CkMyPe(), parent->thisIndex, destPtr->parent->thisIndex);
+    )
     destPtr->generic(makeAmpiMsg(destRank, tag, srcRank, buf, count, type, destComm, seq));
     return MPI_REQUEST_NULL;
   }
@@ -3188,7 +3160,7 @@ MPI_Request ampi::sendLocalInOrderMsg(int tag, int srcRank, const void* buf, int
 
 MPI_Request ampi::sendSyncMsg(int t, int sRank, const void* buf, MPI_Datatype type, int count,
                               int rank, MPI_Comm destcomm, CMK_REFNUM_TYPE seq, CProxy_ampi destProxy,
-                              int destIdx, AmpiSendType sendType, MPI_Request reqIdx) noexcept
+                              int destIdx, AmpiSendType sendType, MPI_Request reqIdx, ampi* destPtr) noexcept
 {
   if (reqIdx == MPI_REQUEST_NULL) {
     reqIdx = postReq(parent->reqPool.newReq<SsendReq>((void*)buf, count, type, rank, t, destcomm, sRank, getDDT(),
@@ -3196,14 +3168,13 @@ MPI_Request ampi::sendSyncMsg(int t, int sRank, const void* buf, MPI_Datatype ty
                                                       AMPI_REQ_BLOCKED : AMPI_REQ_PENDING));
   }
   // All sync messages go thru ampi::genericSync (not generic or genericRdma)
-#if AMPI_LOCAL_IMPL
-  ampi* destPtr = destProxy[destIdx].ckLocal();
+#if AMPI_PE_LOCAL_IMPL
   if (destPtr != NULL) {
-    destPtr->genericSync(makeSyncMsg(t, sRank, buf, count, type, destProxy, destIdx, reqIdx, seq));
+    destPtr->genericSync(makeSyncMsg(t, sRank, buf, count, type, destProxy, destIdx, reqIdx, seq, destPtr));
   } else
 #endif
   {
-    destProxy[destIdx].genericSync(makeSyncMsg(t, sRank, buf, count, type, destProxy, destIdx, reqIdx, seq));
+    destProxy[destIdx].genericSync(makeSyncMsg(t, sRank, buf, count, type, destProxy, destIdx, reqIdx, seq, NULL));
   }
   return reqIdx;
 }
@@ -3225,34 +3196,47 @@ MPI_Request ampi::delesend(int t, int sRank, const void* buf, int count, MPI_Dat
   CMK_REFNUM_TYPE seq = getSeqNo(rank, destcomm, t);
 
   MSG_ORDER_DEBUG(
-    CkPrintf("AMPI vp %d send: tag=%d, src=%d, comm=%d, seq=%d (to %d)\n",parent->thisIndex,t,sRank,destcomm,seq,destIdx);
+    CkPrintf("AMPI vp %d send: tag=%d, src=%d, comm=%d, seq=%d (to %d)\n",
+             parent->thisIndex, t, sRank, destcomm, seq, destIdx);
   )
 
   CkDDT_DataType *ddt = getDDT()->getType(type);
   int size = ddt->getSize(count);
-#if AMPI_LOCAL_IMPL
   ampi *destPtr = arrProxy[destIdx].ckLocal();
+#if AMPI_PE_LOCAL_IMPL
   if (destPtr != nullptr) {
-    return sendLocalInOrderMsg(t, sRank, buf, size, type, count, rank, destcomm, seq, destPtr, sendType, reqIdx);
+    // Complete message inline to PE-local destination VP
+    return sendLocalMsg(t, sRank, buf, size, type, count, rank, destcomm,
+                        seq, destPtr, sendType, reqIdx);
   }
 #endif
   if (
-#if AMPI_LOCAL_IMPL
-      (size >= AMPI_PE_LOCAL_THRESHOLD && destPtr != NULL) ||
-#endif
-#if CMK_SMP
-      (size >= AMPI_NODE_LOCAL_THRESHOLD && destLikelyWithinProcess(arrProxy, destIdx)) ||
+#if AMPI_NODE_LOCAL_IMPL
+      (size >= AMPI_NODE_LOCAL_THRESHOLD && destLikelyWithinProcess(arrProxy, destIdx, destPtr)) ||
 #endif
       (sendType == BLOCKING_SSEND || sendType == I_SSEND))
   {
-    return sendSyncMsg(t, sRank, buf, type, count, rank, destcomm, seq, arrProxy, destIdx, sendType, reqIdx);
+    // Avoid sender- and receiver-side copies via zero copy direct API
+    // (optimized for within-process transfers)
+    return sendSyncMsg(t, sRank, buf, type, count, rank, destcomm,
+                       seq, arrProxy, destIdx, sendType, reqIdx, destPtr);
   }
 #if AMPI_RDMA_IMPL
   if (ddt->isContig() && size >= AMPI_RDMA_THRESHOLD) {
-    return sendRdmaMsg(t, sRank, buf, size, type, destIdx, rank, destcomm, seq, arrProxy, reqIdx);
+    // Avoid sender-side copy via zero copy entry method API
+    return sendRdmaMsg(t, sRank, buf, size, type, destIdx,
+                       rank, destcomm, seq, arrProxy, reqIdx);
   }
 #endif
+  if (size >= AMPI_SSEND_THRESHOLD) {
+    // Avoid sender- and receiver-side copies via zero copy direct API
+    return sendSyncMsg(t, sRank, buf, type, count, rank, destcomm,
+                       seq, arrProxy, destIdx, sendType, reqIdx, destPtr);
+  }
+
+  // Send via normal Charm++ message with copies on both sender- and receiver-sides
   arrProxy[destIdx].generic(makeAmpiMsg(rank, t, sRank, buf, count, type, destcomm, seq));
+
   if (reqIdx != MPI_REQUEST_NULL) { // Persistent send request
     AmpiRequestList& reqList = parent->ampiReqs;
     AmpiRequest& sreq = (*reqList[reqIdx]);
@@ -3340,7 +3324,7 @@ bool ampi::processSsendNcpyShmMsg(AmpiMsg* msg, void* buf, MPI_Datatype type,
     // complete the sender's SsendReq, inline if possible
     int srcIdx = srcInfo.getIdx();
     MPI_Request sreqIdx = msg->getSsendReq();
-#if AMPI_LOCAL_IMPL
+#if AMPI_PE_LOCAL_IMPL
     ampi* srcPtr = thisProxy[srcIdx].ckLocal();
     if (srcPtr != NULL) {
       srcPtr->completedSend(sreqIdx);

--- a/src/libs/ck-libs/ampi/ampi.C
+++ b/src/libs/ck-libs/ampi/ampi.C
@@ -846,9 +846,9 @@ void AMPI_Setup_Switch(void) {
   }
 }
 
-int AMPI_LOCAL_THRESHOLD = AMPI_LOCAL_THRESHOLD_DEFAULT;
+int AMPI_PE_LOCAL_THRESHOLD = AMPI_PE_LOCAL_THRESHOLD_DEFAULT;
+int AMPI_NODE_LOCAL_THRESHOLD = AMPI_NODE_LOCAL_THRESHOLD_DEFAULT;
 int AMPI_RDMA_THRESHOLD = AMPI_RDMA_THRESHOLD_DEFAULT;
-int AMPI_SMP_RDMA_THRESHOLD = AMPI_SMP_RDMA_THRESHOLD_DEFAULT;
 
 static bool nodeinit_has_been_called=false;
 CtvDeclare(ampiParent*, ampiPtr);
@@ -858,6 +858,7 @@ CtvDeclare(bool, ampiFinalized);
 CkpvDeclare(Builtin_kvs, bikvs);
 CkpvDeclare(int, ampiThreadLevel);
 CkpvDeclare(AmpiMsgPool, msgPool);
+CkpvDeclare(int, ssendInfoLen);
 
 CLINKAGE
 long ampiCurrentStackUsage(void){
@@ -937,31 +938,40 @@ static void ampiNodeInit() noexcept
 
   /* read AMPI environment variables */
   char *value;
-  if ((value = getenv("AMPI_LOCAL_THRESHOLD"))) {
-    AMPI_LOCAL_THRESHOLD = atoi(value);
-    if (CkMyNode() == 0) {
-#if AMPI_LOCAL_IMPL
-      CkPrintf("AMPI> local messaging threshold is %d Bytes.\n", AMPI_LOCAL_THRESHOLD);
-#else
-      CkPrintf("Warning: AMPI local messaging threshold ignored since local sends are disabled.\n");
-#endif
-    }
+  bool localThresholdSet = false;
+  if ((value = getenv("AMPI_PE_LOCAL_THRESHOLD"))) {
+    AMPI_PE_LOCAL_THRESHOLD = atoi(value);
+    localThresholdSet = true;
   }
-  bool rdmaSet = false;
+  if ((value = getenv("AMPI_NODE_LOCAL_THRESHOLD"))) {
+    AMPI_NODE_LOCAL_THRESHOLD = atoi(value);
+    localThresholdSet = true;
+  }
+  if (CkMyNode() == 0 && localThresholdSet) {
+#if AMPI_LOCAL_IMPL
+#if CMK_SMP
+    CkPrintf("AMPI> PE-local messaging threshold is %d Bytes and Node-local messaging threshold is %d Bytes.\n",
+             AMPI_PE_LOCAL_THRESHOLD, AMPI_NODE_LOCAL_THRESHOLD);
+#else
+    CkPrintf("AMPI> PE-local messaging threshold is %d Bytes.\n",
+             AMPI_PE_LOCAL_THRESHOLD);
+    if (AMPI_NODE_LOCAL_THRESHOLD != AMPI_NODE_LOCAL_THRESHOLD_DEFAULT) {
+      CkPrintf("Warning: AMPI Node-local messaging threshold ignored on non-SMP build.\n");
+    }
+#endif //CMK_SMP
+#else
+    CkPrintf("Warning: AMPI local messaging threshold ignored since local sends are disabled.\n");
+#endif //AMPI_LOCAL_IMPL
+  }
   if ((value = getenv("AMPI_RDMA_THRESHOLD"))) {
     AMPI_RDMA_THRESHOLD = atoi(value);
-    rdmaSet = true;
-  }
-  if ((value = getenv("AMPI_SMP_RDMA_THRESHOLD"))) {
-    AMPI_SMP_RDMA_THRESHOLD = atoi(value);
-    rdmaSet = true;
-  }
-  if (rdmaSet && CkMyNode() == 0) {
+    if (CkMyNode() == 0) {
 #if AMPI_RDMA_IMPL
-    CkPrintf("AMPI> RDMA threshold is %d Bytes and SMP RDMA threshold is %d Bytes.\n", AMPI_RDMA_THRESHOLD, AMPI_SMP_RDMA_THRESHOLD);
+      CkPrintf("AMPI> RDMA threshold is %d Bytes.\n", AMPI_RDMA_THRESHOLD);
 #else
-    CkPrintf("Warning: AMPI RDMA threshold ignored since AMPI RDMA is disabled.\n");
+      CkPrintf("Warning: AMPI RDMA threshold ignored since AMPI RDMA is disabled.\n");
 #endif
+    }
   }
 
   AmpiReducer = CkReduction::addReducer(AmpiReducerFunc, true /*streamable*/, "AmpiReducerFunc");
@@ -1001,8 +1011,13 @@ static void ampiProcInit() noexcept {
   CkpvInitialize(Builtin_kvs, bikvs); // built-in key-values
   CkpvAccess(bikvs) = Builtin_kvs();
 
-  CkpvInitialize(AmpiMsgPool, msgPool); // pool of small AmpiMsg's
-  CkpvAccess(msgPool) = AmpiMsgPool(AMPI_MSG_POOL_SIZE, AMPI_POOLED_MSG_SIZE);
+  CkpvInitialize(AmpiMsgPool, msgPool); // pool of small AmpiMsg's, big enough for rendezvous messages
+  PUP::sizer pupSizer;
+  SsendInfo srcInfo;
+  pupSizer | srcInfo;
+  CkpvInitialize(int, ssendInfoLen);
+  CkpvAccess(ssendInfoLen) = pupSizer.size();
+  CkpvAccess(msgPool) = AmpiMsgPool(AMPI_MSG_POOL_SIZE, std::max(AMPI_POOLED_MSG_SIZE, CkpvAccess(ssendInfoLen)));
 
 #if AMPIMSGLOG
   char **argv=CkGetArgv();
@@ -2942,15 +2957,18 @@ AmpiMsg *ampi::makeBcastMsg(const void *buf,int count,MPI_Datatype type,int root
   return msg;
 }
 
-// Create an empty AmpiMsg to be matched on the recv side
-AmpiMsg *ampi::makeSyncMsg(int destRank,int t,int sRank,const void *buf,int count, MPI_Datatype type,
-                           MPI_Comm destcomm,int ssendReq,CMK_REFNUM_TYPE seq) noexcept
+// Create a AmpiMsg with a SsendInfo struct as the msg payload
+AmpiMsg *ampi::makeSyncMsg(int destRank,int t,int sRank,const void *buf,int count,
+                           MPI_Datatype type,MPI_Comm destcomm,int ssendReq,CMK_REFNUM_TYPE seq) noexcept
 {
   CkAssert(ssendReq >= 0);
   CkDDT_DataType *ddt = getDDT()->getType(type);
   int len = ddt->getSize(count);
-  AmpiMsg *msg = CkpvAccess(msgPool).newAmpiMsg(seq, ssendReq, t, sRank, 0);
+  SsendInfo srcInfo(thisIndex, count, (char*)buf, ddt);
+  AmpiMsg *msg = CkpvAccess(msgPool).newAmpiMsg(seq, ssendReq, t, sRank, CkpvAccess(ssendInfoLen));
   msg->setLength(len); // set AmpiMsg's length to be that of the real msg payload
+  PUP::toMem pupPacker(msg->getData());
+  pupPacker | srcInfo;
   return msg;
 }
 
@@ -3111,7 +3129,7 @@ MPI_Request ampi::sendLocalMsg(int tag, int srcRank, const void* buf, int size, 
     }
   }
 
-  if (size >= AMPI_LOCAL_THRESHOLD ||
+  if (size >= AMPI_PE_LOCAL_THRESHOLD ||
      (sendType == BLOCKING_SSEND || sendType == I_SSEND)) {
     // Block on the matching request to avoid making an intermediate copy
     MSG_ORDER_DEBUG(
@@ -3181,18 +3199,20 @@ MPI_Request ampi::delesend(int t, int sRank, const void* buf, int count, MPI_Dat
   if (destPtr != nullptr) {
     return sendLocalMsg(t, sRank, buf, size, type, count, rank, destcomm, seq, destPtr, sendType, reqIdx);
   }
-#endif
+#if CMK_SMP
+  if (size >= AMPI_NODE_LOCAL_THRESHOLD && destLikelyWithinProcess(arrProxy, destIdx)) {
+    return sendSyncMsg(t, sRank, buf, type, count, rank, destcomm, seq, arrProxy[destIdx], sendType, reqIdx);
+  }
+#endif //CMK_SMP
+#endif //AMPI_LOCAL_IMPL
   if (sendType == BLOCKING_SSEND || sendType == I_SSEND) {
     return sendSyncMsg(t, sRank, buf, type, count, rank, destcomm, seq, arrProxy[destIdx], sendType, reqIdx);
   }
 #if AMPI_RDMA_IMPL
-  if (ddt->isContig() &&
-      (size >= AMPI_RDMA_THRESHOLD ||
-      (size >= AMPI_SMP_RDMA_THRESHOLD && destLikelyWithinProcess(arrProxy, destIdx))))
-  {
+  if (ddt->isContig() && size >= AMPI_RDMA_THRESHOLD) {
     return sendRdmaMsg(t, sRank, buf, size, type, destIdx, rank, destcomm, seq, arrProxy, reqIdx);
   }
-#endif
+#endif //AMPI_RDMA_IMPL
   arrProxy[destIdx].generic(makeAmpiMsg(rank, t, sRank, buf, count, type, destcomm, seq));
   if (reqIdx != MPI_REQUEST_NULL) { // Persistent send request
     AmpiRequestList& reqList = parent->ampiReqs;
@@ -3216,26 +3236,31 @@ void ampi::requestSsendMsg(AmpiMsg* msg) noexcept
   thisProxy[srcIdx].ssendAck(ssendReq);
 }
 
-bool ampi::processSsendMsg(AmpiMsg* msg, int* msgLen, char** msgData) noexcept {
-  int srcRank = msg->getSrcRank();
-  int srcIdx = getIndexForRank(srcRank);
+bool ampi::processSsendMsg(AmpiMsg* msg, int* msgLen, char** msgData) noexcept
+{
+  SsendInfo srcInfo;
+  PUP::fromMem p(msg->getData());
+  p | srcInfo;
 #if AMPI_LOCAL_IMPL
-  ampi* srcPtr = thisProxy[srcIdx].ckLocal();
-  if (srcPtr != NULL) {
+  if (srcInfo.getNode() == CkMyNode()) {
+    *msgData = srcInfo.getBuf();
+    *msgLen = srcInfo.getDDT()->getSize(srcInfo.getCount());
+    int srcIdx = srcInfo.getIdx();
     MPI_Request sreqIdx = msg->getSsendReq();
-    ampiParent* srcParent = srcPtr->parent;
-    AmpiRequestList& reqs = srcParent->ampiReqs;
-    AmpiRequest& sreq = *(reqs[sreqIdx]);
-    *msgData = (char*)sreq.buf;
-    *msgLen = srcParent->myDDT.getSize(sreq.type) * sreq.count;
     MSG_ORDER_DEBUG(
       CkPrintf("AMPI vp %d in processSsendMsg, src is local so completing Ssend inline (req %d)\n", parent->thisIndex, sreqIdx);
     )
-    srcPtr->completedSend(sreqIdx);
+    ampi* srcPtr = thisProxy[srcIdx].ckLocal();
+    if (srcPtr != NULL) {
+      srcPtr->completedSend(sreqIdx);
+    }
+    else {
+      thisProxy[srcIdx].completedSend(sreqIdx);
+    }
     return true;
   }
   else
-#endif
+#endif //AMPI_LOCAL_IMPL
   {
     requestSsendMsg(msg);
     return false;

--- a/src/libs/ck-libs/ampi/ampi.C
+++ b/src/libs/ck-libs/ampi/ampi.C
@@ -4828,11 +4828,11 @@ void ampi::sendrecv(const void *sbuf, int scount, MPI_Datatype stype, int dest, 
   reqs[1] = send(stag, getRank(), sbuf, scount, stype, dest, comm, I_SEND);
 
   if (sts == MPI_STATUS_IGNORE) {
-    MPI_Waitall(2, reqs, MPI_STATUSES_IGNORE);
+    parent->waitall(2, reqs);
   }
   else {
     MPI_Status statuses[2];
-    MPI_Waitall(2, reqs, statuses);
+    parent->waitall(2, reqs, statuses);
     *sts = statuses[0];
   }
 }
@@ -4881,11 +4881,11 @@ void ampi::sendrecv_replace(void* buf, int count, MPI_Datatype datatype,
   reqs[1] = send(sendtag, getRank(), tmpBuf.data(), count, datatype, dest, comm, I_SEND);
 
   if (status == MPI_STATUS_IGNORE) {
-    MPI_Waitall(2, reqs, MPI_STATUSES_IGNORE);
+    parent->waitall(2, reqs);
   }
   else {
     MPI_Status statuses[2];
-    MPI_Waitall(2, reqs, statuses);
+    parent->waitall(2, reqs, statuses);
     *status = statuses[0];
   }
 }
@@ -6058,7 +6058,7 @@ int SsendReq::wait(ampiParent* disParent, MPI_Status *sts) noexcept {
 }
 
 int ATAReq::wait(ampiParent* parent, MPI_Status *sts) noexcept {
-  MPI_Waitall(reqs.size(), reqs.data(), MPI_STATUSES_IGNORE);
+  parent->waitall(reqs.size(), reqs.data());
   reqs.clear();
   complete = true;
   return 0;
@@ -6143,16 +6143,12 @@ int ampiParent::wait(MPI_Request *request, MPI_Status *sts) noexcept
   return MPI_SUCCESS;
 }
 
-AMPI_API_IMPL(int, MPI_Waitall, int count, MPI_Request request[], MPI_Status sts[])
+int ampiParent::waitall(int count, MPI_Request request[], MPI_Status sts[]/*=MPI_STATUSES_IGNORE*/) noexcept
 {
-  AMPI_API("AMPI_Waitall");
-
-  checkRequests(count, request);
   if (count == 0) return MPI_SUCCESS;
 
-  ampiParent* pptr = getAmpiParent();
-  AmpiRequestList& reqs = pptr->getReqs();
-  CkAssert(pptr->numBlockedReqs == 0);
+  AmpiRequestList& reqs = getReqs();
+  CkAssert(numBlockedReqs == 0);
 
 #if AMPIMSGLOG
   if(msgLogRead){
@@ -6162,9 +6158,9 @@ AMPI_API_IMPL(int, MPI_Waitall, int count, MPI_Request request[], MPI_Status sts
         continue;
       }
       AmpiRequest *waitReq = reqs[request[i]];
-      (*(pptr->fromPUPer))|(pptr->pupBytes);
-      PUParray(*(pptr->fromPUPer), (char *)(waitReq->buf), pptr->pupBytes);
-      PUParray(*(pptr->fromPUPer), (char *)(&sts[i]), sizeof(MPI_Status));
+      (*fromPUPer)|pupBytes;
+      PUParray(*fromPUPer, (char *)(waitReq->buf), pupBytes);
+      PUParray(*fromPUPer, (char *)(&sts[i]), sizeof(MPI_Status));
     }
     return MPI_SUCCESS;
   }
@@ -6182,27 +6178,27 @@ AMPI_API_IMPL(int, MPI_Waitall, int count, MPI_Request request[], MPI_Status sts
     }
     AmpiRequest& req = *reqs[request[i]];
     if (req.test()) {
-      req.wait(pptr, (sts == MPI_STATUSES_IGNORE) ? MPI_STATUS_IGNORE : &sts[i]);
+      req.wait(this, (sts == MPI_STATUSES_IGNORE) ? MPI_STATUS_IGNORE : &sts[i]);
       req.setBlocked(false);
 #if AMPIMSGLOG
-      if(msgLogWrite && record_msglog(pptr->thisIndex)){
-        (pptr->pupBytes) = getDDT()->getSize(req.type) * req.count;
-        (*(pptr->toPUPer))|(pptr->pupBytes);
-        PUParray(*(pptr->toPUPer), (char *)(req.buf), pptr->pupBytes);
-        PUParray(*(pptr->toPUPer), (char *)(&sts[i]), sizeof(MPI_Status));
+      if(msgLogWrite && record_msglog(thisIndex)){
+        pupBytes = getDDT()->getSize(req.type) * req.count;
+        (*toPUPer)|pupBytes;
+        PUParray(*toPUPer, (char *)(req.buf), pupBytes);
+        PUParray(*toPUPer, (char *)(&sts[i]), sizeof(MPI_Status));
       }
 #endif
-      reqs.freeNonPersReq(pptr, request[i]);
+      reqs.freeNonPersReq(this, request[i]);
     }
     else {
       req.setBlocked(true);
-      pptr->numBlockedReqs++;
+      numBlockedReqs++;
     }
   }
 
   // If any requests are incomplete, block until all have been completed
-  if (pptr->numBlockedReqs > 0) {
-    pptr = getAmpiParent()->blockOnRecv();
+  if (numBlockedReqs > 0) {
+    ampiParent* pptr = blockOnRecv();
     reqs = pptr->getReqs(); //update pointer in case of migration while suspended
 
     for (int i=0; i<count; i++) {
@@ -6235,6 +6231,13 @@ AMPI_API_IMPL(int, MPI_Waitall, int count, MPI_Request request[], MPI_Status sts
 #endif
 
   return MPI_SUCCESS;
+}
+
+AMPI_API_IMPL(int, MPI_Waitall, int count, MPI_Request request[], MPI_Status sts[])
+{
+  AMPI_API("AMPI_Waitall");
+  checkRequests(count, request);
+  return getAmpiParent()->waitall(count, request, sts);
 }
 
 AMPI_API_IMPL(int, MPI_Waitany, int count, MPI_Request *request, int *idx, MPI_Status *sts)
@@ -8302,16 +8305,17 @@ AMPI_API_IMPL(int, MPI_Alltoall, const void *sendbuf, int sendcount, MPI_Datatyp
     return ret;
 #endif
 
-  ampi *ptr = getAmpiInstance(comm);
+  ampiParent *pptr = getAmpiParent();
+  ampi *ptr = pptr->comm2ampi(comm);
 
-  if(getAmpiParent()->isInter(comm))
+  if(pptr->isInter(comm))
     CkAbort("AMPI does not implement MPI_Alltoall for Inter-communicators!");
   if(ptr->getSize() == 1)
     return copyDatatype(sendtype,sendcount,recvtype,recvcount,sendbuf,recvbuf);
 
-  int itemsize = getDDT()->getSize(sendtype) * sendcount;
-  int itemextent = getDDT()->getExtent(sendtype) * sendcount;
-  int extent = getDDT()->getExtent(recvtype) * recvcount;
+  int itemsize = pptr->getDDT()->getSize(sendtype) * sendcount;
+  int itemextent = pptr->getDDT()->getExtent(sendtype) * sendcount;
+  int extent = pptr->getDDT()->getExtent(recvtype) * recvcount;
   int size = ptr->getSize();
   int rank = ptr->getRank();
 
@@ -8350,7 +8354,7 @@ AMPI_API_IMPL(int, MPI_Alltoall, const void *sendbuf, int sendcount, MPI_Datatyp
       reqs[size+i] = ptr->send(MPI_ATA_TAG, rank, ((char*)sendbuf)+(itemextent*dst),
                                sendcount, sendtype, dst, comm, I_SEND);
     }
-    MPI_Waitall(reqs.size(), reqs.data(), MPI_STATUSES_IGNORE);
+    pptr->waitall(reqs.size(), reqs.data());
   }
   else if (itemsize <= AMPI_ALLTOALL_LONG_MSG) {
     /* Don't post all sends and recvs at once. Instead do N sends/recvs at a time. */
@@ -8367,7 +8371,7 @@ AMPI_API_IMPL(int, MPI_Alltoall, const void *sendbuf, int sendcount, MPI_Datatyp
         reqs[blockSize+i] = ptr->send(MPI_ATA_TAG, rank, ((char*)sendbuf)+(itemextent*dst),
                                       sendcount, sendtype, dst, comm, I_SEND);
       }
-      MPI_Waitall(blockSize*2, reqs.data(), MPI_STATUSES_IGNORE);
+      pptr->waitall(blockSize*2, reqs.data());
     }
   }
   else {
@@ -8481,7 +8485,8 @@ AMPI_API_IMPL(int, MPI_Alltoallv, const void *sendbuf, const int *sendcounts, co
     return ret;
 #endif
 
-  ampi *ptr = getAmpiInstance(comm);
+  ampiParent *pptr = getAmpiParent();
+  ampi *ptr = pptr->comm2ampi(comm);
   int size = ptr->getSize();
 
   if(getAmpiParent()->isInter(comm))
@@ -8521,7 +8526,7 @@ AMPI_API_IMPL(int, MPI_Alltoallv, const void *sendbuf, const int *sendcounts, co
       reqs[size+i] = ptr->send(MPI_ATA_TAG, rank, ((char*)sendbuf)+(itemextent*sdispls[dst]),
                                sendcounts[dst], sendtype, dst, comm, I_SEND);
     }
-    MPI_Waitall(size*2, reqs.data(), MPI_STATUSES_IGNORE);
+    pptr->waitall(size*2, reqs.data());
   }
   else {
     /* Don't post all sends and recvs at once. Instead do N sends/recvs at a time. */
@@ -8538,7 +8543,7 @@ AMPI_API_IMPL(int, MPI_Alltoallv, const void *sendbuf, const int *sendcounts, co
         reqs[blockSize+i] = ptr->send(MPI_ATA_TAG, rank, ((char*)sendbuf)+(itemextent*sdispls[dst]),
                                       sendcounts[dst], sendtype, dst, comm);
       }
-      MPI_Waitall(blockSize*2, reqs.data(), MPI_STATUSES_IGNORE);
+      getAmpiParent()->waitall(blockSize*2, reqs.data());
     }
   }
 
@@ -8632,11 +8637,12 @@ AMPI_API_IMPL(int, MPI_Alltoallw, const void *sendbuf, const int *sendcounts, co
     return ret;
 #endif
 
-  ampi *ptr = getAmpiInstance(comm);
+  ampiParent *pptr = getAmpiParent();
+  ampi *ptr = pptr->comm2ampi(comm);
   int size = ptr->getSize();
   int rank = ptr->getRank();
 
-  if(getAmpiParent()->isInter(comm))
+  if(pptr->isInter(comm))
     CkAbort("AMPI does not implement MPI_Alltoallw for Inter-communicators!");
   if(size == 1)
     return copyDatatype(sendtypes[0],sendcounts[0],recvtypes[0],recvcounts[0],sendbuf,recvbuf);
@@ -8670,7 +8676,7 @@ AMPI_API_IMPL(int, MPI_Alltoallw, const void *sendbuf, const int *sendcounts, co
       reqs[size+i] = ptr->send(MPI_ATA_TAG, rank, ((char*)sendbuf)+sdispls[dst],
                                sendcounts[dst], sendtypes[dst], dst, comm, I_SEND);
     }
-    MPI_Waitall(size*2, reqs.data(), MPI_STATUSES_IGNORE);
+    pptr->waitall(size*2, reqs.data());
   }
   else {
     /* Don't post all sends and recvs at once. Instead do N sends/recvs at a time. */
@@ -8687,7 +8693,7 @@ AMPI_API_IMPL(int, MPI_Alltoallw, const void *sendbuf, const int *sendcounts, co
         reqs[blockSize+i] = ptr->send(MPI_ATA_TAG, rank, ((char*)sendbuf)+sdispls[dst],
                                       sendcounts[dst], sendtypes[dst], dst, comm);
       }
-      MPI_Waitall(blockSize*2, reqs.data(), MPI_STATUSES_IGNORE);
+      getAmpiParent()->waitall(blockSize*2, reqs.data());
     }
   }
 
@@ -8779,7 +8785,8 @@ AMPI_API_IMPL(int, MPI_Neighbor_alltoall, const void* sendbuf, int sendcount, MP
     return ret;
 #endif
 
-  ampi *ptr = getAmpiInstance(comm);
+  ampiParent *pptr = getAmpiParent();
+  ampi *ptr = pptr->comm2ampi(comm);
   int rank_in_comm = ptr->getRank();
 
   if (ptr->getSize() == 1)
@@ -8801,9 +8808,7 @@ AMPI_API_IMPL(int, MPI_Neighbor_alltoall, const void* sendbuf, int sendcount, MP
                                       sendcount, sendtype, neighbors[i], comm, I_SEND);
   }
 
-  MPI_Waitall(reqs.size(), reqs.data(), MPI_STATUSES_IGNORE);
-
-  return MPI_SUCCESS;
+  return pptr->waitall(reqs.size(), reqs.data());
 }
 
 AMPI_API_IMPL(int, MPI_Ineighbor_alltoall, const void* sendbuf, int sendcount, MPI_Datatype sendtype,
@@ -8884,7 +8889,8 @@ AMPI_API_IMPL(int, MPI_Neighbor_alltoallv, const void* sendbuf, const int *sendc
     return ret;
 #endif
 
-  ampi *ptr = getAmpiInstance(comm);
+  ampiParent *pptr = getAmpiParent();
+  ampi *ptr = pptr->comm2ampi(comm);
   int rank_in_comm = ptr->getRank();
 
   if (ptr->getSize() == 1)
@@ -8906,9 +8912,7 @@ AMPI_API_IMPL(int, MPI_Neighbor_alltoallv, const void* sendbuf, const int *sendc
                                       sendcounts[i], sendtype, neighbors[i], comm, I_SEND);
   }
 
-  MPI_Waitall(reqs.size(), reqs.data(), MPI_STATUSES_IGNORE);
-
-  return MPI_SUCCESS;
+  return pptr->waitall(reqs.size(), reqs.data());
 }
 
 AMPI_API_IMPL(int, MPI_Ineighbor_alltoallv, const void* sendbuf, const int *sendcounts, const int *sdispls,
@@ -8990,7 +8994,8 @@ AMPI_API_IMPL(int, MPI_Neighbor_alltoallw, const void* sendbuf, const int *sendc
     return ret;
 #endif
 
-  ampi *ptr = getAmpiInstance(comm);
+  ampiParent *pptr = getAmpiParent();
+  ampi *ptr = pptr->comm2ampi(comm);
   int rank_in_comm = ptr->getRank();
 
   if (ptr->getSize() == 1)
@@ -9010,9 +9015,7 @@ AMPI_API_IMPL(int, MPI_Neighbor_alltoallw, const void* sendbuf, const int *sendc
                                       sendcounts[i], sendtypes[i], neighbors[i], comm, I_SEND);
   }
 
-  MPI_Waitall(reqs.size(), reqs.data(), MPI_STATUSES_IGNORE);
-
-  return MPI_SUCCESS;
+  return pptr->waitall(reqs.size(), reqs.data());
 }
 
 AMPI_API_IMPL(int, MPI_Ineighbor_alltoallw, const void* sendbuf, const int *sendcounts, const MPI_Aint *sdispls,
@@ -9092,7 +9095,8 @@ AMPI_API_IMPL(int, MPI_Neighbor_allgather, const void* sendbuf, int sendcount, M
     return ret;
 #endif
 
-  ampi *ptr = getAmpiInstance(comm);
+  ampiParent *pptr = getAmpiParent();
+  ampi *ptr = pptr->comm2ampi(comm);
   int rank_in_comm = ptr->getRank();
 
   if (ptr->getSize() == 1)
@@ -9113,9 +9117,7 @@ AMPI_API_IMPL(int, MPI_Neighbor_allgather, const void* sendbuf, int sendcount, M
                                       sendtype, neighbors[i], comm, I_SEND);
   }
 
-  MPI_Waitall(reqs.size(), reqs.data(), MPI_STATUSES_IGNORE);
-
-  return MPI_SUCCESS;
+  return pptr->waitall(reqs.size(), reqs.data());
 }
 
 AMPI_API_IMPL(int, MPI_Ineighbor_allgather, const void* sendbuf, int sendcount, MPI_Datatype sendtype,
@@ -9195,7 +9197,8 @@ AMPI_API_IMPL(int, MPI_Neighbor_allgatherv, const void* sendbuf, int sendcount, 
     return ret;
 #endif
 
-  ampi *ptr = getAmpiInstance(comm);
+  ampiParent *pptr = getAmpiParent();
+  ampi *ptr = pptr->comm2ampi(comm);
   int rank_in_comm = ptr->getRank();
 
   if (ptr->getSize() == 1)
@@ -9214,9 +9217,7 @@ AMPI_API_IMPL(int, MPI_Neighbor_allgatherv, const void* sendbuf, int sendcount, 
                                       sendtype, neighbors[i], comm, I_SEND);
   }
 
-  MPI_Waitall(reqs.size(), reqs.data(), MPI_STATUSES_IGNORE);
-
-  return MPI_SUCCESS;
+  return pptr->waitall(reqs.size(), reqs.data());
 }
 
 AMPI_API_IMPL(int, MPI_Ineighbor_allgatherv, const void* sendbuf, int sendcount, MPI_Datatype sendtype,
@@ -9330,7 +9331,7 @@ AMPI_API_IMPL(int, MPI_Comm_split, MPI_Comm src, int color, int key, MPI_Comm *d
   AMPI_API("AMPI_Comm_split");
   {
     ampiParent *pptr = getAmpiParent();
-    ampi *ptr = getAmpiInstance(src);
+    ampi *ptr = pptr->comm2ampi(src);
     if (pptr->isInter(src)) {
       ptr->split(color, key, dest, MPI_INTER);
     }
@@ -10535,9 +10536,7 @@ AMPI_API_IMPL(int, MPI_Dist_graph_create, MPI_Comm comm_old, int n, const int so
     topo->setDestWeights(tmpWeights);
   }
 
-  MPI_Waitall(sends, requests.data(), MPI_STATUSES_IGNORE);
-
-  return MPI_SUCCESS;
+  return ptr->waitall(sends, requests.data());
 }
 
 AMPI_API_IMPL(int, MPI_Topo_test, MPI_Comm comm, int *status)

--- a/src/libs/ck-libs/ampi/ampi.C
+++ b/src/libs/ck-libs/ampi/ampi.C
@@ -1108,6 +1108,21 @@ static void createCommSelf() noexcept {
   STARTUP_DEBUG("ampiInit> created MPI_COMM_SELF")
 }
 
+// PE-level array object cache, declared in ck.C
+typedef std::unordered_map<CmiUInt8, ArrayElement*> ArrayObjMap;
+CkpvExtern(ArrayObjMap, array_objs);
+
+// We remove objects from array_objs whose performance we don't really care about
+// (TCharm, ampiParent, MPI_COMM_SELF) in order to keep it smaller and faster
+// for those we do care about (MPI_COMM_WORLD and other communicators).
+static void removeUnimportantArrayObjsfromPeCache() noexcept {
+  ampiParent* pptr = getAmpiParent();
+  ArrayObjMap& arrayObjs = CkpvAccess(array_objs);
+  arrayObjs.erase(pptr->getThread()->ckGetID().getID());
+  arrayObjs.erase(pptr->ckGetID().getID());
+  arrayObjs.erase(getAmpiInstance(MPI_COMM_SELF)->ckGetID().getID());
+}
+
 /*
    Called from MPI_Init, a collective initialization call:
    creates a new AMPI array and attaches it to the current
@@ -1198,6 +1213,8 @@ static ampi *ampiInit(char **argv) noexcept
   }
 
   createCommSelf();
+
+  removeUnimportantArrayObjsfromPeCache();
 
 #if CMK_BIGSIM_CHARM
   BgSetStartOutOfCore();
@@ -10747,10 +10764,18 @@ int AMPI_Migrate(MPI_Info hints)
     else if (strncmp(key, "ampi_load_balance", MPI_MAX_INFO_KEY) == 0) {
 
       if (strncmp(value, "sync", MPI_MAX_INFO_VAL) == 0) {
+        int oldPe = CkMyPe();
         TCHARM_Migrate();
+        if (oldPe != CkMyPe()) {
+          removeUnimportantArrayObjsfromPeCache();
+        }
       }
       else if (strncmp(value, "async", MPI_MAX_INFO_VAL) == 0) {
+        int oldPe = CkMyPe();
         TCHARM_Async_Migrate();
+        if (oldPe != CkMyPe()) {
+          removeUnimportantArrayObjsfromPeCache();
+        }
       }
       else if (strncmp(value, "false", MPI_MAX_INFO_VAL) == 0) {
         /* do nothing */

--- a/src/libs/ck-libs/ampi/ampi.C
+++ b/src/libs/ck-libs/ampi/ampi.C
@@ -2359,7 +2359,7 @@ MPI_Comm ampi::cartCreate0D() noexcept {
     tmpVec.push_back(0);
     commCreatePhase1(parent->getNextCart());
     MPI_Comm newComm = parent->getNextCart()-1;
-    ampiCommStruct &newCommStruct = getAmpiParent()->getCart(newComm);
+    ampiCommStruct &newCommStruct = parent->getCart(newComm);
     ampiTopology *newTopo = newCommStruct.getTopology();
     newTopo->setndims(0);
     return newComm;
@@ -2534,7 +2534,7 @@ void ampiParent::intraChildRegister(const ampiCommStruct &s) noexcept {
 
 void ampi::topoDup(int topoType, int rank, MPI_Comm comm, MPI_Comm *newComm) noexcept
 {
-  if (getAmpiParent()->isInter(comm)) {
+  if (parent->isInter(comm)) {
     split(0, rank, newComm, MPI_INTER);
   } else {
     split(0, rank, newComm, topoType);
@@ -2707,18 +2707,17 @@ void ampi::bcastResult(AmpiMsg* msg) noexcept
 
 inline static AmpiRequestList &getReqs() noexcept;
 
-void AmpiRequestList::freeNonPersReq(int &idx) noexcept {
-  ampiParent* pptr = getAmpiParent();
+void AmpiRequestList::freeNonPersReq(ampiParent* pptr, int &idx) noexcept {
   if (!reqs[idx]->isPersistent()) {
-    free(pptr->reqPool, idx, pptr->getDDT());
+    free(idx, pptr->getDDT());
     idx = MPI_REQUEST_NULL;
   }
 }
 
-void AmpiRequestList::free(AmpiRequestPool &reqPool, int idx, CkDDT *ddt) noexcept {
+void AmpiRequestList::free(int idx, CkDDT *ddt) noexcept {
   if (idx < 0) return;
   reqs[idx]->free(ddt);
-  reqPool.deleteReq(reqs[idx]);
+  reqPool->deleteReq(reqs[idx]);
   reqs[idx] = NULL;
   startIdx = std::min(idx, startIdx);
 }
@@ -3029,8 +3028,8 @@ void ampi::waitOnBlockingSend(MPI_Request* req, AmpiSendType sendType) noexcept
   if (*req != MPI_REQUEST_NULL && (sendType == BLOCKING_SEND || sendType == BLOCKING_SSEND)) {
     AmpiRequestList& reqList = getReqs();
     AmpiRequest& sreq = *reqList[*req];
-    sreq.wait(MPI_STATUS_IGNORE);
-    reqList.free(parent->reqPool, *req, parent->getDDT());
+    sreq.wait(parent, MPI_STATUS_IGNORE);
+    getAmpiParent()->getReqs().free(*req, parent->getDDT());
     *req = MPI_REQUEST_NULL;
   }
 }
@@ -3590,7 +3589,7 @@ ampi* ampi::blockOnIReq(void* buf, int count, MPI_Datatype type, int src,
     sts->MPI_LENGTH = req.getNumReceivedBytes(dis->getDDT());
     sts->MPI_CANCEL = 0;
   }
-  reqs.freeNonPersReq(request);
+  reqs.freeNonPersReq(dis->parent, request);
   return dis;
 }
 
@@ -4183,35 +4182,34 @@ inline void checkRequests(int n, MPI_Request* reqs) noexcept {
 #endif
 }
 
-int testRequest(MPI_Request *reqIdx, int *flag, MPI_Status *sts) noexcept {
+int testRequest(ampiParent* pptr, MPI_Request *reqIdx, int *flag, MPI_Status *sts) noexcept {
   if(*reqIdx==MPI_REQUEST_NULL){
     *flag = 1;
     clearStatus(sts);
     return MPI_SUCCESS;
   }
   checkRequest(*reqIdx);
-  ampiParent* pptr = getAmpiParent();
   AmpiRequestList& reqList = pptr->getReqs();
   AmpiRequest& req = *reqList[*reqIdx];
   if(1 == (*flag = req.test())){
-    req.wait(sts);
-    reqList.freeNonPersReq(*reqIdx);
+    req.wait(pptr, sts);
+    reqList.freeNonPersReq(pptr, *reqIdx);
   }
   return MPI_SUCCESS;
 }
 
-int testRequestNoFree(MPI_Request *reqIdx, int *flag, MPI_Status *sts) noexcept {
+int testRequestNoFree(ampiParent* pptr, MPI_Request *reqIdx, int *flag, MPI_Status *sts) noexcept {
   if(*reqIdx==MPI_REQUEST_NULL){
     *flag = 1;
     clearStatus(sts);
     return MPI_SUCCESS;
   }
   checkRequest(*reqIdx);
-  AmpiRequestList& reqList = getReqs();
+  AmpiRequestList& reqList = pptr->getReqs();
   AmpiRequest& req = *reqList[*reqIdx];
   *flag = req.test();
   if(*flag)
-    req.wait(sts);
+    req.wait(pptr, sts);
   return MPI_SUCCESS;
 }
 
@@ -5891,9 +5889,8 @@ void SsendReq::start(MPI_Request reqIdx) noexcept {
   ptr->send(tag, ptr->getRank(), buf, count, type, src /*really, the destination*/, comm, I_SSEND, reqIdx);
 }
 
-int IReq::wait(MPI_Status *sts) noexcept {
+int IReq::wait(ampiParent* parent, MPI_Status *sts) noexcept {
   // ampi::generic() writes directly to the buffer, so the only thing we do here is wait
-  ampiParent *parent = getAmpiParent();
 
   while (!complete) {
     // parent is updated in case an ampi thread is migrated while waiting for a message
@@ -5934,9 +5931,8 @@ int IReq::wait(MPI_Status *sts) noexcept {
   return 0;
 }
 
-int RednReq::wait(MPI_Status *sts) noexcept {
+int RednReq::wait(ampiParent* parent, MPI_Status *sts) noexcept {
   // ampi::irednResult() writes directly to the buffer, so the only thing we do here is wait
-  ampiParent *parent = getAmpiParent();
 
   while (!complete) {
     parent->resumeOnColl = true;
@@ -5966,9 +5962,8 @@ int RednReq::wait(MPI_Status *sts) noexcept {
   return 0;
 }
 
-int GatherReq::wait(MPI_Status *sts) noexcept {
+int GatherReq::wait(ampiParent* parent, MPI_Status *sts) noexcept {
   // ampi::irednResult() writes directly to the buffer, so the only thing we do here is wait
-  ampiParent *parent = getAmpiParent();
 
   while (!complete) {
     parent->resumeOnColl = true;
@@ -5998,9 +5993,8 @@ int GatherReq::wait(MPI_Status *sts) noexcept {
   return 0;
 }
 
-int GathervReq::wait(MPI_Status *sts) noexcept {
+int GathervReq::wait(ampiParent* parent, MPI_Status *sts) noexcept {
   // ampi::irednResult writes directly to the buffer, so the only thing we do here is wait
-  ampiParent *parent = getAmpiParent();
 
   while (!complete) {
     parent->resumeOnColl = true;
@@ -6030,8 +6024,7 @@ int GathervReq::wait(MPI_Status *sts) noexcept {
   return 0;
 }
 
-int SendReq::wait(MPI_Status *sts) noexcept {
-  ampiParent *parent = getAmpiParent();
+int SendReq::wait(ampiParent* parent, MPI_Status *sts) noexcept {
   while (!complete) {
     parent->resumeOnRecv = true;
     parent->numBlockedReqs = 1;
@@ -6048,8 +6041,7 @@ int SendReq::wait(MPI_Status *sts) noexcept {
   return 0;
 }
 
-int SsendReq::wait(MPI_Status *sts) noexcept {
-  ampiParent *disParent = getAmpiParent();
+int SsendReq::wait(ampiParent* disParent, MPI_Status *sts) noexcept {
   while (!complete) {
     disParent->resumeOnRecv = true;
     disParent->numBlockedReqs = 1;
@@ -6065,14 +6057,14 @@ int SsendReq::wait(MPI_Status *sts) noexcept {
   return 0;
 }
 
-int ATAReq::wait(MPI_Status *sts) noexcept {
+int ATAReq::wait(ampiParent* parent, MPI_Status *sts) noexcept {
   MPI_Waitall(reqs.size(), reqs.data(), MPI_STATUSES_IGNORE);
   reqs.clear();
   complete = true;
   return 0;
 }
 
-int GReq::wait(MPI_Status *sts) noexcept {
+int GReq::wait(ampiParent* parent, MPI_Status *sts) noexcept {
   MPI_Status tmpStatus;
   if (pollFn)
     (*pollFn)(extraState, (sts == MPI_STATUS_IGNORE || sts == MPI_STATUSES_IGNORE) ? &tmpStatus : sts);
@@ -6119,7 +6111,7 @@ int ampiParent::wait(MPI_Request *request, MPI_Status *sts) noexcept
   int waitResult = -1;
   do{
     AmpiRequest& waitReq = *reqs[*request];
-    waitResult = waitReq.wait(sts);
+    waitResult = waitReq.wait(pptr, sts);
 #if CMK_BIGSIM_CHARM
     if(_BgInOutOfCoreMode){
       reqs = getReqs();
@@ -6146,7 +6138,7 @@ int ampiParent::wait(MPI_Request *request, MPI_Status *sts) noexcept
   TRACE_BG_AMPI_WAIT(&reqs); // setup forward and backward dependence
 #endif
 
-  reqs.freeNonPersReq(*request);
+  reqs.freeNonPersReq(pptr, *request);
 
   return MPI_SUCCESS;
 }
@@ -6190,7 +6182,7 @@ AMPI_API_IMPL(int, MPI_Waitall, int count, MPI_Request request[], MPI_Status sts
     }
     AmpiRequest& req = *reqs[request[i]];
     if (req.test()) {
-      req.wait((sts == MPI_STATUSES_IGNORE) ? MPI_STATUS_IGNORE : &sts[i]);
+      req.wait(pptr, (sts == MPI_STATUSES_IGNORE) ? MPI_STATUS_IGNORE : &sts[i]);
       req.setBlocked(false);
 #if AMPIMSGLOG
       if(msgLogWrite && record_msglog(pptr->thisIndex)){
@@ -6200,7 +6192,7 @@ AMPI_API_IMPL(int, MPI_Waitall, int count, MPI_Request request[], MPI_Status sts
         PUParray(*(pptr->toPUPer), (char *)(&sts[i]), sizeof(MPI_Status));
       }
 #endif
-      reqs.freeNonPersReq(request[i]);
+      reqs.freeNonPersReq(pptr, request[i]);
     }
     else {
       req.setBlocked(true);
@@ -6222,7 +6214,7 @@ AMPI_API_IMPL(int, MPI_Waitall, int count, MPI_Request request[], MPI_Status sts
       if (!req.test())
         CkAbort("In AMPI_Waitall, all requests should have completed by now!");
 #endif
-      req.wait((sts == MPI_STATUSES_IGNORE) ? MPI_STATUS_IGNORE : &sts[i]);
+      req.wait(pptr, (sts == MPI_STATUSES_IGNORE) ? MPI_STATUS_IGNORE : &sts[i]);
       req.setBlocked(false);
 #if AMPIMSGLOG
       if(msgLogWrite && record_msglog(pptr->thisIndex)){
@@ -6232,7 +6224,7 @@ AMPI_API_IMPL(int, MPI_Waitall, int count, MPI_Request request[], MPI_Status sts
         PUParray(*(pptr->toPUPer), (char *)(&sts[i]), sizeof(MPI_Status));
       }
 #endif
-      reqs.freeNonPersReq(request[i]);
+      reqs.freeNonPersReq(pptr, request[i]);
     }
   }
 
@@ -6268,9 +6260,9 @@ AMPI_API_IMPL(int, MPI_Waitany, int count, MPI_Request *request, int *idx, MPI_S
     }
     AmpiRequest& req = *reqs[request[i]];
     if (req.test()) {
-      req.wait(sts);
+      req.wait(pptr, sts);
       reqs.unblockReqs(&request[0], i);
-      reqs.freeNonPersReq(request[i]);
+      reqs.freeNonPersReq(pptr, request[i]);
       *idx = i;
       CkAssert(pptr->numBlockedReqs == 0);
       return MPI_SUCCESS;
@@ -6297,9 +6289,9 @@ AMPI_API_IMPL(int, MPI_Waitany, int count, MPI_Request *request, int *idx, MPI_S
     }
     AmpiRequest& req = *reqs[request[i]];
     if (req.test()) {
-      req.wait(sts);
+      req.wait(pptr, sts);
       reqs.unblockReqs(&request[i], count-i);
-      reqs.freeNonPersReq(request[i]);
+      reqs.freeNonPersReq(pptr, request[i]);
       *idx = i;
       CkAssert(pptr->numBlockedReqs == 0);
       return MPI_SUCCESS;
@@ -6339,12 +6331,12 @@ AMPI_API_IMPL(int, MPI_Waitsome, int incount, MPI_Request *array_of_requests, in
     }
     AmpiRequest& req = *reqs[array_of_requests[i]];
     if (req.test()) {
-      req.wait(&sts);
+      req.wait(pptr, &sts);
       array_of_indices[(*outcount)] = i;
       (*outcount)++;
       if (array_of_statuses != MPI_STATUSES_IGNORE)
         array_of_statuses[(*outcount)] = sts;
-      reqs.freeNonPersReq(array_of_requests[i]);
+      reqs.freeNonPersReq(pptr, array_of_requests[i]);
     }
     else {
       req.setBlocked(true);
@@ -6372,13 +6364,13 @@ AMPI_API_IMPL(int, MPI_Waitsome, int incount, MPI_Request *array_of_requests, in
       }
       AmpiRequest& req = *reqs[array_of_requests[i]];
       if (req.test()) {
-        req.wait(&sts);
+        req.wait(pptr, &sts);
         array_of_indices[(*outcount)] = i;
         (*outcount)++;
         if (array_of_statuses != MPI_STATUSES_IGNORE)
           array_of_statuses[(*outcount)] = sts;
         reqs.unblockReqs(&array_of_requests[i], incount-i);
-        reqs.freeNonPersReq(array_of_requests[i]);
+        reqs.freeNonPersReq(pptr, array_of_requests[i]);
         CkAssert(pptr->numBlockedReqs == 0);
         return MPI_SUCCESS;
       }
@@ -6442,7 +6434,8 @@ bool GReq::test(MPI_Status *sts/*=MPI_STATUS_IGNORE*/) noexcept {
 }
 
 bool ATAReq::test(MPI_Status *sts/*=MPI_STATUS_IGNORE*/) noexcept {
-  AmpiRequestList& reqList = getReqs();
+  ampiParent* pptr = getAmpiParent();
+  AmpiRequestList& reqList = pptr->getReqs();
   int i = 0;
   while (i < reqs.size()) {
     if (reqs[i] == MPI_REQUEST_NULL) {
@@ -6452,8 +6445,8 @@ bool ATAReq::test(MPI_Status *sts/*=MPI_STATUS_IGNORE*/) noexcept {
     }
     AmpiRequest& req = *reqList[reqs[i]];
     if (req.test()) {
-      req.wait(sts);
-      reqList.freeNonPersReq(reqs[i]);
+      req.wait(pptr, sts);
+      reqList.freeNonPersReq(pptr, reqs[i]);
       std::swap(reqs[i], reqs.back());
       reqs.pop_back();
       continue;
@@ -6540,18 +6533,20 @@ void GathervReq::receive(ampi *ptr, CkReductionMsg *msg) noexcept
 AMPI_API_IMPL(int, MPI_Request_get_status, MPI_Request request, int *flag, MPI_Status *sts)
 {
   AMPI_API("AMPI_Request_get_status");
-  testRequestNoFree(&request, flag, sts);
+  ampiParent* pptr = getAmpiParent();
+  testRequestNoFree(pptr, &request, flag, sts);
   if(*flag != 1)
-    ampiParent* unused = getAmpiParent()->yield();
+    pptr = pptr->yield();
   return MPI_SUCCESS;
 }
 
 AMPI_API_IMPL(int, MPI_Test, MPI_Request *request, int *flag, MPI_Status *sts)
 {
   AMPI_API("AMPI_Test");
-  testRequest(request, flag, sts);
+  ampiParent* pptr = getAmpiParent();
+  testRequest(pptr, request, flag, sts);
   if(*flag != 1)
-    ampiParent* unused = getAmpiParent()->yield();
+    pptr = pptr->yield();
   return MPI_SUCCESS;
 }
 
@@ -6568,6 +6563,7 @@ AMPI_API_IMPL(int, MPI_Testany, int count, MPI_Request *request, int *index, int
     return MPI_SUCCESS;
   }
 
+  ampiParent* pptr = getAmpiParent();
   int nullReqs = 0;
   *flag = 0;
 
@@ -6576,7 +6572,7 @@ AMPI_API_IMPL(int, MPI_Testany, int count, MPI_Request *request, int *index, int
       nullReqs++;
       continue;
     }
-    testRequest(&request[i], flag, sts);
+    testRequest(pptr, &request[i], flag, sts);
     if (*flag) {
       *index = i;
       return MPI_SUCCESS;
@@ -6589,7 +6585,7 @@ AMPI_API_IMPL(int, MPI_Testany, int count, MPI_Request *request, int *index, int
     clearStatus(sts);
   }
   else {
-    ampiParent* unused = getAmpiParent()->yield();
+    pptr = pptr->yield();
   }
 
   return MPI_SUCCESS;
@@ -6628,8 +6624,8 @@ AMPI_API_IMPL(int, MPI_Testall, int count, MPI_Request *request, int *flag, MPI_
       int reqIdx = request[i];
       if (reqIdx != MPI_REQUEST_NULL) {
         AmpiRequest& req = *reqs[reqIdx];
-        req.wait((sts == MPI_STATUSES_IGNORE) ? MPI_STATUS_IGNORE : &sts[i]);
-        reqs.freeNonPersReq(request[i]);
+        req.wait(pptr, (sts == MPI_STATUSES_IGNORE) ? MPI_STATUS_IGNORE : &sts[i]);
+        reqs.freeNonPersReq(pptr, request[i]);
       }
     }
   }
@@ -6648,6 +6644,7 @@ AMPI_API_IMPL(int, MPI_Testsome, int incount, MPI_Request *array_of_requests, in
     return MPI_SUCCESS;
   }
 
+  ampiParent* pptr = getAmpiParent();
   MPI_Status sts;
   int flag = 0, nullReqs = 0;
   *outcount = 0;
@@ -6658,7 +6655,7 @@ AMPI_API_IMPL(int, MPI_Testsome, int incount, MPI_Request *array_of_requests, in
       nullReqs++;
       continue;
     }
-    testRequest(&array_of_requests[i], &flag, &sts);
+    testRequest(pptr, &array_of_requests[i], &flag, &sts);
     if (flag) {
       array_of_indices[(*outcount)] = i;
       (*outcount)++;
@@ -6671,7 +6668,7 @@ AMPI_API_IMPL(int, MPI_Testsome, int incount, MPI_Request *array_of_requests, in
     *outcount = MPI_UNDEFINED;
   }
   else if (*outcount == 0) {
-    ampiParent* unused = getAmpiParent()->yield();
+    pptr = pptr->yield();
   }
 
   return MPI_SUCCESS;
@@ -6684,7 +6681,7 @@ AMPI_API_IMPL(int, MPI_Request_free, MPI_Request *request)
   checkRequest(*request);
   ampiParent* pptr = getAmpiParent();
   AmpiRequestList& reqs = pptr->getReqs();
-  reqs.free(pptr->reqPool, *request, pptr->getDDT());
+  reqs.free(*request, pptr->getDDT());
   *request = MPI_REQUEST_NULL;
   return MPI_SUCCESS;
 }
@@ -9332,14 +9329,15 @@ AMPI_API_IMPL(int, MPI_Comm_split, MPI_Comm src, int color, int key, MPI_Comm *d
 {
   AMPI_API("AMPI_Comm_split");
   {
+    ampiParent *pptr = getAmpiParent();
     ampi *ptr = getAmpiInstance(src);
-    if (getAmpiParent()->isInter(src)) {
+    if (pptr->isInter(src)) {
       ptr->split(color, key, dest, MPI_INTER);
     }
-    else if (getAmpiParent()->isCart(src)) {
+    else if (pptr->isCart(src)) {
       ptr->split(color, key, dest, MPI_CART);
     }
-    else if (getAmpiParent()->isGraph(src)) {
+    else if (pptr->isGraph(src)) {
       ptr->split(color, key, dest, MPI_GRAPH);
     }
     else if (getAmpiParent()->isDistGraph(src)) {
@@ -9352,7 +9350,6 @@ AMPI_API_IMPL(int, MPI_Comm_split, MPI_Comm src, int color, int key, MPI_Comm *d
   if (color == MPI_UNDEFINED) *dest = MPI_COMM_NULL;
 
 #if AMPIMSGLOG
-  ampiParent* pptr = getAmpiParent();
   if(msgLogRead){
     PUParray(*(pptr->fromPUPer), (char *)dest, sizeof(int));
     return MPI_SUCCESS;

--- a/src/libs/ck-libs/ampi/ampi.C
+++ b/src/libs/ck-libs/ampi/ampi.C
@@ -859,6 +859,7 @@ CtvDeclare(bool, ampiFinalized);
 CkpvDeclare(Builtin_kvs, bikvs);
 CkpvDeclare(int, ampiThreadLevel);
 CkpvDeclare(AmpiMsgPool, msgPool);
+CkpvDeclare(CkNcpyBufferPool, ncpyBufferPool);
 
 CLINKAGE
 long ampiCurrentStackUsage(void){
@@ -1016,6 +1017,9 @@ static void ampiProcInit() noexcept {
 
   CkpvInitialize(Builtin_kvs, bikvs); // built-in key-values
   CkpvAccess(bikvs) = Builtin_kvs();
+
+  CkpvInitialize(CkNcpyBufferPool, ncpyBufferPool);  // pool of CkNcpySource objects
+  CkpvAccess(ncpyBufferPool) = CkNcpyBufferPool(64);
 
   CkpvInitialize(AmpiMsgPool, msgPool); // pool of small AmpiMsg's, big enough for rendezvous messages
   CkpvAccess(msgPool) = AmpiMsgPool(AMPI_MSG_POOL_SIZE, AMPI_POOLED_MSG_SIZE);
@@ -2984,7 +2988,7 @@ AmpiMsg* ampi::makeNcpyMsg(int t, int sRank, const void* buf, int count,
   SsendReq& req = *((SsendReq*)(getReqs()[ssendReq]));
 
   if (ddt->isContig()) {
-    req.srcInfo = new CkNcpyBuffer(buf, len, sendCB);
+    req.srcInfo = CkpvAccess(ncpyBufferPool).newCkNcpyBuffer(buf, len, sendCB);
   }
   else {
     // NOTE: if DDT could provide us with a list of pointers to contiguous chunks
@@ -2992,7 +2996,7 @@ AmpiMsg* ampi::makeNcpyMsg(int t, int sRank, const void* buf, int count,
     //       now we just copy into a contiguous system buffer and then send that.
     char* sbuf = new char[len];
     ddt->serialize((char*)buf, sbuf, count, len, PACK);
-    req.srcInfo = new CkNcpyBuffer(sbuf, len, sendCB);
+    req.srcInfo = CkpvAccess(ncpyBufferPool).newCkNcpyBuffer(sbuf, len, sendCB);
     req.setSystemBuf(sbuf); // completedSend will need to free this
     // NOTE: We could set 'req.complete = true' here, but then we'd
     //       have to make sure req.systemBuf gets freed by someone else
@@ -3260,13 +3264,13 @@ void ampi::requestPut(MPI_Request reqIdx, CkNcpyBuffer targetInfo) noexcept {
   sendCB.setRefnum(reqIdx);
 
   if (sddt->isContig()) {
-    req.srcInfo = new CkNcpyBuffer(req.buf, req.count, sendCB);
+    req.srcInfo = CkpvAccess(ncpyBufferPool).newCkNcpyBuffer(req.buf, req.count, sendCB);
   }
   else {
     int len = sddt->getSize(req.count);
     char* sbuf = new char[len];
     sddt->serialize((char*)req.buf, sbuf, req.count, len, PACK);
-    req.srcInfo = new CkNcpyBuffer(sbuf, len, sendCB);
+    req.srcInfo = CkpvAccess(ncpyBufferPool).newCkNcpyBuffer(sbuf, len, sendCB);
     req.setSystemBuf(sbuf); // completedSend will need to free this
     // NOTE: We could set 'req.statusIreq = true' here, but then we'd
     // have to make sure systemBuf gets freed by someone in case the
@@ -3350,7 +3354,7 @@ bool ampi::processSsendNcpyShmMsg(AmpiMsg* msg, void* buf, MPI_Datatype type,
     IReq& ireq = *((IReq*)(parent->ampiReqs[req]));
 
     if (rddt->isContig()) {
-      ireq.targetInfo = new CkNcpyBuffer(buf, len, recvCB);
+      ireq.targetInfo = CkpvAccess(ncpyBufferPool).newCkNcpyBuffer(buf, len, recvCB);
     }
     else {
       // Allocate a contiguous intermediate buffer for the put(),
@@ -3358,7 +3362,7 @@ bool ampi::processSsendNcpyShmMsg(AmpiMsg* msg, void* buf, MPI_Datatype type,
       int slen = srcInfo.getLength();
       char* sbuf = new char[slen];
       ireq.setSystemBuf(sbuf, slen); // completedRecv will need to free this
-      ireq.targetInfo = new CkNcpyBuffer(sbuf, slen, recvCB);
+      ireq.targetInfo = CkpvAccess(ncpyBufferPool).newCkNcpyBuffer(sbuf, slen, recvCB);
     }
     thisProxy[srcInfo.getIdx()].requestPut(srcInfo.getSreqIdx(), *ireq.targetInfo);
     return false;
@@ -3380,12 +3384,12 @@ bool ampi::processSsendNcpyMsg(AmpiMsg* msg, void* buf, MPI_Datatype type, int c
   ireq.length = len;
 
   if (ddt->isContig()) {
-    ireq.targetInfo = new CkNcpyBuffer(buf, len, recvCB);
+    ireq.targetInfo = CkpvAccess(ncpyBufferPool).newCkNcpyBuffer(buf, len, recvCB);
   }
   else {
     char* sbuf = new char[len];
     ireq.setSystemBuf(sbuf);
-    ireq.targetInfo = new CkNcpyBuffer(sbuf, len, recvCB);
+    ireq.targetInfo = CkpvAccess(ncpyBufferPool).newCkNcpyBuffer(sbuf, len, recvCB);
   }
   ireq.targetInfo->get(srcInfo);
   return ireq.complete; // did the get() complete inline (i.e. src is in same process as target)?
@@ -4397,6 +4401,7 @@ void AMPI_Exit(int exitCode)
   // If we are not actually running AMPI code (e.g., by compiling a serial
   // application with ampicc), exit cleanly when the application calls exit().
   AMPI_API_INIT("AMPI_Exit");
+  CkpvAccess(ncpyBufferPool).clear();
   CkpvAccess(msgPool).clear();
 
   if (!atexit_called)

--- a/src/libs/ck-libs/ampi/ampi.C
+++ b/src/libs/ck-libs/ampi/ampi.C
@@ -1193,14 +1193,8 @@ static ampi *ampiInit(char **argv) noexcept
   CkCallback cb(CkReductionTarget(ampi, allInitDone), cbproxy[0]);
   ptr->contribute(cb);
 
-  ampiParent *thisParent = getAmpiParent();
-  while(thisParent->ampiInitCallDone!=1){
-    thisParent->getTCharmThread()->stop();
-    /*
-     * thisParent needs to be updated in case of the parent is being pupped.
-     * In such case, thisParent got changed
-     */
-    thisParent = getAmpiParent();
+  while (pptr->ampiInitCallDone != 1) {
+    pptr = pptr->block();
   }
 
   createCommSelf();
@@ -1544,7 +1538,7 @@ void ampiParent::startCheckpoint(const char* dname) noexcept {
   }
   contribute();
 
-  thread->stop();
+  ampiParent* unused = block();
 
 #if CMK_BIGSIM_CHARM
   TRACE_BG_ADD_TAG("CHECKPOINT_RESUME");
@@ -2097,8 +2091,8 @@ void ampi::split(int color,int key,MPI_Comm *dest, int type) noexcept
     CkCallback cb(CkIndex_ampi::splitPhase1(0),CkArrayIndex1D(rootIdx),myComm.getProxy());
     contribute(sizeof(splitKey),&splitKey,CkReduction::concat,cb);
 
-    thread->suspend(); //Resumed by ampiParent::cartChildRegister
-    MPI_Comm newComm=parent->getNextCart()-1;
+    ampi * dis = block(); //Resumed by ampiParent::cartChildRegister
+    MPI_Comm newComm = dis->parent->getNextCart()-1;
     *dest=newComm;
   }
   else if (type == MPI_GRAPH) {
@@ -2107,8 +2101,8 @@ void ampi::split(int color,int key,MPI_Comm *dest, int type) noexcept
     CkCallback cb(CkIndex_ampi::splitPhase1(0),CkArrayIndex1D(rootIdx),myComm.getProxy());
     contribute(sizeof(splitKey),&splitKey,CkReduction::concat,cb);
 
-    thread->suspend(); //Resumed by ampiParent::graphChildRegister
-    MPI_Comm newComm=parent->getNextGraph()-1;
+    ampi * dis = block(); //Resumed by ampiParent::graphChildRegister
+    MPI_Comm newComm = dis->parent->getNextGraph()-1;
     *dest=newComm;
   }
   else if (type == MPI_DIST_GRAPH) {
@@ -2117,8 +2111,8 @@ void ampi::split(int color,int key,MPI_Comm *dest, int type) noexcept
     CkCallback cb(CkIndex_ampi::splitPhase1(0),CkArrayIndex1D(rootIdx),myComm.getProxy());
     contribute(sizeof(splitKey),&splitKey,CkReduction::concat,cb);
 
-    thread->suspend(); //Resumed by ampiParent::distGraphChildRegister
-    MPI_Comm newComm=parent->getNextDistGraph()-1;
+    ampi * dis = block(); //Resumed by ampiParent::distGraphChildRegister
+    MPI_Comm newComm = dis->parent->getNextDistGraph()-1;
     *dest=newComm;
   }
   else if (type == MPI_INTER) {
@@ -2127,8 +2121,8 @@ void ampi::split(int color,int key,MPI_Comm *dest, int type) noexcept
     CkCallback cb(CkIndex_ampi::splitPhaseInter(0),CkArrayIndex1D(rootIdx),myComm.getProxy());
     contribute(sizeof(splitKey),&splitKey,CkReduction::concat,cb);
 
-    thread->suspend(); //Resumed by ampiParent::interChildRegister
-    MPI_Comm newComm=parent->getNextInter()-1;
+    ampi * dis = block(); //Resumed by ampiParent::interChildRegister
+    MPI_Comm newComm = dis->parent->getNextInter()-1;
     *dest=newComm;
   }
   else {
@@ -2137,8 +2131,8 @@ void ampi::split(int color,int key,MPI_Comm *dest, int type) noexcept
     CkCallback cb(CkIndex_ampi::splitPhase1(0),CkArrayIndex1D(rootIdx),myComm.getProxy());
     contribute(sizeof(splitKey),&splitKey,CkReduction::concat,cb);
 
-    thread->suspend(); //Resumed by ampiParent::splitChildRegister
-    MPI_Comm newComm=parent->getNextSplit()-1;
+    ampi * dis = block(); //Resumed by ampiParent::splitChildRegister
+    MPI_Comm newComm = dis->parent->getNextSplit()-1;
     *dest=newComm;
   }
 #if CMK_BIGSIM_CHARM
@@ -2291,8 +2285,8 @@ void ampi::commCreate(const vector<int>& vec,MPI_Comm* newcomm) noexcept {
   contribute(sizeof(nextgroup), &nextgroup,CkReduction::max_int,cb);
 
   if(getPosOp(thisIndex,vec)>=0){
-    thread->suspend(); //Resumed by ampiParent::groupChildRegister
-    MPI_Comm retcomm = parent->getNextGroup()-1;
+    ampi * dis = block(); //Resumed by ampiParent::groupChildRegister
+    MPI_Comm retcomm = dis->parent->getNextGroup()-1;
     *newcomm = retcomm;
   }else{
     *newcomm = MPI_COMM_NULL;
@@ -2359,8 +2353,8 @@ MPI_Comm ampi::cartCreate(vector<int>& vec, int ndims, const int* dims) noexcept
   contribute(sizeof(nextcart), &nextcart,CkReduction::max_int,cb);
 
   if (getPosOp(thisIndex,vec)>=0) {
-    thread->suspend(); //Resumed by ampiParent::cartChildRegister
-    return parent->getNextCart()-1;
+    ampi * dis = block(); //Resumed by ampiParent::cartChildRegister
+    return dis->parent->getNextCart()-1;
   } else {
     return MPI_COMM_NULL;
   }
@@ -2385,7 +2379,7 @@ void ampi::graphCreate(const vector<int>& vec,MPI_Comm* newcomm) noexcept {
   contribute(sizeof(nextgraph), &nextgraph,CkReduction::max_int,cb);
 
   if(getPosOp(thisIndex,vec)>=0){
-    thread->suspend(); //Resumed by ampiParent::graphChildRegister
+    ampi * dis = block(); //Resumed by ampiParent::graphChildRegister
     MPI_Comm retcomm = parent->getNextGraph()-1;
     *newcomm = retcomm;
   }else
@@ -2411,8 +2405,8 @@ void ampi::distGraphCreate(const vector<int>& vec, MPI_Comm* newcomm) noexcept
   contribute(sizeof(nextDistGraph), &nextDistGraph, CkReduction::max_int, cb);
 
   if (getPosOp(thisIndex,vec) >= 0) {
-    thread->suspend(); //Resumed by ampiParent::distGraphChildRegister
-    MPI_Comm retcomm = parent->getNextDistGraph()-1;
+    ampi * dis = block(); //Resumed by ampiParent::distGraphChildRegister
+    MPI_Comm retcomm = dis->parent->getNextDistGraph()-1;
     *newcomm = retcomm;
   }
   else {
@@ -2438,8 +2432,8 @@ void ampi::intercommCreate(const vector<int>& remoteVec, const int root, MPI_Com
   CkCallback cb(CkReductionTarget(ampi, intercommCreatePhase1),CkArrayIndex1D(root),myComm.getProxy());
   MPI_Comm nextinter = parent->getNextInter();
   contribute(sizeof(nextinter), &nextinter,CkReduction::max_int,cb);
-  thread->suspend(); //Not resumed by ampiParent::interChildRegister. Resumed by ExchangeProxy.
-  *ncomm = parent->getNextInter()-1;
+  ampi * dis = block(); //Not resumed by ampiParent::interChildRegister. Resumed by ExchangeProxy.
+  *ncomm = dis->parent->getNextInter()-1;
 }
 
 void ampi::intercommCreatePhase1(MPI_Comm nextInterComm) noexcept {
@@ -2481,8 +2475,8 @@ void ampi::intercommMerge(int first, MPI_Comm *ncomm) noexcept { // first valid 
   MPI_Comm nextintra = parent->getNextIntra();
   contribute(sizeof(nextintra), &nextintra,CkReduction::max_int,cb);
 
-  thread->suspend(); //Resumed by ampiParent::interChildRegister
-  MPI_Comm newcomm=parent->getNextIntra()-1;
+  ampi * dis = block(); //Resumed by ampiParent::interChildRegister
+  MPI_Comm newcomm = dis->parent->getNextIntra()-1;
   *ncomm=newcomm;
 }
 
@@ -2507,18 +2501,20 @@ void ampi::topoDup(int topoType, int rank, MPI_Comm comm, MPI_Comm *newComm) noe
   } else {
     split(0, rank, newComm, topoType);
 
+    ampiParent * disParent = getAmpiParent();
+
     if (topoType != MPI_UNDEFINED) {
       ampiTopology *topo, *newTopo;
       if (topoType == MPI_CART) {
-        topo = getAmpiParent()->getCart(comm).getTopology();
-        newTopo = getAmpiParent()->getCart(*newComm).getTopology();
+        topo = disParent->getCart(comm).getTopology();
+        newTopo = disParent->getCart(*newComm).getTopology();
       } else if (topoType == MPI_GRAPH) {
-        topo = getAmpiParent()->getGraph(comm).getTopology();
-        newTopo = getAmpiParent()->getGraph(*newComm).getTopology();
+        topo = disParent->getGraph(comm).getTopology();
+        newTopo = disParent->getGraph(*newComm).getTopology();
       } else {
         CkAssert(topoType == MPI_DIST_GRAPH);
-        topo = getAmpiParent()->getDistGraph(comm).getTopology();
-        newTopo = getAmpiParent()->getDistGraph(*newComm).getTopology();
+        topo = disParent->getDistGraph(comm).getTopology();
+        newTopo = disParent->getDistGraph(*newComm).getTopology();
       }
       newTopo->dup(topo);
     }
@@ -2538,37 +2534,29 @@ const ampiCommStruct &universeComm2CommStruct(MPI_Comm universeNo) noexcept
   return mpi_worlds[0]; // meaningless return
 }
 
-void ampiParent::block() noexcept {
-  thread->suspend();
+CMI_WARN_UNUSED_RESULT ampiParent* ampiParent::block() noexcept {
+  TCharm * disThread = thread->suspend();
+  ampiParent* disParent = getAmpiParent();
+  disParent->thread = disThread;
+  return disParent;
+}
+CMI_WARN_UNUSED_RESULT ampiParent* ampiParent::yield() noexcept {
+  TCharm * disThread = thread->schedule();
+  ampiParent* disParent = getAmpiParent();
+  disParent->thread = disThread;
+  return disParent;
 }
 
-void ampiParent::yield() noexcept {
-  thread->schedule();
-}
-
-void ampi::unblock() noexcept {
-  thread->resume();
-}
-
-ampiParent* ampiParent::blockOnRecv() noexcept {
+CMI_WARN_UNUSED_RESULT ampiParent* ampiParent::blockOnRecv() noexcept {
   resumeOnRecv = true;
-  // In case this thread is migrated while suspended,
-  // save myComm to get the ampi instance back. Then
-  // return "dis" in case the caller needs it.
-  thread->suspend();
-  ampiParent* dis = getAmpiParent();
-  dis->resumeOnRecv = false;
-  return dis;
+  ampiParent* disParent = block();
+  disParent->resumeOnRecv = false;
+  return disParent;
 }
 
-ampi* ampi::blockOnRecv() noexcept {
+CMI_WARN_UNUSED_RESULT ampi* ampi::blockOnRecv() noexcept {
   parent->resumeOnRecv = true;
-  // In case this thread is migrated while suspended,
-  // save myComm to get the ampi instance back. Then
-  // return "dis" in case the caller needs it.
-  MPI_Comm comm = myComm.getComm();
-  thread->suspend();
-  ampi *dis = getAmpiInstance(comm);
+  ampi *dis = block();
   dis->parent->resumeOnRecv = false;
   return dis;
 }
@@ -2581,7 +2569,7 @@ void ampi::setBlockingReq(AmpiRequest *req) noexcept {
 }
 
 // block on (All)Reduce or (All)Gather(v)
-ampi* ampi::blockOnColl() noexcept {
+CMI_WARN_UNUSED_RESULT ampi* ampi::static_blockOnColl(ampi *dis) noexcept {
 #if CMK_BIGSIM_CHARM
   void *curLog; // store current log in timeline
   _TRACE_BG_TLINE_END(&curLog);
@@ -2590,10 +2578,8 @@ ampi* ampi::blockOnColl() noexcept {
 #endif
 #endif
 
-  CkAssert(parent->resumeOnColl == true);
-  MPI_Comm comm = myComm.getComm();
-  thread->suspend();
-  ampi *dis = getAmpiInstance(comm);
+  CkAssert(dis->parent->resumeOnColl == true);
+  dis = dis->block();
   dis->parent->resumeOnColl = false;
 
 #if (defined(_FAULT_MLOG_) || defined(_FAULT_CAUSAL_))
@@ -2905,7 +2891,7 @@ MPI_Request ampi::send(int t, int sRank, const void* buf, int count, MPI_Datatyp
   if (ssendReq == 1) {
     // waiting for receiver side
     parent->resumeOnRecv = false;            // so no one else awakes it
-    parent->block();
+    parent = parent->block();
   }
 
   return req;
@@ -3208,9 +3194,9 @@ static inline bool handle_MPI_PROC_NULL(int src, MPI_Comm comm, MPI_Status* sts)
   return false;
 }
 
-int ampi::recv(int t, int s, void* buf, int count, MPI_Datatype type, MPI_Comm comm, MPI_Status *sts) noexcept
+int ampi::static_recv(ampi *dis, int t, int s, void* buf, int count, MPI_Datatype type, MPI_Comm comm, MPI_Status *sts) noexcept
 {
-  MPI_Comm disComm = myComm.getComm();
+  MPI_Comm disComm = dis->myComm.getComm();
   if (handle_MPI_PROC_NULL(s, disComm, sts)) return 0;
 
 #if CMK_BIGSIM_CHARM
@@ -3221,17 +3207,16 @@ int ampi::recv(int t, int s, void* buf, int count, MPI_Datatype type, MPI_Comm c
 #endif
 #endif
 
-  if (isInter()) {
-    s = myComm.getIndexForRemoteRank(s);
+  if (dis->isInter()) {
+    s = dis->myComm.getIndexForRemoteRank(s);
   }
 
   MSG_ORDER_DEBUG(
-    CkPrintf("AMPI vp %d blocking recv: tag=%d, src=%d, comm=%d\n",thisIndex,t,s,comm);
+    CkPrintf("AMPI vp %d blocking recv: tag=%d, src=%d, comm=%d\n",dis->thisIndex,t,s,comm);
   )
 
-  ampi *dis = getAmpiInstance(disComm);
   MPI_Status tmpStatus;
-  AmpiMsg* msg = unexpectedMsgs.get(t, s, (sts == MPI_STATUS_IGNORE) ? (int*)&tmpStatus : (int*)sts);
+  AmpiMsg* msg = dis->unexpectedMsgs.get(t, s, (sts == MPI_STATUS_IGNORE) ? (int*)&tmpStatus : (int*)sts);
   if (msg) { // the matching message has already arrived
     if (sts != MPI_STATUS_IGNORE) {
       sts->MPI_SOURCE = msg->getSrcRank();
@@ -3240,7 +3225,7 @@ int ampi::recv(int t, int s, void* buf, int count, MPI_Datatype type, MPI_Comm c
       sts->MPI_LENGTH = msg->getLength();
       sts->MPI_CANCEL = 0;
     }
-    processAmpiMsg(msg, buf, type, count);
+    dis->processAmpiMsg(msg, buf, type, count);
 #if CMK_BIGSIM_CHARM
     TRACE_BG_AMPI_BREAK(thread->getThread(), "RECV_RESUME", NULL, 0, 0);
     if (msg->eventPe == CkMyPe()) _TRACE_BG_ADD_BACKWARD_DEP(msg->event);
@@ -3248,18 +3233,17 @@ int ampi::recv(int t, int s, void* buf, int count, MPI_Datatype type, MPI_Comm c
     CkpvAccess(msgPool).deleteAmpiMsg(msg);
   }
   else { // post a request and block until the matching message arrives
-    int request = postReq(dis->parent->reqPool.newReq<IReq>(buf, count, type, s, t, comm, getDDT(), AMPI_REQ_BLOCKED));
-    CkAssert(parent->numBlockedReqs == 0);
-    parent->numBlockedReqs = 1;
+    int request = dis->postReq(dis->parent->reqPool.newReq<IReq>(buf, count, type, s, t, comm, dis->getDDT(), AMPI_REQ_BLOCKED));
+    CkAssert(dis->parent->numBlockedReqs == 0);
+    dis->parent->numBlockedReqs = 1;
     dis = dis->blockOnRecv(); // "dis" is updated in case an ampi thread is migrated while waiting for a message
-    parent = dis->parent;
-    AmpiRequestList& reqs = parent->getReqs();
+    AmpiRequestList& reqs = dis->parent->getReqs();
     if (sts != MPI_STATUS_IGNORE) {
       AmpiRequest& req = *reqs[request];
       sts->MPI_SOURCE = req.src;
       sts->MPI_TAG    = req.tag;
       sts->MPI_COMM   = req.comm;
-      sts->MPI_LENGTH = req.getNumReceivedBytes(getDDT());
+      sts->MPI_LENGTH = req.getNumReceivedBytes(dis->getDDT());
       sts->MPI_CANCEL = 0;
     }
     reqs.freeNonPersReq(request);
@@ -3278,7 +3262,7 @@ int ampi::recv(int t, int s, void* buf, int count, MPI_Datatype type, MPI_Comm c
   return 0;
 }
 
-void ampi::probe(int t, int s, MPI_Comm comm, MPI_Status *sts) noexcept
+void ampi::static_probe(ampi *dis, int t, int s, MPI_Comm comm, MPI_Status *sts) noexcept
 {
   if (handle_MPI_PROC_NULL(s, comm, sts)) return;
 
@@ -3287,11 +3271,10 @@ void ampi::probe(int t, int s, MPI_Comm comm, MPI_Status *sts) noexcept
   _TRACE_BG_TLINE_END(&curLog);
 #endif
 
-  ampi *dis = getAmpiInstance(comm);
   AmpiMsg *msg = NULL;
   while(1) {
     MPI_Status tmpStatus;
-    msg = unexpectedMsgs.probe(t, s, (sts == MPI_STATUS_IGNORE) ? (int*)&tmpStatus : (int*)sts);
+    msg = dis->unexpectedMsgs.probe(t, s, (sts == MPI_STATUS_IGNORE) ? (int*)&tmpStatus : (int*)sts);
     if (msg) break;
     // "dis" is updated in case an ampi thread is migrated while waiting for a message
     dis = dis->blockOnRecv();
@@ -3310,7 +3293,7 @@ void ampi::probe(int t, int s, MPI_Comm comm, MPI_Status *sts) noexcept
 #endif
 }
 
-void ampi::mprobe(int t, int s, MPI_Comm comm, MPI_Status *sts, MPI_Message *message) noexcept
+void ampi::static_mprobe(ampi *dis, int t, int s, MPI_Comm comm, MPI_Status *sts, MPI_Message *message) noexcept
 {
   if (handle_MPI_PROC_NULL(s, comm, sts)) {
     *message = MPI_MESSAGE_NO_PROC;
@@ -3322,13 +3305,12 @@ void ampi::mprobe(int t, int s, MPI_Comm comm, MPI_Status *sts, MPI_Message *mes
   _TRACE_BG_TLINE_END(&curLog);
 #endif
 
-  ampi *dis = this;
   AmpiMsg *msg = NULL;
   while(1) {
     MPI_Status tmpStatus;
     // We call get() rather than probe() here because we want to remove this msg
     // from ampi::unexpectedMsgs and then insert it into ampiParent::matchedMsgs
-    msg = unexpectedMsgs.get(t, s, (sts == MPI_STATUS_IGNORE) ? (int*)&tmpStatus : (int*)sts);
+    msg = dis->unexpectedMsgs.get(t, s, (sts == MPI_STATUS_IGNORE) ? (int*)&tmpStatus : (int*)sts);
     if (msg)
       break;
     // "dis" is updated in case an ampi thread is migrated while waiting for a message
@@ -3336,7 +3318,7 @@ void ampi::mprobe(int t, int s, MPI_Comm comm, MPI_Status *sts, MPI_Message *mes
   }
 
   msg->setComm(comm);
-  *message = parent->putMatchedMsg(msg);
+  *message = dis->parent->putMatchedMsg(msg);
 
   if (sts != MPI_STATUS_IGNORE) {
     sts->MPI_SOURCE = msg->getSrcRank();
@@ -3372,7 +3354,7 @@ int ampi::iprobe(int t, int s, MPI_Comm comm, MPI_Status *sts) noexcept
   void *curLog; // store current log in timeline
   _TRACE_BG_TLINE_END(&curLog);
 #endif
-  thread->schedule();
+  ampi* unused = yield();
 #if CMK_BIGSIM_CHARM
   _TRACE_BG_SET_INFO(NULL, "IPROBE_RESUME",  &curLog, 1);
 #endif
@@ -3408,7 +3390,7 @@ int ampi::improbe(int tag, int source, MPI_Comm comm, MPI_Status *sts,
   void *curLog; // store current log in timeline
   _TRACE_BG_TLINE_END(&curLog);
 #endif
-  thread->schedule();
+  ampi* unused = yield();
 #if CMK_BIGSIM_CHARM
   _TRACE_BG_SET_INFO(NULL, "IMPROBE_RESUME",  &curLog, 1);
 #endif
@@ -3787,7 +3769,7 @@ void AmpiRequestList::pup(PUP::er &p, AmpiRequestPool* pool) noexcept {
 }
 
 //------------------ External Interface -----------------
-ampiParent *getAmpiParent() noexcept {
+CMI_WARN_UNUSED_RESULT ampiParent *getAmpiParent() noexcept {
   ampiParent *p = CtvAccess(ampiPtr);
 #if CMK_ERROR_CHECKING
   if (p==NULL) CkAbort("Cannot call MPI routines before AMPI is initialized.\n");
@@ -3795,7 +3777,7 @@ ampiParent *getAmpiParent() noexcept {
   return p;
 }
 
-ampi *getAmpiInstance(MPI_Comm comm) noexcept {
+CMI_WARN_UNUSED_RESULT ampi *getAmpiInstance(MPI_Comm comm) noexcept {
   ampi *ptr=getAmpiParent()->comm2ampi(comm);
 #if CMK_ERROR_CHECKING
   if (ptr==NULL) CkAbort("AMPI's getAmpiInstance> null pointer\n");
@@ -4560,14 +4542,41 @@ AMPI_API_IMPL(int, MPI_Sendrecv_replace, void* buf, int count, MPI_Datatype data
   return MPI_SUCCESS;
 }
 
-void ampi::barrier() noexcept
+CMI_WARN_UNUSED_RESULT ampi * ampi::barrier() noexcept
 {
   CkAssert(parent->resumeOnColl == false);
   parent->resumeOnColl = true;
   CkCallback barrierCB(CkReductionTarget(ampi, barrierResult), getProxy());
   contribute(barrierCB);
-  thread->suspend(); //Resumed by ampi::barrierResult
-  getAmpiParent()->resumeOnColl = false;
+  ampi * dis = block(); //Resumed by ampi::barrierResult
+  dis->parent->resumeOnColl = false;
+  return dis;
+}
+
+CMI_WARN_UNUSED_RESULT ampi * ampi::block() noexcept
+{
+  // In case this thread is migrated while suspended,
+  // save myComm to get the ampi instance back. Then
+  // return "dis" in case the caller needs it.
+  MPI_Comm disComm = myComm.getComm();
+  ampiParent * disParent = parent->block();
+  ampi * dis = getAmpiInstance(disComm);
+  dis->parent = disParent;
+  dis->thread = TCharm::get();
+  return dis;
+}
+
+CMI_WARN_UNUSED_RESULT ampi * ampi::yield() noexcept
+{
+  // In case this thread is migrated while suspended,
+  // save myComm to get the ampi instance back. Then
+  // return "dis" in case the caller needs it.
+  MPI_Comm disComm = myComm.getComm();
+  ampiParent * disParent = parent->yield();
+  ampi * dis = getAmpiInstance(disComm);
+  dis->parent = disParent;
+  dis->thread = TCharm::get();
+  return dis;
 }
 
 void ampi::barrierResult() noexcept
@@ -4599,7 +4608,7 @@ AMPI_API_IMPL(int, MPI_Barrier, MPI_Comm comm)
 
   // implementation of intercomm barrier is equivalent to that for intracomm barrier
 
-  ptr->barrier();
+  ptr = ptr->barrier();
 
   return MPI_SUCCESS;
 }
@@ -5006,8 +5015,8 @@ AMPI_API_IMPL(int, MPI_Reduce, const void *inbuf, void *outbuf, int count, MPI_D
     return copyDatatype(type,count,type,count,inbuf,outbuf);
 
 #if AMPIMSGLOG
-  ampiParent* pptr = getAmpiParent();
   if(msgLogRead){
+    ampiParent* pptr = getAmpiParent();
     (*(pptr->fromPUPer))|(pptr->pupBytes);
     PUParray(*(pptr->fromPUPer), (char *)outbuf, (pptr->pupBytes));
     return MPI_SUCCESS;
@@ -5039,10 +5048,13 @@ AMPI_API_IMPL(int, MPI_Reduce, const void *inbuf, void *outbuf, int count, MPI_D
 #endif
 
 #if AMPIMSGLOG
-  if(msgLogWrite && record_msglog(pptr->thisIndex)){
-    (pptr->pupBytes) = getDDT()->getSize(type) * count;
-    (*(pptr->toPUPer))|(pptr->pupBytes);
-    PUParray(*(pptr->toPUPer), (char *)outbuf, (pptr->pupBytes));
+  if(msgLogWrite){
+    ampiParent* pptr = getAmpiParent();
+    if(record_msglog(pptr->thisIndex)){
+      (pptr->pupBytes) = getDDT()->getSize(type) * count;
+      (*(pptr->toPUPer))|(pptr->pupBytes);
+      PUParray(*(pptr->toPUPer), (char *)outbuf, (pptr->pupBytes));
+    }
   }
 #endif
 
@@ -5079,8 +5091,8 @@ AMPI_API_IMPL(int, MPI_Allreduce, const void *inbuf, void *outbuf, int count, MP
 #endif
 
 #if AMPIMSGLOG
-  ampiParent* pptr = getAmpiParent();
   if(msgLogRead){
+    ampiParent* pptr = getAmpiParent();
     (*(pptr->fromPUPer))|(pptr->pupBytes);
     PUParray(*(pptr->fromPUPer), (char *)outbuf, (pptr->pupBytes));
     return MPI_SUCCESS;
@@ -5094,13 +5106,16 @@ AMPI_API_IMPL(int, MPI_Allreduce, const void *inbuf, void *outbuf, int count, MP
   msg->setCallback(allreduceCB);
   ptr->contribute(msg);
 
-  ptr->blockOnColl();
+  ptr = ptr->blockOnColl();
 
 #if AMPIMSGLOG
-  if(msgLogWrite && record_msglog(pptr->thisIndex)){
-    (pptr->pupBytes) = getDDT()->getSize(type) * count;
-    (*(pptr->toPUPer))|(pptr->pupBytes);
-    PUParray(*(pptr->toPUPer), (char *)outbuf, (pptr->pupBytes));
+  if(msgLogWrite){
+    ampiParent* pptr = getAmpiParent();
+    if(record_msglog(pptr->thisIndex)){
+      (pptr->pupBytes) = getDDT()->getSize(type) * count;
+      (*(pptr->toPUPer))|(pptr->pupBytes);
+      PUParray(*(pptr->toPUPer), (char *)outbuf, (pptr->pupBytes));
+    }
   }
 #endif
 
@@ -5510,9 +5525,8 @@ int IReq::wait(MPI_Status *sts) noexcept {
     parent->resumeOnRecv = true;
     parent->numBlockedReqs = 1;
     setBlocked(true);
-    parent->block();
+    parent = parent->block();
     setBlocked(false);
-    parent = getAmpiParent();
 
     if (cancelled) {
       if (sts != MPI_STATUS_IGNORE) sts->MPI_CANCEL = 1;
@@ -5553,9 +5567,8 @@ int RednReq::wait(MPI_Status *sts) noexcept {
     parent->resumeOnColl = true;
     parent->numBlockedReqs = 1;
     setBlocked(true);
-    parent->block();
+    parent = parent->block();
     setBlocked(false);
-    parent = getAmpiParent();
 
 #if CMK_BIGSIM_CHARM
     //Because of the out-of-core emulation, this pointer is changed after in-out
@@ -5586,9 +5599,8 @@ int GatherReq::wait(MPI_Status *sts) noexcept {
     parent->resumeOnColl = true;
     parent->numBlockedReqs = 1;
     setBlocked(true);
-    parent->block();
+    parent = parent->block();
     setBlocked(false);
-    parent = getAmpiParent();
 
 #if CMK_BIGSIM_CHARM
     //Because of the out-of-core emulation, this pointer is changed after in-out
@@ -5619,9 +5631,8 @@ int GathervReq::wait(MPI_Status *sts) noexcept {
     parent->resumeOnColl = true;
     parent->numBlockedReqs = 1;
     setBlocked(true);
-    parent->block();
+    parent = parent->block();
     setBlocked(false);
-    parent = getAmpiParent();
 
 #if CMK_BIGSIM_CHARM
     //Because of the out-of-core emulation, this pointer is changed after in-out
@@ -5650,10 +5661,8 @@ int SendReq::wait(MPI_Status *sts) noexcept {
     parent->resumeOnRecv = true;
     parent->numBlockedReqs = 1;
     setBlocked(true);
-    parent->block();
+    parent = parent->block();
     setBlocked(false);
-    // "dis" is updated in case an ampi thread is migrated while waiting for a message
-    parent = getAmpiParent();
   }
   parent->resumeOnRecv = false;
   AMPI_DEBUG("SendReq::wait has resumed\n");
@@ -5818,8 +5827,7 @@ AMPI_API_IMPL(int, MPI_Waitall, int count, MPI_Request request[], MPI_Status sts
 
   // If any requests are incomplete, block until all have been completed
   if (pptr->numBlockedReqs > 0) {
-    getAmpiParent()->blockOnRecv();
-    pptr = getAmpiParent();
+    pptr = getAmpiParent()->blockOnRecv();
     reqs = pptr->getReqs(); //update pointer in case of migration while suspended
 
     for (int i=0; i<count; i++) {
@@ -6147,7 +6155,7 @@ AMPI_API_IMPL(int, MPI_Request_get_status, MPI_Request request, int *flag, MPI_S
   AMPI_API("AMPI_Request_get_status");
   testRequestNoFree(&request, flag, sts);
   if(*flag != 1)
-    getAmpiParent()->yield();
+    ampiParent* unused = getAmpiParent()->yield();
   return MPI_SUCCESS;
 }
 
@@ -6156,7 +6164,7 @@ AMPI_API_IMPL(int, MPI_Test, MPI_Request *request, int *flag, MPI_Status *sts)
   AMPI_API("AMPI_Test");
   testRequest(request, flag, sts);
   if(*flag != 1)
-    getAmpiParent()->yield();
+    ampiParent* unused = getAmpiParent()->yield();
   return MPI_SUCCESS;
 }
 
@@ -6194,7 +6202,7 @@ AMPI_API_IMPL(int, MPI_Testany, int count, MPI_Request *request, int *index, int
     clearStatus(sts);
   }
   else {
-    getAmpiParent()->yield();
+    ampiParent* unused = getAmpiParent()->yield();
   }
 
   return MPI_SUCCESS;
@@ -6223,7 +6231,7 @@ AMPI_API_IMPL(int, MPI_Testall, int count, MPI_Request *request, int *flag, MPI_
     }
     if (!reqs[request[i]]->test()) {
       *flag = 0;
-      pptr->yield();
+      pptr = pptr->yield();
       return MPI_SUCCESS;
     }
   }
@@ -6276,7 +6284,7 @@ AMPI_API_IMPL(int, MPI_Testsome, int incount, MPI_Request *array_of_requests, in
     *outcount = MPI_UNDEFINED;
   }
   else if (*outcount == 0) {
-    getAmpiParent()->yield();
+    ampiParent* unused = getAmpiParent()->yield();
   }
 
   return MPI_SUCCESS;
@@ -7122,7 +7130,7 @@ AMPI_API_IMPL(int, MPI_Allgather, const void *sendbuf, int sendcount, MPI_Dataty
   MSG_ORDER_DEBUG(CkPrintf("[%d] AMPI_Allgather called on comm %d\n", ptr->thisIndex, comm));
   ptr->contribute(msg);
 
-  ptr->blockOnColl();
+  ptr = ptr->blockOnColl();
 
   return MPI_SUCCESS;
 }
@@ -7214,7 +7222,7 @@ AMPI_API_IMPL(int, MPI_Allgatherv, const void *sendbuf, int sendcount, MPI_Datat
   MSG_ORDER_DEBUG(CkPrintf("[%d] AMPI_Allgatherv called on comm %d\n", ptr->thisIndex, comm));
   ptr->contribute(msg);
 
-  ptr->blockOnColl();
+  ptr = ptr->blockOnColl();
 
   return MPI_SUCCESS;
 }
@@ -7303,8 +7311,8 @@ AMPI_API_IMPL(int, MPI_Gather, const void *sendbuf, int sendcount, MPI_Datatype 
     return copyDatatype(sendtype,sendcount,recvtype,recvcount,sendbuf,recvbuf);
 
 #if AMPIMSGLOG
-  ampiParent* pptr = getAmpiParent();
   if(msgLogRead){
+    ampiParent* pptr = getAmpiParent();
     (*(pptr->fromPUPer))|(pptr->pupBytes);
     PUParray(*(pptr->fromPUPer), (char *)recvbuf, (pptr->pupBytes));
     return MPI_SUCCESS;
@@ -7323,14 +7331,17 @@ AMPI_API_IMPL(int, MPI_Gather, const void *sendbuf, int sendcount, MPI_Datatype 
   ptr->contribute(msg);
 
   if (rank == root) {
-    ptr->blockOnColl();
+    ptr = ptr->blockOnColl();
   }
 
 #if AMPIMSGLOG
-  if(msgLogWrite && record_msglog(pptr->thisIndex)){
-    (pptr->pupBytes) = getDDT()->getSize(recvtype) * recvcount * size;
-    (*(pptr->toPUPer))|(pptr->pupBytes);
-    PUParray(*(pptr->toPUPer), (char *)recvbuf, (pptr->pupBytes));
+  if(msgLogWrite){
+    ampiParent* pptr = getAmpiParent();
+    if(record_msglog(pptr->thisIndex)){
+      (pptr->pupBytes) = getDDT()->getSize(recvtype) * recvcount * size;
+      (*(pptr->toPUPer))|(pptr->pupBytes);
+      PUParray(*(pptr->toPUPer), (char *)recvbuf, (pptr->pupBytes));
+    }
   }
 #endif
 
@@ -7444,8 +7455,8 @@ AMPI_API_IMPL(int, MPI_Gatherv, const void *sendbuf, int sendcount, MPI_Datatype
     return copyDatatype(sendtype,sendcount,recvtype,recvcounts[0],sendbuf,recvbuf);
 
 #if AMPIMSGLOG
-  ampiParent* pptr = getAmpiParent();
   if(msgLogRead){
+    ampiParent* pptr = getAmpiParent();
     int commsize;
     int itemsize = getDDT()->getSize(recvtype);
     (*(pptr->fromPUPer))|commsize;
@@ -7469,15 +7480,18 @@ AMPI_API_IMPL(int, MPI_Gatherv, const void *sendbuf, int sendcount, MPI_Datatype
   ptr->contribute(msg);
 
   if (rank == root) {
-    ptr->blockOnColl();
+    ptr = ptr->blockOnColl();
   }
 
 #if AMPIMSGLOG
-  if(msgLogWrite && record_msglog(pptr->thisIndex)){
-    for(int i=0;i<size;i++){
-      (pptr->pupBytes) = getDDT()->getSize(recvtype) * recvcounts[i];
-      (*(pptr->toPUPer))|(pptr->pupBytes);
-      PUParray(*(pptr->toPUPer), (char *)(((char*)recvbuf)+(itemsize*displs[i])), (pptr->pupBytes));
+  if(msgLogWrite){
+    ampiParent* pptr = getAmpiParent();
+    if(record_msglog(pptr->thisIndex)){
+      for(int i=0;i<size;i++){
+        (pptr->pupBytes) = getDDT()->getSize(recvtype) * recvcounts[i];
+        (*(pptr->toPUPer))|(pptr->pupBytes);
+        PUParray(*(pptr->toPUPer), (char *)(((char*)recvbuf)+(itemsize*displs[i])), (pptr->pupBytes));
+      }
     }
   }
 #endif
@@ -8880,12 +8894,16 @@ AMPI_API_IMPL(int, MPI_Ineighbor_allgatherv, const void* sendbuf, int sendcount,
 AMPI_API_IMPL(int, MPI_Comm_dup, MPI_Comm comm, MPI_Comm *newcomm)
 {
   AMPI_API("AMPI_Comm_dup");
-  ampi *ptr = getAmpiInstance(comm);
-  int topoType, rank = ptr->getRank();
-  MPI_Topo_test(comm, &topoType);
-  ptr->topoDup(topoType, rank, comm, newcomm);
+
+  {
+    ampi *ptr = getAmpiInstance(comm);
+    int topoType, rank = ptr->getRank();
+    MPI_Topo_test(comm, &topoType);
+    ptr->topoDup(topoType, rank, comm, newcomm);
+  }
+
   int ret = getAmpiParent()->dupUserKeyvals(comm, *newcomm);
-  ptr->barrier();
+  ampi * unused = getAmpiInstance(comm)->barrier();
 
 #if AMPIMSGLOG
   ampiParent* pptr = getAmpiParent();
@@ -8995,8 +9013,7 @@ AMPI_API_IMPL(int, MPI_Comm_free, MPI_Comm *comm)
     // FIXME: free user-defined attribute keyvals owned by this communicator
     //ret = parent->freeUserKeyvals(*comm, parent->getKeyvals(*comm));
     if (*comm != MPI_COMM_WORLD && *comm != MPI_COMM_SELF) {
-      ampi* ptr = getAmpiInstance(*comm);
-      ptr->barrier();
+      ampi* ptr = getAmpiInstance(*comm)->barrier();
       if (ptr->getRank() == 0) {
         CProxy_CkArray(ptr->ckGetArrayID()).ckDestroy();
       }
@@ -9645,9 +9662,8 @@ AMPI_API_IMPL(int, MPI_Comm_create, MPI_Comm comm, MPI_Group group, MPI_Comm* ne
 
   if(getAmpiParent()->isInter(comm)){
     /* inter-communicator: create a single new comm. */
-    ampi *ptr = getAmpiInstance(comm);
-    ptr->commCreate(vec, newcomm);
-    ptr->barrier();
+    getAmpiInstance(comm)->commCreate(vec, newcomm);
+    ampi * unused = getAmpiInstance(comm)->barrier();
   }
   else{
     /* intra-communicator: create comm's for disjoint subgroups,
@@ -9932,7 +9948,7 @@ AMPI_API_IMPL(int, MPI_Graph_create, MPI_Comm comm_old, int nnodes, const int *i
   ampiParent *ptr = getAmpiParent();
   vector<int> vec = ptr->group2vec(ptr->comm2group(comm_old));
   getAmpiInstance(comm_old)->graphCreate(vec, comm_graph);
-  ampiTopology &topo = *ptr->getGraph(*comm_graph).getTopology();
+  ampiTopology &topo = *getAmpiParent()->getGraph(*comm_graph).getTopology();
 
   vector<int> index_(index, index+nnodes), edges_, nborsv;
   topo.setnvertices(nnodes);
@@ -9974,7 +9990,7 @@ AMPI_API_IMPL(int, MPI_Dist_graph_create_adjacent, MPI_Comm comm_old, int indegr
   ampiParent *ptr = getAmpiParent();
   vector<int> vec = ptr->group2vec(ptr->comm2group(comm_old));
   getAmpiInstance(comm_old)->distGraphCreate(vec,comm_dist_graph);
-  ampiCommStruct &c = ptr->getDistGraph(*comm_dist_graph);
+  ampiCommStruct &c = getAmpiParent()->getDistGraph(*comm_dist_graph);
   ampiTopology *topo = c.getTopology();
 
   topo->setInDegree(indegree);
@@ -10028,7 +10044,7 @@ AMPI_API_IMPL(int, MPI_Dist_graph_create, MPI_Comm comm_old, int n, const int so
   ampiParent *ptr = getAmpiParent();
   vector<int> vec = ptr->group2vec(ptr->comm2group(comm_old));
   getAmpiInstance(comm_old)->distGraphCreate(vec,comm_dist_graph);
-  ampiCommStruct &c = ptr->getDistGraph(*comm_dist_graph);
+  ampiCommStruct &c = getAmpiParent()->getDistGraph(*comm_dist_graph);
   ampiTopology *topo = c.getTopology();
 
   int p = c.getSize();
@@ -10758,13 +10774,13 @@ int AMPI_Migrate(MPI_Info hints)
         else {
           CkAbort("AMPI> Error: No checkpoint directory name given to AMPI_Migrate\n");
         }
-        getAmpiInstance(MPI_COMM_WORLD)->barrier();
-        getAmpiParent()->startCheckpoint(&value[offset]);
+        ampi * ptr = getAmpiInstance(MPI_COMM_WORLD)->barrier();
+        ptr->getParent()->startCheckpoint(&value[offset]);
       }
       else if (strncmp(value, "in_memory", MPI_MAX_INFO_VAL) == 0) {
 #if CMK_MEM_CHECKPOINT
-        getAmpiInstance(MPI_COMM_WORLD)->barrier();
-        getAmpiParent()->startCheckpoint("");
+        ampi * ptr = getAmpiInstance(MPI_COMM_WORLD)->barrier();
+        ptr->getParent()->startCheckpoint("");
 #else
         CkPrintf("AMPI> Error: In-memory checkpoint/restart is not enabled!\n");
         CkAbort("AMPI> Error: Recompile Charm++/AMPI with CMK_MEM_CHECKPOINT.\n");
@@ -10948,7 +10964,7 @@ CLINKAGE
 int AMPI_Suspend(void)
 {
   AMPI_API("AMPI_Suspend");
-  getAmpiParent()->block();
+  ampiParent* unused = getAmpiParent()->block();
   return MPI_SUCCESS;
 }
 
@@ -10956,7 +10972,7 @@ CLINKAGE
 int AMPI_Yield(void)
 {
   AMPI_API("AMPI_Yield");
-  getAmpiParent()->yield();
+  ampiParent* unused = getAmpiParent()->yield();
   return MPI_SUCCESS;
 }
 
@@ -11067,7 +11083,7 @@ int GPUReq::wait(MPI_Status *sts) noexcept
 {
   (void)sts;
   while (!complete) {
-    getAmpiParent()->block();
+    ampiParent* unused = getAmpiParent()->block();
   }
   return 0;
 }

--- a/src/libs/ck-libs/ampi/ampi.ci
+++ b/src/libs/ck-libs/ampi/ampi.ci
@@ -43,13 +43,14 @@ module ampi {
     entry EXPEDITED_REDN void allInitDone(void);
     entry EXPEDITED void setInitDoneFlag();
     entry EXPEDITED void unblock(void);
-    entry EXPEDITED void ssendAck(int sreqIdx);
     entry EXPEDITED void injectMsg(int size, char buf[size]);
     entry EXPEDITED void genericSync(AmpiMsg *);
     entry EXPEDITED void generic(AmpiMsg *);
     entry EXPEDITED void genericRdma(nocopy char buf[size], int size, CMK_REFNUM_TYPE seq, int tag, int srcRank);
     entry EXPEDITED void completedSend(int sreqIdx);
     entry EXPEDITED_NOKEEP void completedRdmaSend(CkDataMsg *msg);
+    entry EXPEDITED_NOKEEP void completedRdmaRecv(CkDataMsg *msg);
+    entry EXPEDITED void requestPut(MPI_Request req, CkNcpyBuffer targetInfo);
     entry EXPEDITED_REDN void barrierResult(void);
     entry EXPEDITED_REDN void ibarrierResult(void);
     entry EXPEDITED_NOKEEP void bcastResult(AmpiMsg *);

--- a/src/libs/ck-libs/ampi/ampi.ci
+++ b/src/libs/ck-libs/ampi/ampi.ci
@@ -48,6 +48,7 @@ module ampi {
     entry EXPEDITED void genericSync(AmpiMsg *);
     entry EXPEDITED void generic(AmpiMsg *);
     entry EXPEDITED void genericRdma(nocopy char buf[size], int size, CMK_REFNUM_TYPE seq, int tag, int srcRank);
+    entry EXPEDITED void completedSend(int sreqIdx);
     entry EXPEDITED_NOKEEP void completedRdmaSend(CkDataMsg *msg);
     entry EXPEDITED_REDN void barrierResult(void);
     entry EXPEDITED_REDN void ibarrierResult(void);

--- a/src/libs/ck-libs/ampi/ampi.ci
+++ b/src/libs/ck-libs/ampi/ampi.ci
@@ -43,11 +43,11 @@ module ampi {
     entry EXPEDITED_REDN void allInitDone(void);
     entry EXPEDITED void setInitDoneFlag();
     entry EXPEDITED void unblock(void);
-    entry EXPEDITED void ssend_ack(int);
+    entry EXPEDITED void ssendAck(int sreqIdx);
     entry EXPEDITED void injectMsg(int size, char buf[size]);
+    entry EXPEDITED void genericSync(AmpiMsg *);
     entry EXPEDITED void generic(AmpiMsg *);
-    entry EXPEDITED void genericRdma(nocopy char buf[size], int size, CMK_REFNUM_TYPE seq, int tag,
-                                     int srcRank, MPI_Comm destcomm, int ssendReq);
+    entry EXPEDITED void genericRdma(nocopy char buf[size], int size, CMK_REFNUM_TYPE seq, int tag, int srcRank);
     entry EXPEDITED_NOKEEP void completedRdmaSend(CkDataMsg *msg);
     entry EXPEDITED_REDN void barrierResult(void);
     entry EXPEDITED_REDN void ibarrierResult(void);

--- a/src/libs/ck-libs/ampi/ampiOneSided.C
+++ b/src/libs/ck-libs/ampi/ampiOneSided.C
@@ -734,7 +734,7 @@ AMPI_API_IMPL(int, MPI_Win_create, void *base, MPI_Aint size, int disp_unit,
   parent->setAttr(*newwin, keyvals, MPI_WIN_BASE, &base);
   parent->setAttr(*newwin, keyvals, MPI_WIN_SIZE, &size);
   parent->setAttr(*newwin, keyvals, MPI_WIN_DISP_UNIT, &disp_unit);
-  ptr->barrier(); // synchronize all participating virtual processes
+  ptr = ptr->barrier(); // synchronize all participating virtual processes
   return MPI_SUCCESS;
 }
 
@@ -753,7 +753,7 @@ AMPI_API_IMPL(int, MPI_Win_free, MPI_Win *win)
   ampi *ptr = getAmpiInstance(winStruct->comm);
   ptr->deleteWinInstance(*win);
   /* Need a barrier here: to ensure that every process participates */
-  ptr->barrier();
+  ptr = ptr->barrier();
   *win = MPI_WIN_NULL;
   return MPI_SUCCESS;
 }
@@ -977,10 +977,9 @@ AMPI_API_IMPL(int, MPI_Win_fence, int assertion, MPI_Win win)
   AMPI_API("AMPI_Win_fence");
   WinStruct *winStruct = getAmpiParent()->getWinStruct(win);
   MPI_Comm comm = winStruct->comm;
-  ampi *ptr = getAmpiInstance(comm);
 
   // Wait until everyone reaches the fence
-  ptr->barrier();
+  ampi *unused = getAmpiInstance(comm)->barrier();
 
   // Complete all outstanding one-sided comm requests
   // no need to do this for the pseudo-implementation

--- a/src/libs/ck-libs/ampi/ampiOneSided.C
+++ b/src/libs/ck-libs/ampi/ampiOneSided.C
@@ -14,7 +14,6 @@
 #define WIN_ERROR   (-1)
 
 extern int AMPI_RDMA_THRESHOLD;
-extern int AMPI_SMP_RDMA_THRESHOLD;
 
 win_obj::win_obj() noexcept {
   baseAddr = NULL;
@@ -221,9 +220,7 @@ int ampi::winPut(const void *orgaddr, int orgcnt, MPI_Datatype orgtype, int rank
                             targcnt, targtype, win->index);
     }
 #if AMPI_RDMA_IMPL
-    else if (orgtotalsize >= AMPI_RDMA_THRESHOLD ||
-            (orgtotalsize >= AMPI_SMP_RDMA_THRESHOLD && destLikelyWithinProcess(thisProxy, rank)))
-    {
+    else if (orgtotalsize >= AMPI_RDMA_THRESHOLD) {
       AmpiRequestList& reqs = getReqs();
       SendReq* ampiReq = parent->reqPool.newReq<SendReq>(orgtype, myComm.getComm(), getDDT());
       MPI_Request req = reqs.insert(ampiReq);
@@ -408,9 +405,7 @@ int ampi::winAccumulate(const void *orgaddr, int orgcnt, MPI_Datatype orgtype, i
                                    targcnt, targtype, op, win->index);
     }
 #if AMPI_RDMA_IMPL
-    else if (orgtotalsize >= AMPI_RDMA_THRESHOLD ||
-            (orgtotalsize >= AMPI_SMP_RDMA_THRESHOLD && destLikelyWithinProcess(thisProxy, rank)))
-    {
+    else if (ddt->isContig() && orgtotalsize >= AMPI_RDMA_THRESHOLD) {
       AmpiRequestList& reqs = getReqs();
       SendReq* ampiReq = parent->reqPool.newReq<SendReq>(orgtype, myComm.getComm(), getDDT());
       MPI_Request req = reqs.insert(ampiReq);
@@ -473,9 +468,7 @@ int ampi::winGetAccumulate(const void *orgaddr, int orgcnt, MPI_Datatype orgtype
       return MPI_SUCCESS;
     }
 #if AMPI_RDMA_IMPL
-    else if (orgtotalsize >= AMPI_RDMA_THRESHOLD ||
-            (orgtotalsize >= AMPI_SMP_RDMA_THRESHOLD && destLikelyWithinProcess(thisProxy, rank)))
-    {
+    else if (orgtotalsize >= AMPI_RDMA_THRESHOLD) {
       AmpiRequestList& reqs = getReqs();
       SendReq* ampiReq = parent->reqPool.newReq<SendReq>(orgtype, myComm.getComm(), getDDT());
       MPI_Request req = reqs.insert(ampiReq);

--- a/src/libs/ck-libs/ampi/ampiOneSided.C
+++ b/src/libs/ck-libs/ampi/ampiOneSided.C
@@ -228,8 +228,8 @@ int ampi::winPut(const void *orgaddr, int orgcnt, MPI_Datatype orgtype, int rank
       completedSendCB.setRefnum(req);
       thisProxy[rank].winRemotePut(orgtotalsize, CkSendBuffer(orgaddr, completedSendCB), orgcnt, orgtype,
                                    targdisp, targcnt, targtype, win->index);
-      ampiReq->wait(MPI_STATUS_IGNORE);
-      reqs.free(parent->reqPool, req, getDDT());
+      ampiReq->wait(parent, MPI_STATUS_IGNORE);
+      reqs.free(req, getDDT());
     }
 #endif
     else {
@@ -413,8 +413,8 @@ int ampi::winAccumulate(const void *orgaddr, int orgcnt, MPI_Datatype orgtype, i
       completedSendCB.setRefnum(req);
       thisProxy[rank].winRemoteAccumulate(orgtotalsize, CkSendBuffer(orgaddr, completedSendCB), orgcnt,
                                           orgtype, targdisp, targcnt, targtype,  op, win->index);
-      ampiReq->wait(MPI_STATUS_IGNORE);
-      reqs.free(parent->reqPool, req, getDDT());
+      ampiReq->wait(parent, MPI_STATUS_IGNORE);
+      reqs.free(req, getDDT());
     }
 #endif
     else {
@@ -476,8 +476,8 @@ int ampi::winGetAccumulate(const void *orgaddr, int orgcnt, MPI_Datatype orgtype
       completedSendCB.setRefnum(req);
       msg = thisProxy[rank].winRemoteGetAccumulate(orgtotalsize, CkSendBuffer(orgaddr, completedSendCB), orgcnt,
                                                    orgtype, targdisp, targcnt, targtype, op, win->index);
-      ampiReq->wait(MPI_STATUS_IGNORE);
-      reqs.free(parent->reqPool, req, getDDT());
+      ampiReq->wait(parent, MPI_STATUS_IGNORE);
+      reqs.free(req, getDDT());
     }
 #endif
     else {

--- a/src/libs/ck-libs/ampi/ampiimpl.h
+++ b/src/libs/ck-libs/ampi/ampiimpl.h
@@ -109,6 +109,11 @@ class fromzDisk : public zdisk {
 #define AMPI_LOCAL_IMPL ( !CMK_BIGSIM_CHARM && !CMK_TRACE_ENABLED )
 #endif
 
+/* messages larger than or equal to this threshold may block on a matching recv if local */
+#ifndef AMPI_LOCAL_THRESHOLD_DEFAULT
+#define AMPI_LOCAL_THRESHOLD_DEFAULT 4096
+#endif
+
 /* AMPI uses RDMA sends if BigSim is not being used and the underlying comm
  * layer supports it (except for GNI, which has experimental RDMA support). */
 #ifndef AMPI_RDMA_IMPL
@@ -1853,6 +1858,7 @@ public:
   inline CMK_REFNUM_TYPE getSeqIncoming() const noexcept { return seqIncoming; }
 
   inline void incSeqOutgoing() noexcept { seqOutgoing++; if (seqOutgoing==0) seqOutgoing=1; }
+  inline void decSeqOutgoing() noexcept { seqOutgoing--; if (seqOutgoing==0) seqOutgoing=std::numeric_limits<CMK_REFNUM_TYPE>::max(); }
   inline CMK_REFNUM_TYPE getSeqOutgoing() const noexcept { return seqOutgoing; }
 
   inline void incNumOutOfOrder() noexcept { numOutOfOrder++; }
@@ -1894,7 +1900,7 @@ public:
   /// Is this message in order (return >0) or not (return 0)?
   /// Same as put() except we don't call putOutOfOrder() here,
   /// so the caller should do that separately
-  inline int isInOrder(int srcRank, CMK_REFNUM_TYPE seq) noexcept {
+  inline int putIfInOrder(int srcRank, CMK_REFNUM_TYPE seq) noexcept {
     AmpiOtherElement &el = elements[srcRank];
     if (seq == el.getSeqIncoming()) { // In order:
       el.incSeqIncoming();
@@ -1903,6 +1909,11 @@ public:
     else { // Out of order: caller should stash message
       return 0;
     }
+  }
+
+  /// Is this in-order?
+  inline bool isInOrder(int seqIdx, CMK_REFNUM_TYPE seq) noexcept {
+    return (seq == elements[seqIdx].getSeqIncoming());
   }
 
   /// Get an out-of-order message from the table.
@@ -1922,6 +1933,11 @@ public:
     AmpiOtherElement &el = elements[destRank];
     el.incSeqOutgoing();
     return el.getSeqOutgoing();
+  }
+
+  /// Reset the outgoing sequence number to its previous value.
+  inline void resetOutgoing(int destRank) noexcept {
+    elements[destRank].decSeqOutgoing();
   }
 };
 PUPmarshall(AmpiSeqQ)
@@ -2453,9 +2469,12 @@ class ampi final : public CBase_ampi {
   CkPupPtrVec<win_obj> winObjects;
 
  private:
+  inline bool isInOrder(int seqIdx, int seq) noexcept { return oorder.isInOrder(seqIdx, seq); }
   bool inorder(AmpiMsg *msg) noexcept;
   void inorderBcast(AmpiMsg *msg, bool deleteMsg) noexcept;
   void inorderRdma(char* buf, int size, CMK_REFNUM_TYPE seq, int tag, int srcRank) noexcept;
+  inline void localInorder(char* buf, int size, int seqIdx, CMK_REFNUM_TYPE seq, int tag,
+                           int srcRank, IReq* ireq) noexcept;
 
   void init() noexcept;
   void findParent(bool forMigration) noexcept;
@@ -2532,6 +2551,7 @@ class ampi final : public CBase_ampi {
   MPI_Request postReq(AmpiRequest* newreq) noexcept;
   inline void waitOnBlockingSend(MPI_Request* req, AmpiSendType sendType) noexcept;
   inline void requestSsendMsg(AmpiMsg* msg) noexcept;
+  inline void completedSend(MPI_Request req) noexcept;
 
   inline CMK_REFNUM_TYPE getSeqNo(int destRank, MPI_Comm destcomm, int tag) noexcept;
   AmpiMsg *makeBcastMsg(const void *buf,int count,MPI_Datatype type,int root,MPI_Comm destcomm) noexcept;
@@ -2539,17 +2559,21 @@ class ampi final : public CBase_ampi {
                        MPI_Datatype type,MPI_Comm destcomm,int ssendReq,CMK_REFNUM_TYPE seq) noexcept;
   AmpiMsg *makeAmpiMsg(int destRank,int t,int sRank,const void *buf,int count,
                        MPI_Datatype type,MPI_Comm destcomm) noexcept;
+  AmpiMsg *makeAmpiMsg(int destRank,int t,int sRank,const void *buf,int count,
+                       MPI_Datatype type,MPI_Comm destcomm,CMK_REFNUM_TYPE seq) noexcept;
 
   MPI_Request send(int t, int s, const void* buf, int count, MPI_Datatype type, int rank,
                    MPI_Comm destcomm, AmpiSendType sendType=BLOCKING_SEND, MPI_Request=MPI_REQUEST_NULL) noexcept;
   static void sendraw(int t, int s, void* buf, int len, CkArrayID aid, int idx) noexcept;
-  inline MPI_Request sendLocalMsg(int t, int sRank, const void* buf, int size, MPI_Datatype type, int destRank,
-                                  MPI_Comm destcomm, ampi* destPtr, AmpiSendType sendType, MPI_Request req) noexcept;
-  inline MPI_Request sendRdmaMsg(int t, int sRank, const void* buf, int size, MPI_Datatype type, int destIdx,
-                                 int destRank, MPI_Comm destcomm, CProxy_ampi arrProxy, MPI_Request req) noexcept;
   inline MPI_Request sendSyncMsg(int t, int sRank, const void* buf, MPI_Datatype type, int count,
-                                int rank, MPI_Comm destcomm, CProxyElement_ampi destElem,
-                                AmpiSendType sendType, MPI_Request req) noexcept;
+                                 int rank, MPI_Comm destcomm, CMK_REFNUM_TYPE seq, CProxyElement_ampi destElem,
+                                 AmpiSendType sendType, MPI_Request reqIdx) noexcept;
+  inline MPI_Request sendLocalMsg(int t, int sRank, const void* buf, int size, MPI_Datatype type,
+                                  int count, int destRank, MPI_Comm destcomm, CMK_REFNUM_TYPE seq,
+                                  ampi* destPtr, AmpiSendType sendType, MPI_Request reqIdx) noexcept;
+  inline MPI_Request sendRdmaMsg(int t, int sRank, const void* buf, int size, MPI_Datatype type, int destIdx,
+                                 int destRank, MPI_Comm destcomm, CMK_REFNUM_TYPE seq, CProxy_ampi arrProxy,
+                                 MPI_Request reqIdx) noexcept;
   inline bool destLikelyWithinProcess(CProxy_ampi arrProxy, int destIdx) const noexcept {
     CkArray* localBranch = arrProxy.ckLocalBranch();
     int destPe = localBranch->lastKnown(CkArrayIndex1D(destIdx));
@@ -2557,6 +2581,7 @@ class ampi final : public CBase_ampi {
   }
   inline MPI_Request delesend(int t, int s, const void* buf, int count, MPI_Datatype type, int rank,
                               MPI_Comm destcomm, CProxy_ampi arrproxy, AmpiSendType sendType, MPI_Request req) noexcept;
+  inline bool processSsendMsg(AmpiMsg* msg, int* msgLen, char** msgData) noexcept;
   inline bool processAmpiMsg(AmpiMsg *msg, void* buf, MPI_Datatype type, int count) noexcept;
   inline void processRdmaMsg(const void *sbuf, int slength, int srank, void* rbuf,
                              int rcount, MPI_Datatype rtype, MPI_Comm comm) noexcept;

--- a/src/libs/ck-libs/ampi/ampiimpl.h
+++ b/src/libs/ck-libs/ampi/ampiimpl.h
@@ -105,18 +105,33 @@ class fromzDisk : public zdisk {
 
 /* AMPI sends messages inline to PE-local destination VPs if: BigSim is not being used and
  * if tracing is not being used (see bug #1640 for more details on the latter). */
-#ifndef AMPI_LOCAL_IMPL
-#define AMPI_LOCAL_IMPL ( !CMK_BIGSIM_CHARM && !CMK_TRACE_ENABLED )
+#ifndef AMPI_PE_LOCAL_IMPL
+#define AMPI_PE_LOCAL_IMPL ( !CMK_BIGSIM_CHARM && !CMK_TRACE_ENABLED )
+#endif
+
+/* AMPI sends messages using a zero copy protocol to Node-local destination VPs if:
+ * BigSim is not being used and if tracing is not being used (such msgs are currently untraced). */
+#ifndef AMPI_NODE_LOCAL_IMPL
+#define AMPI_NODE_LOCAL_IMPL ( CMK_SMP && !CMK_BIGSIM_CHARM && !CMK_TRACE_ENABLED )
 #endif
 
 /* messages larger than or equal to this threshold may block on a matching recv if local to the PE*/
 #ifndef AMPI_PE_LOCAL_THRESHOLD_DEFAULT
-#define AMPI_PE_LOCAL_THRESHOLD_DEFAULT 4096
+#define AMPI_PE_LOCAL_THRESHOLD_DEFAULT 8192
 #endif
 
 /* messages larger than or equal to this threshold may block on a matching recv if local to the Node */
 #ifndef AMPI_NODE_LOCAL_THRESHOLD_DEFAULT
-#define AMPI_NODE_LOCAL_THRESHOLD_DEFAULT 16384
+#define AMPI_NODE_LOCAL_THRESHOLD_DEFAULT 32768
+#endif
+
+/* messages larger than or equal to this threshold will always block on a matching recv */
+#ifndef AMPI_SSEND_THRESHOLD_DEFAULT
+#if CMK_USE_IBVERBS || CMK_CONVERSE_UGNI
+#define AMPI_SSEND_THRESHOLD_DEFAULT 262144
+#else
+#define AMPI_SSEND_THRESHOLD_DEFAULT 131072
+#endif
 #endif
 
 /* AMPI uses RDMA sends if BigSim is not being used. */
@@ -126,11 +141,7 @@ class fromzDisk : public zdisk {
 
 /* contiguous messages larger than or equal to this threshold are sent via RDMA */
 #ifndef AMPI_RDMA_THRESHOLD_DEFAULT
-#if CMK_USE_IBVERBS || CMK_OFI || CMK_CONVERSE_UGNI
-#define AMPI_RDMA_THRESHOLD_DEFAULT 65536
-#else
-#define AMPI_RDMA_THRESHOLD_DEFAULT 32768
-#endif
+#define AMPI_RDMA_THRESHOLD_DEFAULT 102400
 #endif
 
 extern int AMPI_RDMA_THRESHOLD;
@@ -2679,7 +2690,8 @@ class ampi final : public CBase_ampi {
   AmpiMsg *makeBcastMsg(const void *buf,int count,MPI_Datatype type,int root,MPI_Comm destcomm) noexcept;
   AmpiMsg *makeSyncMsg(int t,int sRank,const void *buf,int count,
                        MPI_Datatype type,CProxy_ampi destProxy,
-                       int destIdx,int ssendReq,CMK_REFNUM_TYPE seq) noexcept;
+                       int destIdx,int ssendReq,CMK_REFNUM_TYPE seq,
+                       ampi* destPtr) noexcept;
   AmpiMsg *makeNcpyShmMsg(int t, int sRank, const void* buf, int count,
                           MPI_Datatype type, int ssendReq, int seq) noexcept;
   AmpiMsg *makeNcpyMsg(int t, int sRank, const void* buf, int count,
@@ -2694,22 +2706,22 @@ class ampi final : public CBase_ampi {
   static void sendraw(int t, int s, void* buf, int len, CkArrayID aid, int idx) noexcept;
   inline MPI_Request sendSyncMsg(int t, int sRank, const void* buf, MPI_Datatype type, int count,
                                  int rank, MPI_Comm destcomm, CMK_REFNUM_TYPE seq, CProxy_ampi destElem,
-                                 int destIdx, AmpiSendType sendType, MPI_Request reqIdx) noexcept;
-  inline MPI_Request sendLocalInOrderMsg(int t, int sRank, const void* buf, int size, MPI_Datatype type,
-                                         int count, int destRank, MPI_Comm destcomm, CMK_REFNUM_TYPE seq,
-                                         ampi* destPtr, AmpiSendType sendType, MPI_Request reqIdx) noexcept;
+                                 int destIdx, AmpiSendType sendType, MPI_Request reqIdx, ampi* destPtr) noexcept;
+  inline MPI_Request sendLocalMsg(int t, int sRank, const void* buf, int size, MPI_Datatype type,
+                                  int count, int destRank, MPI_Comm destcomm, CMK_REFNUM_TYPE seq,
+                                  ampi* destPtr, AmpiSendType sendType, MPI_Request reqIdx) noexcept;
   inline MPI_Request sendRdmaMsg(int t, int sRank, const void* buf, int size, MPI_Datatype type, int destIdx,
                                  int destRank, MPI_Comm destcomm, CMK_REFNUM_TYPE seq, CProxy_ampi arrProxy,
                                  MPI_Request reqIdx) noexcept;
-  inline bool destLikelyWithinProcess(CProxy_ampi arrProxy, int destIdx) const noexcept {
+  inline bool destLikelyWithinProcess(CProxy_ampi arrProxy, int destIdx, ampi* destPtr) const noexcept {
 #if CMK_MULTICORE
     return true;
 #elif CMK_SMP
+    if (destPtr != NULL) return true;
     CkArray* localBranch = arrProxy.ckLocalBranch();
     int destPe = localBranch->lastKnown(CkArrayIndex1D(destIdx));
     return (CkNodeOf(destPe) == CkMyNode());
 #else // non-SMP
-    ampi* destPtr = arrProxy[destIdx].ckLocal();
     return (destPtr != NULL);
 #endif
   }

--- a/src/libs/ck-libs/ampi/ampiimpl.h
+++ b/src/libs/ck-libs/ampi/ampiimpl.h
@@ -1100,6 +1100,66 @@ inline vector<int> rangeExclOp(int n, int ranges[][3], const vector<int>& vec,
 
 extern int _mpi_nworlds;
 
+class CkNcpyBufferPool {
+ private:
+  std::forward_list<CkNcpyBuffer *> srcInfos; // list of free CkNcpyBuffer's
+  int curr;
+  int max;
+
+ public:
+  CkNcpyBufferPool() noexcept : curr(0), max(0) {}
+  CkNcpyBufferPool(int _max) noexcept : curr(0), max(_max) {}
+  ~CkNcpyBufferPool() noexcept {
+    clear();
+  }
+  inline void clear() noexcept {
+    while (!srcInfos.empty()) {
+      delete srcInfos.front();
+      srcInfos.pop_front();
+    }
+    curr = 0;
+  }
+  inline CkNcpyBuffer* newCkNcpyBuffer() noexcept {
+    if (srcInfos.empty()) {
+      return new CkNcpyBuffer();
+    } else {
+      CkNcpyBuffer* srcInfo = srcInfos.front();
+      CkAssert(srcInfo != NULL);
+      srcInfos.pop_front();
+      curr--;
+      return srcInfo;
+    }
+  }
+  inline CkNcpyBuffer* newCkNcpyBuffer(const void* buf, size_t size, CkCallback& cb) noexcept {
+    if (srcInfos.empty()) {
+      return new CkNcpyBuffer(buf, size, cb);
+    } else {
+      CkNcpyBuffer* srcInfo = srcInfos.front();
+      CkAssert(srcInfo != NULL);
+      srcInfos.pop_front();
+      curr--;
+      srcInfo->init(buf, size, cb);
+      srcInfo->registerMem();
+      return srcInfo;
+    }
+  }
+  inline void deleteCkNcpyBuffer(CkNcpyBuffer* srcInfo) noexcept {
+    if (curr != max) {
+      CkAssert(srcInfo != NULL);
+      srcInfos.push_front(srcInfo);
+      curr++;
+    } else {
+      delete srcInfo;
+    }
+  }
+  void pup(PUP::er& p) noexcept {
+    p|max;
+    // Don't PUP the CkNcpyBuffer's in the free list, let the pool fill lazily
+  }
+};
+
+CkpvExtern(CkNcpyBufferPool, ncpyBufferPool);
+
 //MPI_ANY_TAG is defined in ampi.h to MPI_TAG_UB_VALUE+1
 #define MPI_ATA_SEQ_TAG     MPI_TAG_UB_VALUE+2
 #define MPI_BCAST_TAG       MPI_TAG_UB_VALUE+3
@@ -1328,7 +1388,7 @@ class IReq final : public AmpiRequest {
   void deregisterMem() noexcept override {
     if (targetInfo) {
       targetInfo->deregisterMem();
-      delete targetInfo;
+      CkpvAccess(ncpyBufferPool).deleteCkNcpyBuffer(targetInfo);
     }
     if (systemBuf) {
       delete [] systemBuf;
@@ -1344,9 +1404,7 @@ class IReq final : public AmpiRequest {
     bool hasTargetInfo = (targetInfo != NULL);
     p|hasTargetInfo;
     if (hasTargetInfo) {
-      if (p.isUnpacking()) {
-        targetInfo = new CkNcpyBuffer();
-      }
+      if (p.isUnpacking()) targetInfo = CkpvAccess(ncpyBufferPool).newCkNcpyBuffer();
       p|*targetInfo;
     }
   }
@@ -1540,7 +1598,7 @@ class SsendReq final : public AmpiRequest {
   void deregisterMem() noexcept override {
     if (srcInfo) {
       srcInfo->deregisterMem();
-      delete srcInfo;
+      CkpvAccess(ncpyBufferPool).deleteCkNcpyBuffer(srcInfo);
     }
     if (systemBuf) {
       delete [] (char*)buf;
@@ -1558,7 +1616,7 @@ class SsendReq final : public AmpiRequest {
     bool hasSrcInfo = (srcInfo != NULL);
     p|hasSrcInfo;
     if (hasSrcInfo) {
-      if (p.isUnpacking()) srcInfo = new CkNcpyBuffer();
+      if (p.isUnpacking()) srcInfo = CkpvAccess(ncpyBufferPool).newCkNcpyBuffer();
       p|*srcInfo;
     }
   }

--- a/src/libs/ck-libs/ampi/ampiimpl.h
+++ b/src/libs/ck-libs/ampi/ampiimpl.h
@@ -109,9 +109,14 @@ class fromzDisk : public zdisk {
 #define AMPI_LOCAL_IMPL ( !CMK_BIGSIM_CHARM && !CMK_TRACE_ENABLED )
 #endif
 
-/* messages larger than or equal to this threshold may block on a matching recv if local */
-#ifndef AMPI_LOCAL_THRESHOLD_DEFAULT
-#define AMPI_LOCAL_THRESHOLD_DEFAULT 4096
+/* messages larger than or equal to this threshold may block on a matching recv if local to the PE*/
+#ifndef AMPI_PE_LOCAL_THRESHOLD_DEFAULT
+#define AMPI_PE_LOCAL_THRESHOLD_DEFAULT 4096
+#endif
+
+/* messages larger than or equal to this threshold may block on a matching recv if local to the Node */
+#ifndef AMPI_NODE_LOCAL_THRESHOLD_DEFAULT
+#define AMPI_NODE_LOCAL_THRESHOLD_DEFAULT 16384
 #endif
 
 /* AMPI uses RDMA sends if BigSim is not being used and the underlying comm
@@ -129,14 +134,7 @@ class fromzDisk : public zdisk {
 #endif
 #endif
 
-/* contiguous messages larger than or equal to this threshold that are being sent
- * within a process are sent via RDMA. */
-#ifndef AMPI_SMP_RDMA_THRESHOLD_DEFAULT
-#define AMPI_SMP_RDMA_THRESHOLD_DEFAULT 16384
-#endif
-
 extern int AMPI_RDMA_THRESHOLD;
-extern int AMPI_SMP_RDMA_THRESHOLD;
 
 #define AMPI_ALLTOALL_THROTTLE   64
 #define AMPI_ALLTOALL_SHORT_MSG  256
@@ -287,6 +285,30 @@ class AmpiOpHeader {
   AmpiOpHeader(MPI_User_function* f,MPI_Datatype d,int l,int szd) noexcept :
     func(f),dtype(d),len(l),szdata(szd) { }
 };
+
+/*
+ * For within-node Ssend's: used in ampi::processSsendMsg()
+ */
+class SsendInfo {
+ private:
+  int node;
+  int idx;
+  int count;
+  char* buf;
+  CkDDT_DataType* ddt;
+
+ public:
+  SsendInfo() = default;
+  SsendInfo(int idx_, int count_, char* buf_, CkDDT_DataType* ddt_) noexcept :
+    node(CkMyNode()), idx(idx_), count(count_), buf(buf_), ddt(ddt_) {}
+  ~SsendInfo() {}
+  inline int getNode() const noexcept { return node; }
+  inline int getIdx() const noexcept { return idx; }
+  inline int getCount() const noexcept { return count; }
+  inline char* getBuf() const noexcept { CkAssert(node == CkMyNode()); return buf; }
+  inline CkDDT_DataType* getDDT() const noexcept { CkAssert(node == CkMyNode()); return ddt; }
+};
+PUPbytes(SsendInfo) // PUP as bytes b/c buf & ddt are only meant to be accessed from within shared memory
 
 //------------------- added by YAN for one-sided communication -----------
 /* the index is unique within a communicator */
@@ -2575,9 +2597,16 @@ class ampi final : public CBase_ampi {
                                  int destRank, MPI_Comm destcomm, CMK_REFNUM_TYPE seq, CProxy_ampi arrProxy,
                                  MPI_Request reqIdx) noexcept;
   inline bool destLikelyWithinProcess(CProxy_ampi arrProxy, int destIdx) const noexcept {
+#if CMK_MULTICORE
+    return true;
+#elif CMK_SMP
     CkArray* localBranch = arrProxy.ckLocalBranch();
     int destPe = localBranch->lastKnown(CkArrayIndex1D(destIdx));
     return (CkNodeOf(destPe) == CkMyNode());
+#else // non-SMP
+    ampi* destPtr = arrProxy[destIdx].ckLocal();
+    return (destPtr != NULL);
+#endif
   }
   inline MPI_Request delesend(int t, int s, const void* buf, int count, MPI_Datatype type, int rank,
                               MPI_Comm destcomm, CProxy_ampi arrproxy, AmpiSendType sendType, MPI_Request req) noexcept;

--- a/src/libs/ck-libs/ampi/ampiimpl.h
+++ b/src/libs/ck-libs/ampi/ampiimpl.h
@@ -1178,7 +1178,7 @@ class AmpiRequest {
 
   /// Block until this request is finished,
   ///  returning a valid MPI error code.
-  virtual int wait(MPI_Status *sts) noexcept =0;
+  virtual int wait(ampiParent* parent, MPI_Status *sts) noexcept =0;
 
   /// Mark this request for cancellation.
   /// Supported only for IReq requests
@@ -1296,7 +1296,7 @@ class IReq final : public AmpiRequest {
   IReq() =default;
   ~IReq() =default;
   bool test(MPI_Status *sts=MPI_STATUS_IGNORE) noexcept override;
-  int wait(MPI_Status *sts) noexcept override;
+  int wait(ampiParent* parent, MPI_Status *sts) noexcept override;
   void cancel() noexcept override { if (!complete) cancelled = true; }
   AmpiReqType getType() const noexcept override { return AMPI_I_REQ; }
   bool isUnmatched() const noexcept override { return !complete; }
@@ -1361,7 +1361,7 @@ class RednReq final : public AmpiRequest {
   RednReq() =default;
   ~RednReq() =default;
   bool test(MPI_Status *sts=MPI_STATUS_IGNORE) noexcept override;
-  int wait(MPI_Status *sts) noexcept override;
+  int wait(ampiParent* parent, MPI_Status *sts) noexcept override;
   void cancel() noexcept override {}
   AmpiReqType getType() const noexcept override { return AMPI_REDN_REQ; }
   bool isUnmatched() const noexcept override { return !complete; }
@@ -1390,7 +1390,7 @@ class GatherReq final : public AmpiRequest {
   GatherReq() =default;
   ~GatherReq() =default;
   bool test(MPI_Status *sts=MPI_STATUS_IGNORE) noexcept override;
-  int wait(MPI_Status *sts) noexcept override;
+  int wait(ampiParent* parent, MPI_Status *sts) noexcept override;
   void cancel() noexcept override {}
   AmpiReqType getType() const noexcept override { return AMPI_GATHER_REQ; }
   bool isUnmatched() const noexcept override { return !complete; }
@@ -1423,7 +1423,7 @@ class GathervReq final : public AmpiRequest {
   GathervReq() =default;
   ~GathervReq() =default;
   bool test(MPI_Status *sts=MPI_STATUS_IGNORE) noexcept override;
-  int wait(MPI_Status *sts) noexcept override;
+  int wait(ampiParent* parent, MPI_Status *sts) noexcept override;
   AmpiReqType getType() const noexcept override { return AMPI_GATHERV_REQ; }
   bool isUnmatched() const noexcept override { return !complete; }
   bool receive(ampi *ptr, AmpiMsg *msg, bool deleteMsg=true) noexcept override { return true; }
@@ -1460,7 +1460,7 @@ class SendReq final : public AmpiRequest {
   SendReq() noexcept {}
   ~SendReq() noexcept {}
   bool test(MPI_Status *sts=MPI_STATUS_IGNORE) noexcept override;
-  int wait(MPI_Status *sts) noexcept override;
+  int wait(ampiParent* parent, MPI_Status *sts) noexcept override;
   void setPersistent(bool p) noexcept override { persistent = p; }
   bool isPersistent() const noexcept override { return persistent; }
   void start(MPI_Request reqIdx) noexcept override;
@@ -1517,7 +1517,7 @@ class SsendReq final : public AmpiRequest {
   SsendReq() =default;
   ~SsendReq() =default;
   bool test(MPI_Status *sts=MPI_STATUS_IGNORE) noexcept override;
-  int wait(MPI_Status *sts) noexcept override;
+  int wait(ampiParent* parent, MPI_Status *sts) noexcept override;
   void setPersistent(bool p) noexcept override { persistent = p; }
   bool isPersistent() const noexcept override { return persistent; }
   void start(MPI_Request reqIdx) noexcept override;
@@ -1578,7 +1578,7 @@ class ATAReq final : public AmpiRequest {
   ATAReq() =default;
   ~ATAReq() =default;
   bool test(MPI_Status *sts=MPI_STATUS_IGNORE) noexcept override;
-  int wait(MPI_Status *sts) noexcept override;
+  int wait(ampiParent* parent, MPI_Status *sts) noexcept override;
   bool receive(ampi *ptr, AmpiMsg *msg, bool deleteMsg=true) noexcept override { return true; }
   void receive(ampi *ptr, CkReductionMsg *msg) noexcept override {}
   int getCount() const noexcept { return reqs.size(); }
@@ -1610,7 +1610,7 @@ class GReq final : public AmpiRequest {
   GReq() =default;
   ~GReq() noexcept { (*freeFn)(extraState); }
   bool test(MPI_Status *sts=MPI_STATUS_IGNORE) noexcept override;
-  int wait(MPI_Status *sts) noexcept override;
+  int wait(ampiParent* parent, MPI_Status *sts) noexcept override;
   bool receive(ampi *ptr, AmpiMsg *msg, bool deleteMsg=true) noexcept override { return true; }
   void receive(ampi *ptr, CkReductionMsg *msg) noexcept override {}
   void cancel() noexcept override { (*cancelFn)(extraState, complete); }
@@ -1648,8 +1648,8 @@ class AmpiRequestList {
     return reqs[n];
 #endif
   }
-  void free(AmpiRequestPool& reqPool, int idx, CkDDT *ddt) noexcept;
-  void freeNonPersReq(int &idx) noexcept;
+  void free(int idx, CkDDT *ddt) noexcept;
+  void freeNonPersReq(ampiParent* pptr, int &idx) noexcept;
   inline int insert(AmpiRequest* req) noexcept {
     for (int i=startIdx; i<reqs.size(); i++) {
       if (reqs[i] == NULL) {
@@ -2666,6 +2666,7 @@ class ampi final : public CBase_ampi {
     return static_blockOnColl(this);
   }
   inline void setBlockingReq(AmpiRequest *req) noexcept;
+  inline AmpiRequestPool& getReqPool() const { return parent->reqPool; }
   inline ampi* blockOnIReq(void* buf, int count, MPI_Datatype type, int s,
                            int t, MPI_Comm comm, MPI_Status* sts) noexcept;
   MPI_Request postReq(AmpiRequest* newreq) noexcept;

--- a/src/libs/ck-libs/ampi/ampiimpl.h
+++ b/src/libs/ck-libs/ampi/ampiimpl.h
@@ -1986,6 +1986,7 @@ class ampiParent final : public CBase_ampiParent {
 
  public:
   void prepareCtv() noexcept;
+  TCharm* getThread() noexcept { return thread; }
 
   MPI_Message putMatchedMsg(AmpiMsg* msg) noexcept {
     // Search thru matchedMsgs for any NULL ones first:

--- a/src/libs/ck-libs/ampi/ampiimpl.h
+++ b/src/libs/ck-libs/ampi/ampiimpl.h
@@ -2499,6 +2499,7 @@ class ampiParent final : public CBase_ampiParent {
   }
 
   int wait(MPI_Request* req, MPI_Status* sts) noexcept;
+  int waitall(int count, MPI_Request request[], MPI_Status sts[]=MPI_STATUSES_IGNORE) noexcept;
   void init() noexcept;
   void finalize() noexcept;
   CMI_WARN_UNUSED_RESULT ampiParent* block() noexcept;

--- a/src/libs/ck-libs/ampi/ampiimpl.h
+++ b/src/libs/ck-libs/ampi/ampiimpl.h
@@ -1094,9 +1094,11 @@ enum AmpiReqSts : char {
   AMPI_REQ_COMPLETED = 2
 };
 
-enum AmpiSendType : bool {
-  BLOCKING_SEND = false,
-  I_SEND = true
+enum AmpiSendType : char {
+  BLOCKING_SEND = 0,
+  I_SEND = 1,
+  BLOCKING_SSEND = 2,
+  I_SSEND = 3
 };
 
 #define MyAlign8(x) (((x)+7)&(~7))
@@ -1152,14 +1154,16 @@ class AmpiRequest {
   virtual bool isPersistent() const noexcept { return false; }
 
   /// Receive an AmpiMsg
-  virtual void receive(ampi *ptr, AmpiMsg *msg, bool deleteMsg=true) noexcept =0;
+  /// Returns true if the msg payload is recv'ed, otherwise return false
+  /// (if the msg is a sync msg, it can't be recv'ed until the caller
+  /// acks the sender to get the real payload)
+  virtual bool receive(ampi *ptr, AmpiMsg *msg, bool deleteMsg=true) noexcept =0;
 
   /// Receive a CkReductionMsg
   virtual void receive(ampi *ptr, CkReductionMsg *msg) noexcept =0;
 
   /// Receive an Rdma message
-  virtual void receiveRdma(ampi *ptr, char *sbuf, int slength, int ssendReq,
-                           int srcRank, MPI_Comm scomm) noexcept { }
+  virtual void receiveRdma(ampi *ptr, char *sbuf, int slength, int srcRank) noexcept { }
 
   /// Set the request's index into AmpiRequestList
   void setReqIdx(MPI_Request idx) noexcept { reqIdx = idx; }
@@ -1255,9 +1259,9 @@ class IReq final : public AmpiRequest {
   void setPersistent(bool p) noexcept override { persistent = p; }
   bool isPersistent() const noexcept override { return persistent; }
   void start(MPI_Request reqIdx) noexcept override;
-  void receive(ampi *ptr, AmpiMsg *msg, bool deleteMsg=true) noexcept override;
+  bool receive(ampi *ptr, AmpiMsg *msg, bool deleteMsg=true) noexcept override;
   void receive(ampi *ptr, CkReductionMsg *msg) noexcept override {}
-  void receiveRdma(ampi *ptr, char *sbuf, int slength, int ssendReq, int srcRank, MPI_Comm scomm) noexcept override;
+  void receiveRdma(ampi *ptr, char *sbuf, int slength, int srcRank) noexcept override;
   int getNumReceivedBytes(CkDDT *ptr) const noexcept override {
     return length;
   }
@@ -1293,7 +1297,7 @@ class RednReq final : public AmpiRequest {
   void cancel() noexcept override {}
   AmpiReqType getType() const noexcept override { return AMPI_REDN_REQ; }
   bool isUnmatched() const noexcept override { return !complete; }
-  void receive(ampi *ptr, AmpiMsg *msg, bool deleteMsg=true) noexcept override {}
+  bool receive(ampi *ptr, AmpiMsg *msg, bool deleteMsg=true) noexcept override { return true; }
   void receive(ampi *ptr, CkReductionMsg *msg) noexcept override;
   void pup(PUP::er &p) noexcept override {
     AmpiRequest::pup(p);
@@ -1322,7 +1326,7 @@ class GatherReq final : public AmpiRequest {
   void cancel() noexcept override {}
   AmpiReqType getType() const noexcept override { return AMPI_GATHER_REQ; }
   bool isUnmatched() const noexcept override { return !complete; }
-  void receive(ampi *ptr, AmpiMsg *msg, bool deleteMsg=true) noexcept override {}
+  bool receive(ampi *ptr, AmpiMsg *msg, bool deleteMsg=true) noexcept override { return true; }
   void receive(ampi *ptr, CkReductionMsg *msg) noexcept override;
   void pup(PUP::er &p) noexcept override {
     AmpiRequest::pup(p);
@@ -1354,7 +1358,7 @@ class GathervReq final : public AmpiRequest {
   int wait(MPI_Status *sts) noexcept override;
   AmpiReqType getType() const noexcept override { return AMPI_GATHERV_REQ; }
   bool isUnmatched() const noexcept override { return !complete; }
-  void receive(ampi *ptr, AmpiMsg *msg, bool deleteMsg=true) noexcept override {}
+  bool receive(ampi *ptr, AmpiMsg *msg, bool deleteMsg=true) noexcept override { return true; }
   void receive(ampi *ptr, CkReductionMsg *msg) noexcept override;
   void pup(PUP::er &p) noexcept override {
     AmpiRequest::pup(p);
@@ -1392,7 +1396,7 @@ class SendReq final : public AmpiRequest {
   void setPersistent(bool p) noexcept override { persistent = p; }
   bool isPersistent() const noexcept override { return persistent; }
   void start(MPI_Request reqIdx) noexcept override;
-  void receive(ampi *ptr, AmpiMsg *msg, bool deleteMsg=true) noexcept override {}
+  bool receive(ampi *ptr, AmpiMsg *msg, bool deleteMsg=true) noexcept override { return true; }
   void receive(ampi *ptr, CkReductionMsg *msg) noexcept override {}
   AmpiReqType getType() const noexcept override { return AMPI_SEND_REQ; }
   bool isUnmatched() const noexcept override { return false; }
@@ -1407,6 +1411,8 @@ class SendReq final : public AmpiRequest {
 class SsendReq final : public AmpiRequest {
  private:
   bool persistent = false; // is this a persistent Ssend request?
+ public:
+  int destRank = MPI_PROC_NULL;
 
  public:
   SsendReq(MPI_Datatype type_, MPI_Comm comm_, CkDDT* ddt_, AmpiReqSts sts_=AMPI_REQ_PENDING) noexcept
@@ -1415,26 +1421,27 @@ class SsendReq final : public AmpiRequest {
     comm = comm_;
     AMPI_REQUEST_COMMON_INIT
   }
-  SsendReq(void* buf_, int count_, MPI_Datatype type_, int dest_, int tag_, MPI_Comm comm_,
+  SsendReq(const void* buf_, int count_, MPI_Datatype type_, int dest_, int tag_, MPI_Comm comm_,
            CkDDT* ddt_, AmpiReqSts sts_=AMPI_REQ_PENDING) noexcept
   {
-    buf   = buf_;
-    count = count_;
-    type  = type_;
-    src   = dest_;
-    tag   = tag_;
-    comm  = comm_;
+    buf      = (void*)buf_;
+    count    = count_;
+    type     = type_;
+    tag      = tag_;
+    comm     = comm_;
+    destRank = dest_;
     AMPI_REQUEST_COMMON_INIT
   }
-  SsendReq(void* buf_, int count_, MPI_Datatype type_, int dest_, int tag_, MPI_Comm comm_,
+  SsendReq(const void* buf_, int count_, MPI_Datatype type_, int dest_, int tag_, MPI_Comm comm_,
            int src_, CkDDT* ddt_, AmpiReqSts sts_=AMPI_REQ_PENDING) noexcept
   {
-    buf   = buf_;
-    count = count_;
-    type  = type_;
-    src   = dest_;
-    tag   = tag_;
-    comm  = comm_;
+    buf      = (void*)buf_;
+    count    = count_;
+    type     = type_;
+    src      = src_;
+    tag      = tag_;
+    comm     = comm_;
+    destRank = dest_;
     AMPI_REQUEST_COMMON_INIT
   }
   SsendReq() =default;
@@ -1444,7 +1451,7 @@ class SsendReq final : public AmpiRequest {
   void setPersistent(bool p) noexcept override { persistent = p; }
   bool isPersistent() const noexcept override { return persistent; }
   void start(MPI_Request reqIdx) noexcept override;
-  void receive(ampi *ptr, AmpiMsg *msg, bool deleteMsg=true) noexcept override {}
+  bool receive(ampi *ptr, AmpiMsg *msg, bool deleteMsg=true) noexcept override { return true; }
   void receive(ampi *ptr, CkReductionMsg *msg) noexcept override {}
   AmpiReqType getType() const noexcept override { return AMPI_SSEND_REQ; }
   bool isUnmatched() const noexcept override { return false; }
@@ -1452,6 +1459,7 @@ class SsendReq final : public AmpiRequest {
   void pup(PUP::er &p) noexcept override {
     AmpiRequest::pup(p);
     p|persistent;
+    p|destRank;
   }
   void print() const noexcept override;
 };
@@ -1481,7 +1489,7 @@ class ATAReq final : public AmpiRequest {
   ~ATAReq() =default;
   bool test(MPI_Status *sts=MPI_STATUS_IGNORE) noexcept override;
   int wait(MPI_Status *sts) noexcept override;
-  void receive(ampi *ptr, AmpiMsg *msg, bool deleteMsg=true) noexcept override {}
+  bool receive(ampi *ptr, AmpiMsg *msg, bool deleteMsg=true) noexcept override { return true; }
   void receive(ampi *ptr, CkReductionMsg *msg) noexcept override {}
   int getCount() const noexcept { return reqs.size(); }
   AmpiReqType getType() const noexcept override { return AMPI_ATA_REQ; }
@@ -1513,7 +1521,7 @@ class GReq final : public AmpiRequest {
   ~GReq() noexcept { (*freeFn)(extraState); }
   bool test(MPI_Status *sts=MPI_STATUS_IGNORE) noexcept override;
   int wait(MPI_Status *sts) noexcept override;
-  void receive(ampi *ptr, AmpiMsg *msg, bool deleteMsg=true) noexcept override {}
+  bool receive(ampi *ptr, AmpiMsg *msg, bool deleteMsg=true) noexcept override { return true; }
   void receive(ampi *ptr, CkReductionMsg *msg) noexcept override {}
   void cancel() noexcept override { (*cancelFn)(extraState, complete); }
   AmpiReqType getType() const noexcept override { return AMPI_G_REQ; }
@@ -1622,7 +1630,7 @@ class AmpiMsgPool;
 
 class AmpiMsg final : public CMessage_AmpiMsg {
  private:
-  int ssendReq; //Index to the sender's request
+  int ssendReq; //Index to the sender's request (MPI_REQUEST_NULL if no request)
   int tag; //MPI tag
   int srcRank; //Communicator rank for source
   int length; //Number of bytes in this message
@@ -1644,15 +1652,16 @@ class AmpiMsg final : public CMessage_AmpiMsg {
   AmpiMsg(CMK_REFNUM_TYPE seq, int sreq, int t, int sRank, int l) noexcept :
     ssendReq(sreq), tag(t), srcRank(sRank), length(l), origLength(l)
   { CkSetRefNum(this, seq); }
-  inline void setSsendReq(int s) noexcept { CkAssert(s >= 0); ssendReq = s; }
+  inline bool isSsend(void) const noexcept { return (ssendReq >= 0); }
+  inline void setSsendReq(int s) noexcept { ssendReq = s; }
   inline void setSeq(CMK_REFNUM_TYPE s) noexcept { CkAssert(s >= 0); UsrToEnv(this)->setRef(s); }
   inline void setSrcRank(int sr) noexcept { srcRank = sr; }
   inline void setLength(int l) noexcept { length = l; }
   inline void setTag(int t) noexcept { tag = t; }
   inline void setComm(MPI_Comm c) noexcept { comm = c; }
-  inline CMK_REFNUM_TYPE getSeq() const noexcept { return UsrToEnv(this)->getRef(); }
-  inline int getSsendReq() const noexcept { return ssendReq; }
-  inline int getSeqIdx() const noexcept {
+  inline CMK_REFNUM_TYPE getSeq(void) const noexcept { return UsrToEnv(this)->getRef(); }
+  inline int getSsendReq(void) const noexcept { return ssendReq; }
+  inline int getSeqIdx(void) const noexcept {
     // seqIdx is srcRank, unless this message was part of a collective
     if (tag >= MPI_BCAST_TAG && tag <= MPI_ATA_TAG) {
       return COLL_SEQ_IDX;
@@ -2444,10 +2453,9 @@ class ampi final : public CBase_ampi {
   CkPupPtrVec<win_obj> winObjects;
 
  private:
-  void inorder(AmpiMsg *msg) noexcept;
+  bool inorder(AmpiMsg *msg) noexcept;
   void inorderBcast(AmpiMsg *msg, bool deleteMsg) noexcept;
-  void inorderRdma(char* buf, int size, CMK_REFNUM_TYPE seq, int tag, int srcRank,
-                   MPI_Comm comm, int ssendReq) noexcept;
+  void inorderRdma(char* buf, int size, CMK_REFNUM_TYPE seq, int tag, int srcRank) noexcept;
 
   void init() noexcept;
   void findParent(bool forMigration) noexcept;
@@ -2470,14 +2478,14 @@ class ampi final : public CBase_ampi {
   }
 
   void injectMsg(int size, char* buf) noexcept;
+  void genericSync(AmpiMsg *) noexcept;
   void generic(AmpiMsg *) noexcept;
-  void genericRdma(char* buf, int size, CMK_REFNUM_TYPE seq, int tag, int srcRank,
-                   MPI_Comm destcomm, int ssendReq) noexcept;
+  void genericRdma(char* buf, int size, CMK_REFNUM_TYPE seq, int tag, int srcRank) noexcept;
   void completedRdmaSend(CkDataMsg *msg) noexcept;
-  void ssend_ack(int sreq) noexcept;
-  void barrierResult() noexcept;
-  void ibarrierResult() noexcept;
+  void ssendAck(int sreqIdx) noexcept;
   void bcastResult(AmpiMsg *msg) noexcept;
+  void barrierResult(void) noexcept;
+  void ibarrierResult(void) noexcept;
   void rednResult(CkReductionMsg *msg) noexcept;
   void irednResult(CkReductionMsg *msg) noexcept;
 
@@ -2519,29 +2527,38 @@ class ampi final : public CBase_ampi {
     return static_blockOnColl(this);
   }
   inline void setBlockingReq(AmpiRequest *req) noexcept;
+  inline ampi* blockOnIReq(void* buf, int count, MPI_Datatype type, int s,
+                           int t, MPI_Comm comm, MPI_Status* sts) noexcept;
   MPI_Request postReq(AmpiRequest* newreq) noexcept;
+  inline void waitOnBlockingSend(MPI_Request* req, AmpiSendType sendType) noexcept;
+  inline void requestSsendMsg(AmpiMsg* msg) noexcept;
 
   inline CMK_REFNUM_TYPE getSeqNo(int destRank, MPI_Comm destcomm, int tag) noexcept;
   AmpiMsg *makeBcastMsg(const void *buf,int count,MPI_Datatype type,int root,MPI_Comm destcomm) noexcept;
+  AmpiMsg *makeSyncMsg(int destRank,int t,int sRank,const void *buf,int count,
+                       MPI_Datatype type,MPI_Comm destcomm,int ssendReq,CMK_REFNUM_TYPE seq) noexcept;
   AmpiMsg *makeAmpiMsg(int destRank,int t,int sRank,const void *buf,int count,
-                       MPI_Datatype type,MPI_Comm destcomm, int ssendReq=0) noexcept;
+                       MPI_Datatype type,MPI_Comm destcomm) noexcept;
 
   MPI_Request send(int t, int s, const void* buf, int count, MPI_Datatype type, int rank,
-                   MPI_Comm destcomm, int ssendReq=0, AmpiSendType sendType=BLOCKING_SEND) noexcept;
+                   MPI_Comm destcomm, AmpiSendType sendType=BLOCKING_SEND, MPI_Request=MPI_REQUEST_NULL) noexcept;
   static void sendraw(int t, int s, void* buf, int len, CkArrayID aid, int idx) noexcept;
   inline MPI_Request sendLocalMsg(int t, int sRank, const void* buf, int size, MPI_Datatype type, int destRank,
-                                  MPI_Comm destcomm, ampi* destPtr, int ssendReq, AmpiSendType sendType) noexcept;
+                                  MPI_Comm destcomm, ampi* destPtr, AmpiSendType sendType, MPI_Request req) noexcept;
   inline MPI_Request sendRdmaMsg(int t, int sRank, const void* buf, int size, MPI_Datatype type, int destIdx,
-                                 int destRank, MPI_Comm destcomm, CProxy_ampi arrProxy, int ssendReq) noexcept;
+                                 int destRank, MPI_Comm destcomm, CProxy_ampi arrProxy, MPI_Request req) noexcept;
+  inline MPI_Request sendSyncMsg(int t, int sRank, const void* buf, MPI_Datatype type, int count,
+                                int rank, MPI_Comm destcomm, CProxyElement_ampi destElem,
+                                AmpiSendType sendType, MPI_Request req) noexcept;
   inline bool destLikelyWithinProcess(CProxy_ampi arrProxy, int destIdx) const noexcept {
     CkArray* localBranch = arrProxy.ckLocalBranch();
     int destPe = localBranch->lastKnown(CkArrayIndex1D(destIdx));
     return (CkNodeOf(destPe) == CkMyNode());
   }
-  MPI_Request delesend(int t, int s, const void* buf, int count, MPI_Datatype type, int rank,
-                       MPI_Comm destcomm, CProxy_ampi arrproxy, int ssend, AmpiSendType sendType) noexcept;
-  inline void processAmpiMsg(AmpiMsg *msg, void* buf, MPI_Datatype type, int count) noexcept;
-  inline void processRdmaMsg(const void *sbuf, int slength, int ssendReq, int srank, void* rbuf,
+  inline MPI_Request delesend(int t, int s, const void* buf, int count, MPI_Datatype type, int rank,
+                              MPI_Comm destcomm, CProxy_ampi arrproxy, AmpiSendType sendType, MPI_Request req) noexcept;
+  inline bool processAmpiMsg(AmpiMsg *msg, void* buf, MPI_Datatype type, int count) noexcept;
+  inline void processRdmaMsg(const void *sbuf, int slength, int srank, void* rbuf,
                              int rcount, MPI_Datatype rtype, MPI_Comm comm) noexcept;
   inline void processRednMsg(CkReductionMsg *msg, void* buf, MPI_Datatype type, int count) noexcept;
   inline void processNoncommutativeRednMsg(CkReductionMsg *msg, void* buf, MPI_Datatype type, int count,

--- a/src/libs/ck-libs/armci/armci_vp.C
+++ b/src/libs/ck-libs/armci/armci_vp.C
@@ -195,7 +195,7 @@ void ArmciVirtualProcessor::get(pointer src, pointer dst,
   }*/
   thisProxy[src_proc].requestFromGet(src, dst, nbytes, thisIndex, -1);
   // wait for reply
-  thread->suspend();
+  TCharm * unused = thread->suspend();
 }
 
 int ArmciVirtualProcessor::nbget(pointer src, pointer dst,
@@ -229,7 +229,7 @@ void ArmciVirtualProcessor::wait(int hdl){
     if(hdlList[hdl]->acked != 0)
       break;
     else
-      thread->suspend();
+      TCharm * unused = thread->suspend();
   }
 }
 
@@ -294,7 +294,7 @@ void ArmciVirtualProcessor::barrier(){
   allfence();
   CkCallback cb(CkIndex_ArmciVirtualProcessor::resumeThread(),thisProxy);
   contribute(0,NULL,CkReduction::sum_int,cb);
-  thread->suspend();
+  TCharm * unused = thread->suspend();
 }
 
 void ArmciVirtualProcessor::resumeThread(void){
@@ -446,7 +446,7 @@ void ArmciVirtualProcessor::gets(pointer src_ptr, int src_stride_ar[],
   thisProxy[src_proc].requestFromGets(src_ptr, src_stride_ar, dst_ptr, dst_stride_ar, 
   					count, stride_levels, thisIndex, -1);
   // wait for reply
-  thread->suspend();
+  TCharm * unused = thread->suspend();
 }
 
 int ArmciVirtualProcessor::nbgets(pointer src_ptr, int src_stride_ar[], 
@@ -579,7 +579,7 @@ void ArmciVirtualProcessor::notify_wait(int proc){
     hasNote = noteList.size() - 1;
   }
   if(noteList[hasNote]->notified < noteList[hasNote]->waited){
-    thread->suspend();
+    TCharm * unused = thread->suspend();
   }
 }
 
@@ -605,7 +605,8 @@ void ArmciVirtualProcessor::requestAddresses(pointer ptr, pointer ptr_arr[], int
   CkCallback cb(CkIndex_ArmciVirtualProcessor::mallocClient(NULL),CkArrayIndex1D(0),thisProxy);
   contribute(sizeof(addressPair), pair, CkReduction::concat, cb);
   // wait for the reply to arrive.
-  while(addressReply==NULL) thread->suspend();
+  while (addressReply==NULL)
+    TCharm * unused = thread->suspend();
 
   // copy the acquired data to the user-allocated array.
   for (int i=0; i<numPE; i++) {
@@ -663,7 +664,7 @@ void ArmciVirtualProcessor::msgBcast(void *buffer, int len, int root) {
   } else {
     // copy the buffer pointer to thread object
     collectiveTmpBufferPtr = buffer;
-    thread->suspend();
+    TCharm * unused = thread->suspend();
   }
 }
 
@@ -739,7 +740,7 @@ void ArmciVirtualProcessor::startCheckpoint(const char* dname){
   } else {
     contribute(0, NULL, CkReduction::sum_int);
   }
-  thread->suspend();
+  TCharm * unused = thread->suspend();
 }
 void ArmciVirtualProcessor::checkpoint(int len, const char* dname){
   if (len == 0) { // memory checkpoint

--- a/src/libs/ck-libs/collide/threadCollide.C
+++ b/src/libs/ck-libs/collide/threadCollide.C
@@ -145,7 +145,7 @@ public:
 	void contribute(int n,const bbox3d *boxes,const int *prio) 
 	{
 		CollideBoxesPrio(collide,thisIndex,n,boxes,prio);
-		thread->suspend(); //Will be resumed by call to resultsDone()
+		TCharm * unused = thread->suspend(); //Will be resumed by call to resultsDone()
 	}
 	
 	/// No more collisions will arrive this step.

--- a/src/libs/ck-libs/mblock/mblock.C
+++ b/src/libs/ck-libs/mblock/mblock.C
@@ -388,7 +388,7 @@ MBlockChunk::wait_update(void)
 {
   if(update.wait_seqnum != (-1)) {
     DBG("sleeping for "<<nRecvPatches-nRecd<<" update messages")
-    thread->suspend();
+    TCharm * unused = thread->suspend();
     DBG("got all update messages for "<<seqnum)  
   }
   return MBLK_SUCCESS;
@@ -450,7 +450,7 @@ MBlockChunk::reduce(int fid, const void *inbuf, void *outbuf, int op)
   reduce_output = outbuf;
   contribute(len, (void *)inbuf, rtype, 
   	CkCallback(index_t::reductionResult(0),thisProxy) );
-  thread->suspend();
+  TCharm * unused = thread->suspend();
 }
 
 void
@@ -560,7 +560,7 @@ CLINKAGE int
 MBLK_Migrate(void)
 {
   MBLOCKAPI("MBLK_Migrate");
-  TCharm::get()->migrate();
+  TCharm * unused = TCharm::get()->migrate();
   return MBLK_SUCCESS;
 }
 

--- a/src/libs/ck-libs/tcharm/tcharm.C
+++ b/src/libs/ck-libs/tcharm/tcharm.C
@@ -398,16 +398,16 @@ TCharm::~TCharm()
   delete initMsg;
 }
 
-void TCharm::migrateTo(int destPE) noexcept {
-	if (destPE==CkMyPe()) return;
+CMI_WARN_UNUSED_RESULT TCharm * TCharm::migrateTo(int destPE) noexcept {
+	if (destPE==CkMyPe()) return this;
 	if (CthMigratable() == 0) {
 	    CkPrintf("Warning> thread migration is not supported!\n");
-            return;
+            return this;
         }
 	asyncMigrate = true;
 	// Make sure migrateMe gets called *after* we suspend:
 	thisProxy[thisIndex].migrateDelayed(destPE);
-	suspend();
+	return suspend();
 }
 void TCharm::migrateDelayed(int destPE) {
 	migrateMe(destPE);
@@ -465,38 +465,41 @@ void TCharm::run() noexcept
 }
 
 //Go to sync, block, possibly migrate, and then resume
-void TCharm::migrate() noexcept
+CMI_WARN_UNUSED_RESULT TCharm * TCharm::migrate() noexcept
 {
 #if CMK_LBDB_ON
   DBG("going to sync");
   AtSync();
-  stop();
+  return stop();
 #else
   DBG("skipping sync, because there is no load balancer");
+  return this;
 #endif
 }
 
 #if CMK_FAULT_EVAC
-void TCharm::evacuate() noexcept {
+CMI_WARN_UNUSED_RESULT TCharm * TCharm::evacuate() noexcept {
 	//CkClearAllArrayElementsCPP();
 	if(CkpvAccess(startedEvac)){
 		CcdCallFnAfter((CcdVoidFn)CkEmmigrateElement, (void *)myRec, 1);
-		suspend();
+		return suspend();
 	}
+	return this;
 }
 #endif
 
 //calls atsync with async mode
-void TCharm::async_migrate() noexcept
+CMI_WARN_UNUSED_RESULT TCharm * TCharm::async_migrate() noexcept
 {
 #if CMK_LBDB_ON
   DBG("going to sync at async mode");
   ReadyMigrate(false);
   asyncMigrate = true;
   AtSync(0);
-  schedule();
+  return schedule();
 #else
   DBG("skipping sync, because there is no load balancer");
+  return this;
 #endif
 }
 
@@ -504,16 +507,17 @@ void TCharm::async_migrate() noexcept
 Note:
  thread can only migrate at the point when this is called
 */
-void TCharm::allow_migrate()
+CMI_WARN_UNUSED_RESULT TCharm * TCharm::allow_migrate()
 {
 #if CMK_LBDB_ON
   int nextPe = MigrateToPe();
   if (nextPe != -1) {
-    migrateTo(nextPe);
+    return migrateTo(nextPe);
   }
 #else
   DBG("skipping sync, because there is no load balancer");
 #endif
+  return this;
 }
 
 //Resume from sync: start the thread again
@@ -544,7 +548,7 @@ CkArrayID TCHARM_Get_threads() {
 /************* Startup/Shutdown Coordination Support ************/
 
 //Called when we want to go to a barrier
-void TCharm::barrier() noexcept {
+CMI_WARN_UNUSED_RESULT TCharm * TCharm::barrier() noexcept {
 	//Contribute to a synchronizing reduction
 	contribute(CkCallback(CkReductionTarget(TCharm, atBarrier), thisProxy[0]));
 #if CMK_BIGSIM_CHARM
@@ -552,10 +556,11 @@ void TCharm::barrier() noexcept {
         _TRACE_BG_TLINE_END(&curLog);
 	TRACE_BG_AMPI_BREAK(NULL, "TCharm_Barrier_START", NULL, 0, 1);
 #endif
-	stop();
+	TCharm * dis = stop();
 #if CMK_BIGSIM_CHARM
 	 _TRACE_BG_SET_INFO(NULL, "TCHARM_Barrier_END",  &curLog, 1);
 #endif
+	return dis;
 }
 
 //Called when we've reached the barrier
@@ -576,7 +581,7 @@ void TCharm::done(int exitcode) noexcept {
 		contribute(exitmsg);
 	}
 	isSelfDone = true;
-	stop();
+	TCharm * unused = stop();
 }
 //Called when all threads are done running
 void TCharm::atExit(CkReductionMsg* msg) noexcept {
@@ -749,8 +754,7 @@ CkArrayOptions TCHARM_Attach_start(CkArrayID *retTCharmArray,int *retNumElts)
 }
 
 void TCHARM_Suspend() {
-	TCharm *tc=TCharm::get();
-	tc->suspend();
+	TCharm * unused = TCharm::get()->suspend();
 }
 
 /***********************************
@@ -839,35 +843,35 @@ CLINKAGE void TCHARM_Migrate()
 	    CkPrintf("Warning> thread migration is not supported!\n");
           return;
         }
-	TCharm::get()->migrate();
+	TCharm * unused = TCharm::get()->migrate();
 }
 FORTRAN_AS_C(TCHARM_MIGRATE,TCHARM_Migrate,tcharm_migrate,(void),())
 
 CLINKAGE void TCHARM_Async_Migrate()
 {
 	TCHARMAPI("TCHARM_Async_Migrate");
-	TCharm::get()->async_migrate();
+	TCharm * unused = TCharm::get()->async_migrate();
 }
 FORTRAN_AS_C(TCHARM_ASYNC_MIGRATE,TCHARM_Async_Migrate,tcharm_async_migrate,(void),())
 
 CLINKAGE void TCHARM_Allow_Migrate()
 {
 	TCHARMAPI("TCHARM_Allow_Migrate");
-	TCharm::get()->allow_migrate();
+	TCharm * unused = TCharm::get()->allow_migrate();
 }
 FORTRAN_AS_C(TCHARM_ALLOW_MIGRATE,TCHARM_Allow_Migrate,tcharm_allow_migrate,(void),())
 
 CLINKAGE void TCHARM_Migrate_to(int destPE)
 {
 	TCHARMAPI("TCHARM_Migrate_to");
-	TCharm::get()->migrateTo(destPE);
+	TCharm * unused = TCharm::get()->migrateTo(destPE);
 }
 
 #if CMK_FAULT_EVAC
 CLINKAGE void TCHARM_Evacuate()
 {
 	TCHARMAPI("TCHARM_Migrate_to");
-	TCharm::get()->evacuate();
+	TCharm * unused = TCharm::get()->evacuate();
 }
 #endif
 
@@ -877,14 +881,14 @@ FORTRAN_AS_C(TCHARM_MIGRATE_TO,TCHARM_Migrate_to,tcharm_migrate_to,
 CLINKAGE void TCHARM_Yield()
 {
 	TCHARMAPI("TCHARM_Yield");
-	TCharm::get()->schedule();
+	TCharm * unused = TCharm::get()->schedule();
 }
 FORTRAN_AS_C(TCHARM_YIELD,TCHARM_Yield,tcharm_yield,(void),())
 
 CLINKAGE void TCHARM_Barrier()
 {
 	TCHARMAPI("TCHARM_Barrier");
-	TCharm::get()->barrier();
+	TCharm * unused = TCharm::get()->barrier();
 }
 FORTRAN_AS_C(TCHARM_BARRIER,TCHARM_Barrier,tcharm_barrier,(void),())
 
@@ -982,9 +986,9 @@ TCharm::TCharmSemaphore *TCharm::getSema(int id) {
 	if (s->data==NULL) 
 	{ //Semaphore isn't filled yet: wait until it is
 		s->thread=CthSelf();
-		suspend(); //Will be woken by semaPut
+		TCharm * dis = suspend(); //Will be woken by semaPut
 		// Semaphore may have moved-- find it again
-		s=findSema(id);
+		s = dis->findSema(id);
 		if (s->data==NULL) CkAbort("TCharm::semaGet awoken too early!");
 	}
 	return s;
@@ -1051,7 +1055,7 @@ int TCharm::system(const char *cmd)
 	s.cmd=cmd;
 	s.ret=&ret;
 	thisProxy[thisIndex].callSystem(s);
-	suspend();
+	TCharm * unused = suspend();
 	return ret;
 }
 

--- a/src/libs/ck-libs/tcharm/tcharm.C
+++ b/src/libs/ck-libs/tcharm/tcharm.C
@@ -9,7 +9,7 @@ Orion Sky Lawlor, olawlor@acm.org, 11/19/2001
 #include <ctype.h>
 #include "memory-isomalloc.h"
 
-CtvDeclare(TCharm *,_curTCharm);
+CtvDeclare(std::atomic<TCharm *>,_curTCharm);
 
 static int lastNumChunks=0;
 
@@ -75,7 +75,7 @@ void TCharm::nodeInit()
 
 void TCharm::procInit()
 {
-  CtvInitialize(TCharm *,_curTCharm);
+  CtvInitialize(std::atomic<TCharm *>,_curTCharm);
   CtvAccess(_curTCharm)=NULL;
   tcharm_initted=true;
   CtgInit();
@@ -162,7 +162,7 @@ static void startTCharmThread(TCharmInitMsg *msg)
        TCHARM_Thread_data_start_fn threadFn = getTCharmThreadFunction(msg->threadFn);
 	threadFn(msg->data);
 	TCharm::deactivateThread();
-	CtvAccess(_curTCharm)->done(0);
+	CtvAccess(_curTCharm).load()->done(0);
 }
 
 TCharm::TCharm(TCharmInitMsg *initMsg_)

--- a/src/libs/ck-libs/tcharm/tcharm_impl.h
+++ b/src/libs/ck-libs/tcharm/tcharm_impl.h
@@ -19,6 +19,8 @@ Orion Sky Lawlor, olawlor@acm.org, 11/19/2001
 
 #include "cmitls.h"
 
+#include <atomic>
+
 #if 0
      /*Many debugging statements:*/
 #    define DBG(x) ckout<<"["<<thisIndex<<","<<CkMyPe()<<"] TCHARM> "<<x<<endl;
@@ -77,7 +79,7 @@ class TCharmInitMsg : public CMessage_TCharmInitMsg {
 extern bool tcharm_nothreads;
 
 //Thread-local variables:
-CtvExtern(TCharm *,_curTCharm);
+CtvExtern(std::atomic<TCharm *>,_curTCharm);
 
 class TCharm: public CBase_TCharm
 {


### PR DESCRIPTION
*Original date: 2019-05-03 19:19:28*
*Original PR: https://charm.cs.illinois.edu/gerrit/3946*

---

Change-Id: I6907e15381eae157bdf767665284e48d27e958de