### PR TITLE
AMPI cleanup: move MPI_Waitall implementation into ampiParent::waitall()

### DIFF
--- a/src/libs/ck-libs/ampi/ampi.C
+++ b/src/libs/ck-libs/ampi/ampi.C
@@ -5960,7 +5960,7 @@ CMI_WARN_UNUSED_RESULT ampiParent* IReq::wait(ampiParent* parent, MPI_Status *st
       complete = true;
       parent->resumeOnRecv = false;
 #if CMK_BIGSIM_CHARM
-      *result = 0;
+      if (result) *result = 0;
 #endif
       return parent;
     }
@@ -5970,7 +5970,7 @@ CMI_WARN_UNUSED_RESULT ampiParent* IReq::wait(ampiParent* parent, MPI_Status *st
     //memory operation. So we need to return from this function and do the while loop
     //in the outer function call.
     if (_BgInOutOfCoreMode) {
-      *result = -1;
+      if (result) *result = -1;
       return parent;
     }
 #endif
@@ -5989,7 +5989,7 @@ CMI_WARN_UNUSED_RESULT ampiParent* IReq::wait(ampiParent* parent, MPI_Status *st
   }
 
 #if CMK_BIGSIM_CHARM
-  *result = 0;
+  if (result) *result = 0;
 #endif
   return parent;
 }

--- a/src/libs/ck-libs/ampi/ampiimpl.h
+++ b/src/libs/ck-libs/ampi/ampiimpl.h
@@ -2466,6 +2466,7 @@ class ampiParent final : public CBase_ampiParent {
   }
 
   CMI_WARN_UNUSED_RESULT ampiParent* wait(MPI_Request* req, MPI_Status* sts) noexcept;
+  int waitall(int count, MPI_Request request[], MPI_Status sts[]=MPI_STATUSES_IGNORE) noexcept;
   void init() noexcept;
   void finalize() noexcept;
   CMI_WARN_UNUSED_RESULT ampiParent* block() noexcept;

--- a/src/libs/ck-libs/ampi/ampiimpl.h
+++ b/src/libs/ck-libs/ampi/ampiimpl.h
@@ -2466,7 +2466,7 @@ class ampiParent final : public CBase_ampiParent {
   }
 
   CMI_WARN_UNUSED_RESULT ampiParent* wait(MPI_Request* req, MPI_Status* sts) noexcept;
-  int waitall(int count, MPI_Request request[], MPI_Status sts[]=MPI_STATUSES_IGNORE) noexcept;
+  CMI_WARN_UNUSED_RESULT ampiParent* waitall(int count, MPI_Request request[], MPI_Status sts[]=MPI_STATUSES_IGNORE) noexcept;
   void init() noexcept;
   void finalize() noexcept;
   CMI_WARN_UNUSED_RESULT ampiParent* block() noexcept;


### PR DESCRIPTION
*Original date: 2019-05-03 19:18:19*
*Original PR: https://charm.cs.illinois.edu/gerrit/4143*

---

Change-Id: I520a6d8598a0ec6e0dc553ebaeb7b1a481d52c95