### PR TITLE
Implement malloc_info to enhance mall_info

### DIFF
--- a/src/scripts/configure.ac
+++ b/src/scripts/configure.ac
@@ -871,6 +871,16 @@ EOT
 test_cxx "whether has regex.h " "yes" "no" ""
 AC_DEFINE_UNQUOTED(CMK_HAS_REGEX_H, $pass, [whether has regex.h])
 
+#### test for mallocinfo ###
+cat > $t <<EOT
+#include <malloc.h>
+int main() {
+  malloc_info(0, NULL);
+}
+EOT
+test_link "whether has mallocinfo" "yes" "no" ""
+AC_DEFINE_UNQUOTED(CMK_HAS_MALLOCINFO, $pass, [whether has mallocinfo])
+
 #### Check long long ####
 cat > $t <<EOT
 #include <stdlib.h>


### PR DESCRIPTION
*Original author: Shaoqin Lu*
*Original date: 2018-04-16 17:18:29*
*Original PR: https://charm.cs.illinois.edu/gerrit/3968*

---

mall_info does not support 64 bit sized memory reporting.
malloc_info is used as a fall through after 32 bit is overflowed

malloc_info is streamed in a xml format. program parses the
string to extract mmap and total usage from the summary section
and reports the difference compared to the first malloc_info run.

Change-Id: I7884e23716581cc7589fe1bac0e445ce2521b0af