### PR TITLE
Enable building charm with -fno-rtti compiler flags

### DIFF
--- a/src/libs/ck-libs/pythonCCS/PythonCCS.C
+++ b/src/libs/ck-libs/pythonCCS/PythonCCS.C
@@ -83,12 +83,21 @@ static PyObject *CkPy_myindex(PyObject *self, PyObject *args) {
   PyObject *dict = PyModule_GetDict(PyImport_AddModule("__main__"));
   PythonObject *object = (PythonObject*)PyLong_AsVoidPtr(PyDict_GetItemString(dict,"__charmObject__"));
   //CmiLock(CsvAccess(pyLock));
+#if CMK_NO_RTTI
+  ArrayElement1D *pyArray1 = (ArrayElement1D *)object;
+  ArrayElement2D *pyArray2 = (ArrayElement2D *)object;
+  ArrayElement3D *pyArray3 = (ArrayElement3D *)object;
+  ArrayElement4D *pyArray4 = (ArrayElement4D *)object;
+  ArrayElement5D *pyArray5 = (ArrayElement5D *)object;
+  ArrayElement6D *pyArray6 = (ArrayElement6D *)object;
+#else
   ArrayElement1D *pyArray1 = dynamic_cast<ArrayElement1D*>(object);
   ArrayElement2D *pyArray2 = dynamic_cast<ArrayElement2D*>(object);
   ArrayElement3D *pyArray3 = dynamic_cast<ArrayElement3D*>(object);
   ArrayElement4D *pyArray4 = dynamic_cast<ArrayElement4D*>(object);
   ArrayElement5D *pyArray5 = dynamic_cast<ArrayElement5D*>(object);
   ArrayElement6D *pyArray6 = dynamic_cast<ArrayElement6D*>(object);
+#endif
   //CmiUnlock(CsvAccess(pyLock));
   if (pyArray1) return Py_BuildValue("(i)", pyArray1->thisIndex);
   else if (pyArray2) return Py_BuildValue("(ii)", pyArray2->thisIndex.x, pyArray2->thisIndex.y);
@@ -165,8 +174,13 @@ void PythonObject::replyIntValue(PythonObject *obj, CcsDelayedReply *reply, CmiU
   forward.reply = *reply;
   forward.value = *value;
   CkCallback cb(CkIndex_PythonCCS::forwardInt(0), pythonCcsProxy);
+#if CMK_NO_RTTI
+  ArrayElement *array = (ArrayElement *)obj;
+  Group *group = (Group *)obj;
+#else
   ArrayElement *array = dynamic_cast<ArrayElement *>(obj);
   Group *group = dynamic_cast<Group *>(obj);
+#endif
   if (array != NULL) array->contribute(sizeof(PythonReplyInt), &forward, CkReduction::bitvec_and, cb);
   else if (group != NULL) group->contribute(sizeof(PythonReplyInt), &forward, CkReduction::bitvec_and, cb);
   else CcsSendDelayedReply(*reply, sizeof(CmiUInt4), (void *)value);
@@ -232,8 +246,13 @@ void PythonObject::print (PythonPrint *pyMsg, CcsDelayedReply *reply) {
       forward->reply = *reply;
       memcpy(forward->data, str, length);
       CkCallback cb(CkIndex_PythonCCS::forwardString(0), pythonCcsProxy);
+#if CMK_NO_RTTI
+      ArrayElement *array = (ArrayElement *)this;
+      Group *group = (Group *)this;
+#else
       ArrayElement *array = dynamic_cast<ArrayElement *>(this);
       Group *group = dynamic_cast<Group *>(this);
+#endif
       if (array != NULL) array->contribute(sizeof(CcsDelayedReply)+length, forward, PythonCCS::reduceString, cb);
       else if (group != NULL) group->contribute(sizeof(CcsDelayedReply)+length, forward, PythonCCS::reduceString, cb);
       else CcsSendDelayedReply(*reply, length, str);

--- a/src/xlat-i/sdag/constructs/CaseList.C
+++ b/src/xlat-i/sdag/constructs/CaseList.C
@@ -42,7 +42,11 @@ void CaseListConstruct::propagateState(std::list<EncapState*> encap,
 
     for (std::list<SdagConstruct*>::iterator iter = constructs->begin();
          iter != constructs->end(); ++iter) {
+#if CMK_NO_RTTI
+      ((WhenConstruct *)*iter)->speculativeState = sv;
+#else
       dynamic_cast<WhenConstruct*>(*iter)->speculativeState = sv;
+#endif
     }
     std::list<CStateVar*> lst;
     lst.push_back(sv);

--- a/src/xlat-i/xi-Chare.C
+++ b/src/xlat-i/xi-Chare.C
@@ -261,7 +261,11 @@ static void disambig_proxy(XStr& str, const XStr& super) {
 XStr Chare::virtualPupDef(const XStr& name) {
   XStr str;
   str << "virtual_pup(PUP::er &p) {"
+#if CMK_NO_RTTI
+      << "\n    recursive_pup<" << name << ">((" << name << " *)this), p);"
+#else
       << "\n    recursive_pup<" << name << ">(dynamic_cast<" << name << "*>(this), p);"
+#endif
       << "\n}";
   return str;
 }

--- a/src/xlat-i/xi-Entry.C
+++ b/src/xlat-i/xi-Entry.C
@@ -191,7 +191,11 @@ void Entry::setChare(Chare* c) {
                    "CkArgMsg* if that's how they're implemented.\n";
     }
     if (container->isArray()) {
+#if CMK_NO_RTTI
+      Array* a = (Array *)c;
+#else
       Array* a = dynamic_cast<Array*>(c);
+#endif
       a->hasVoidConstructor = true;
     }
   }

--- a/src/xlat-i/xi-Template.C
+++ b/src/xlat-i/xi-Template.C
@@ -101,12 +101,20 @@ TName::TName(Type* t, const char* n, const char* v) : type(t), name(n), val(v) {
 TVarList::TVarList(TVar* v, TVarList* n) : tvar(v), next(n) {}
 
 void Template::outputClosuresDecl(XStr& str) {
+#if CMK_NO_RTTI
+  Chare* c = (Chare *)entity;
+#else
   Chare* c = dynamic_cast<Chare*>(entity);
+#endif
   if (c) str << c->closuresDecl;
 }
 
 void Template::outputClosuresDef(XStr& str) {
+#if CMK_NO_RTTI
+  Chare* c = (Chare *)entity;
+#else
   Chare* c = dynamic_cast<Chare*>(entity);
+#endif
   if (c) str << c->closuresDef;
 }
 


### PR DESCRIPTION
*Original date: 2018-11-27 22:50:33*
*Original PR: https://charm.cs.illinois.edu/gerrit/4829*

---

This allows users to build with -fno-rtti by passing -DCMK_NO_RTTI=1.

Change-Id: I237184672ec9263018ecf5f3bcaa41e0cab9e965