### PR TITLE
Fixed CmiNodeBarrier() for PAPI Initialization:

### DIFF
--- a/doc/projections/manual.tex
+++ b/doc/projections/manual.tex
@@ -1059,10 +1059,11 @@ proportional to the number of processors to be displayed.
 
 This view is enabled when \charmpp{} is compiled with the {\tt papi}
 option, which enables the collection of performance counter data using
-PAPI. Currently, this collects {\tt PAPI\_L1\_TCM}, {\tt PAPI\_L1\_TCA},
-{\tt PAPI\_L2\_TCM}, and {\tt PAPI\_L2\_TCA} on all platforms except
-Cray, where it collects {\tt PAPI\_FP\_OPS}, {\tt PAPI\_TOT\_INS},
-{\tt perf::PERF\_COUNT\_HW\_CACHE\_LL:MISS}, {\tt DATA\_PREFETCHER:ALL},
+PAPI. Currently, this collects {\tt PAPI\_L1\_DCM}, {\tt PAPI\_L2\_DCM},
+{\tt PAPI\_L1\_ICM}, {\tt PAPI\_L2\_ICM}, {\tt PAPI\_L1\_TCM}, {\tt PAPI\_L2\_TCM},
+{\tt PAPI\_L3\_TCM}, {\tt PAPI\_LD\_INS} and {\tt PAPI\_SR\_INS} on all
+platforms where possible except Cray, where it collects {\tt PAPI\_FP\_OPS},
+{\tt PAPI\_TOT\_INS},{\tt perf::PERF\_COUNT\_HW\_CACHE\_LL:MISS}, {\tt DATA\_PREFETCHER:ALL},
 {\tt PAPI\_L1\_DCA} and {\tt PAPI\_TOT\_CYC}. This tool shows the
 values of the collected performance counters on different PEs, broken
 down by entry point.  An example is show in Figure \ref{performance counters}.

--- a/src/arch/pami-linux-ppc64le/conv-mach.h
+++ b/src/arch/pami-linux-ppc64le/conv-mach.h
@@ -49,4 +49,6 @@
 
 #define CMK_LBDB_ON                                        1
 
+#define CMK_PPC64                                          1
+
 #endif

--- a/src/arch/verbs-linux-ppc64le/conv-mach.h
+++ b/src/arch/verbs-linux-ppc64le/conv-mach.h
@@ -72,4 +72,6 @@
 #undef CMK_IBVERBS_FAST_START
 #define CMK_IBVERBS_FAST_START                             0
 
+#define CMK_PPC64                                          1
+
 #endif

--- a/src/ck-perf/trace-common.C
+++ b/src/ck-perf/trace-common.C
@@ -948,11 +948,8 @@ CkpvDeclare(int, papiEventSet);
 CkpvDeclare(LONG_LONG_PAPI*, papiValues);
 CkpvDeclare(int, papiStarted);
 CkpvDeclare(int, papiStopped);
-#ifdef USE_SPP_PAPI
-int papiEvents[NUMPAPIEVENTS];
-#else
-int papiEvents[NUMPAPIEVENTS] = { PAPI_L1_TCM, PAPI_L1_TCA, PAPI_L2_TCM, PAPI_L2_TCA};
-#endif
+CkpvDeclare(int*, papiEvents);
+CkpvDeclare(int, numEvents);
 #endif // CMK_HAS_COUNTER_PAPI
 
 #if CMK_HAS_COUNTER_PAPI
@@ -993,17 +990,21 @@ void initPAPI() {
   if (PAPI_create_eventset(&CkpvAccess(papiEventSet)) != PAPI_OK) {
     CmiAbort("PAPI failed to create event set!\n");
   }
+  CkpvInitialize(int*, papiEvents);
+  CkpvInitialize(int, numEvents);
 #ifdef USE_SPP_PAPI
+  CkpvAccess(numEvents) = NUMPAPIEVENTS;
+  CkpvAccess(papiEvents) = new int[CkpvAccess(numEvents)];
   //  CmiPrintf("Using SPP counters for PAPI\n");
   if(PAPI_query_event(PAPI_FP_OPS)==PAPI_OK) {
-    papiEvents[0] = PAPI_FP_OPS;
+    CkpvAccess(papiEvents)[0] = PAPI_FP_OPS;
   }else{
     if(CmiMyPe()==0){
       CmiAbort("WARNING: PAPI_FP_OPS doesn't exist on this platform!");
     }
   }
   if(PAPI_query_event(PAPI_TOT_INS)==PAPI_OK) {
-    papiEvents[1] = PAPI_TOT_INS;
+    CkpvAccess(papiEvents)[1] = PAPI_TOT_INS;
   }else{
     CmiAbort("WARNING: PAPI_TOT_INS doesn't exist on this platform!");
   }
@@ -1011,30 +1012,91 @@ void initPAPI() {
   int ret;
   ret=PAPI_event_name_to_code("perf::PERF_COUNT_HW_CACHE_LL:MISS",&EventCode);
   if(PAPI_query_event(EventCode)==PAPI_OK) {
-    papiEvents[2] = EventCode;
+    CkpvAccess(papiEvents)[2] = EventCode;
   }else{
     CmiAbort("WARNING: perf::PERF_COUNT_HW_CACHE_LL:MISS doesn't exist on this platform!");
   }
   ret=PAPI_event_name_to_code("DATA_PREFETCHER:ALL",&EventCode);
   if(PAPI_query_event(EventCode)==PAPI_OK) {
-    papiEvents[3] = EventCode;
+    CkpvAccess(papiEvents)[3] = EventCode;
   }else{
     CmiAbort("WARNING: DATA_PREFETCHER:ALL doesn't exist on this platform!");
   }
   if(PAPI_query_event(PAPI_L1_DCA)==PAPI_OK) {
-    papiEvents[4] = PAPI_L1_DCA;
+    CkpvAccess(papiEvents)[4] = PAPI_L1_DCA;
   }else{
     CmiAbort("WARNING: PAPI_L1_DCA doesn't exist on this platform!");
   }
   if(PAPI_query_event(PAPI_TOT_CYC)==PAPI_OK) {
-    papiEvents[5] = PAPI_TOT_CYC;
+    CkpvAccess(papiEvents)[5] = PAPI_TOT_CYC;
   }else{
     CmiAbort("WARNING: PAPI_TOT_CYC doesn't exist on this platform!");
   }
 #else
-  // just uses { PAPI_L2_DCM, PAPI_FP_OPS } the 2 initialized PAPI_EVENTS
+  int i = 0;
+  int temp[9];
+  if(PAPI_query_event(PAPI_L1_DCM)==PAPI_OK) {
+    temp[i] = PAPI_L1_DCM;
+    i++;
+  }else{
+    CmiPrintf("WARNING: PAPI_L1_DCM doesn't exist on this platform!\n");
+  }
+  if(PAPI_query_event(PAPI_L2_DCM)==PAPI_OK) {
+    temp[i] = PAPI_L2_DCM;
+    i++;
+  }else{
+    CmiPrintf("WARNING: PAPI_L2_DCM doesn't exist on this platform!\n");
+  }
+  if(PAPI_query_event(PAPI_L1_ICM)==PAPI_OK) {
+    temp[i] = PAPI_L1_ICM;
+    i++;
+  }else{
+    CmiPrintf("WARNING: PAPI_L1_ICM doesn't exist on this platform!\n");
+  }
+  if(PAPI_query_event(PAPI_L2_ICM)==PAPI_OK) {
+    temp[i] = PAPI_L2_ICM;
+    i++;
+  }else{
+    CmiPrintf("WARNING: PAPI_L2_ICM doesn't exist on this platform!\n");
+  }
+  if(PAPI_query_event(PAPI_L1_TCM)==PAPI_OK) {
+    temp[i] = PAPI_L1_TCM;
+    i++;
+  }else{
+    CmiPrintf("WARNING: PAPI_L1_TCM doesn't exist on this platform!\n");
+  }
+  if(PAPI_query_event(PAPI_L2_TCM)==PAPI_OK) {
+    temp[i] = PAPI_L2_TCM;
+    i++;
+  }else{
+    CmiPrintf("WARNING: PAPI_L2_TCM doesn't exist on this platform!\n");
+  }
+  if(PAPI_query_event(PAPI_L3_TCM)==PAPI_OK) {
+    temp[i] = PAPI_L3_TCM;
+    i++;
+  }else{
+    CmiPrintf("WARNING: PAPI_L3_TCM doesn't exist on this platform!\n");
+  }
+  if(PAPI_query_event(PAPI_LD_INS)==PAPI_OK) {
+    temp[i] = PAPI_LD_INS;
+    i++;
+  }else{
+    CmiPrintf("WARNING: PAPI_LD_INS doesn't exist on this platform!\n");
+  }
+  if(PAPI_query_event(PAPI_SR_INS)==PAPI_OK) {
+    temp[i] = PAPI_SR_INS;
+    i++;
+  }else{
+    CmiPrintf("WARNING: PAPI_SR_INS doesn't exist on this platform!\n");
+  }
+  if(i == 0)
+    CmiAbort("WARNING: No PAPI events found on this platform.\n");
+  CkpvAccess(numEvents) = i;
+  CkpvAccess(papiEvents) = new int[CkpvAccess(numEvents)];
+  for(i = 0; i < CkpvAccess(numEvents); i++)
+    CkpvAccess(papiEvents)[i] = temp[i];
 #endif
-  papiRetValue = PAPI_add_events(CkpvAccess(papiEventSet), papiEvents, NUMPAPIEVENTS);
+  papiRetValue = PAPI_add_events(CkpvAccess(papiEventSet), papiEvents, numEvents);
   if (papiRetValue < 0) {
     if (papiRetValue == PAPI_ECNFLCT) {
       CmiAbort("PAPI events conflict! Please re-assign event types!\n");
@@ -1047,18 +1109,18 @@ void initPAPI() {
   }
   if(CkMyPe()==0)
     {
-      CmiPrintf("Registered %d PAPI counters:",NUMPAPIEVENTS);
+      CmiPrintf("Registered %d PAPI counters:",CkpvAccess(numEvents));
       char nameBuf[PAPI_MAX_STR_LEN];
-      for(int i=0;i<NUMPAPIEVENTS;i++)
+      for(int i=0;i<CkpvAccess(numEvents);i++)
 	{
-	  PAPI_event_code_to_name(papiEvents[i], nameBuf);
+	  PAPI_event_code_to_name(CkpvAccess(papiEvents)[i], nameBuf);
 	  CmiPrintf("%s ",nameBuf);
 	}
       CmiPrintf("\n");
     }
   CkpvInitialize(LONG_LONG_PAPI*, papiValues);
-  CkpvAccess(papiValues) = (LONG_LONG_PAPI*)malloc(NUMPAPIEVENTS*sizeof(LONG_LONG_PAPI));
-  memset(CkpvAccess(papiValues), 0, NUMPAPIEVENTS*sizeof(LONG_LONG_PAPI));
+  CkpvAccess(papiValues) = (LONG_LONG_PAPI*)malloc(CkpvAccess(numEvents)*sizeof(LONG_LONG_PAPI));
+  memset(CkpvAccess(papiValues), 0, CkpvAccess(numEvents)*sizeof(LONG_LONG_PAPI));
 #endif
 }
 #endif

--- a/src/ck-perf/trace-common.C
+++ b/src/ck-perf/trace-common.C
@@ -51,6 +51,9 @@ int peNumKeep;
 bool outlierUsePhases;
 double entryThreshold;
 
+bool papiUsingFile;
+char *papiFilename;
+
 typedef void (*mTFP)();                   // function pointer for
 CpvStaticDeclare(mTFP, machineTraceFuncPtr);    // machine user event
                                           // registration
@@ -197,7 +200,11 @@ static void traceCommonInit(char **argv)
         free(root);
   }
 
-  
+  if (CmiGetArgStringDesc(argv, "+papi", &papiFilename, "File with PAPI events to be followed")) {
+    papiUsingFile = true;
+  } else {
+    papiUsingFile = false;
+  }
   
 #ifdef __BIGSIM__
   if(BgNodeRank()==0) {
@@ -992,6 +999,50 @@ void initPAPI() {
   }
   CkpvInitialize(int*, papiEvents);
   CkpvInitialize(int, numEvents);
+
+  if(papiUsingFile) {
+    FILE *papiFile = fopen(papiFilename, "r");
+    if(papiFile == NULL)
+      CmiAbort("Couldn't open PAPI Event List.");
+    char *line = NULL;
+    size_t n = 0;
+    int count = 0;
+    while(getline(&line, &n, papiFile) != -1) {
+      count++;
+      line = NULL;
+      n = 0;
+    }
+    if(count > 50)
+      CmiAbort("Event list has too many events. Max allowed num of events is 50");
+    fclose(papiFile);
+    papiFile = fopen(papiFilename, "r");
+    if(papiFile == NULL)
+      CmiAbort("Couldn't open PAPI Event List.");
+    line = NULL;
+    n = 0;
+    int i = 0;
+    int temp[count];
+    while(getline(&line, &n, papiFile) != -1) {
+      while(line[strlen(line) - 1] == '\n')
+        line[strlen(line) - 1] = '\0';
+      int EventCode, ret;
+      ret = PAPI_event_name_to_code(line, &EventCode);
+      if(PAPI_query_event(EventCode) == PAPI_OK) {
+        temp[i] = EventCode;
+        i++;
+      } else {
+        CmiAbort("WARNING: Event is not recognized on this platform");
+      }
+      line = NULL;
+      n = 0;
+    }
+    fclose(papiFile);
+    CkpvAccess(numEvents) = i;
+    CkpvAccess(papiEvents) = new int[CkpvAccess(numEvents)];
+    for(i = 0; i < CkpvAccess(numEvents); i++) {
+      CkpvAccess(papiEvents)[i] = temp[i];
+    }
+  } else {
 #ifdef USE_SPP_PAPI
   CkpvAccess(numEvents) = NUMPAPIEVENTS;
   CkpvAccess(papiEvents) = new int[CkpvAccess(numEvents)];
@@ -1096,16 +1147,59 @@ void initPAPI() {
   for(i = 0; i < CkpvAccess(numEvents); i++)
     CkpvAccess(papiEvents)[i] = temp[i];
 #endif
-  papiRetValue = PAPI_add_events(CkpvAccess(papiEventSet), papiEvents, numEvents);
-  if (papiRetValue < 0) {
-    if (papiRetValue == PAPI_ECNFLCT) {
-      CmiAbort("PAPI events conflict! Please re-assign event types!\n");
+  }
+  int totalAdded = 0;
+  CkpvInitialize(LONG_LONG_PAPI*, papiValues);
+  CkpvAccess(papiValues) = (LONG_LONG_PAPI*)malloc(CkpvAccess(numEvents)*sizeof(LONG_LONG_PAPI));
+  for(int i = 0; i < CkpvAccess(numEvents); i++) {
+    memset(CkpvAccess(papiValues), 0, CkpvAccess(numEvents)*sizeof(LONG_LONG_PAPI));
+    papiRetValue = PAPI_add_event(CkpvAccess(papiEventSet), CkpvAccess(papiEvents)[i]);
+    if(papiRetValue != PAPI_OK) {
+      char nameBuf[PAPI_MAX_STR_LEN];
+      PAPI_event_code_to_name(CkpvAccess(papiEvents)[i], nameBuf);
+      CmiPrintf("Event not added: %s\n", nameBuf);
+      if(papiUsingFile)
+        break;
+      int *temp = CkpvAccess(papiEvents);
+      CkpvAccess(papiEvents) = new int[CkpvAccess(numEvents) - 1];
+      for(int j = 0, count = 0; j < CkpvAccess(numEvents); j++, count++) {
+          if(i == j) {
+            count--;
+            continue;
+          }
+          CkpvAccess(papiEvents)[count] = temp[j];
+      }
+      CkpvAccess(numEvents)--;
+      i--;
+      free(temp);
+      temp = NULL;
+    } else if(PAPI_OK != PAPI_read(CkpvAccess(papiEventSet), CkpvAccess(papiValues))) {
+      if(papiUsingFile)
+        break;
+      PAPI_remove_event(CkpvAccess(papiEventSet), CkpvAccess(papiEvents)[totalAdded]);
+      int *temp = CkpvAccess(papiEvents);
+      CkpvAccess(papiEvents) = new int[CkpvAccess(numEvents) - 1];
+      for(int j = 0, count = 0; j < CkpvAccess(numEvents); j++, count++) {
+          if(i == j) {
+            count--;
+            continue;
+          }
+          CkpvAccess(papiEvents)[count] = temp[j];
+      }
+      CkpvAccess(numEvents)--;
+      i--;
+      free(temp);
+      temp = NULL;
     } else {
-      char error_str[PAPI_MAX_STR_LEN];
-      //PAPI_perror(error_str);
-      //PAPI_perror(papiRetValue,error_str,PAPI_MAX_STR_LEN);
-      CmiAbort("PAPI failed to add designated events!\n");
+      totalAdded++;
     }
+  }
+  if (papiUsingFile && papiRetValue == PAPI_ECNFLCT) {
+    CmiAbort("PAPI failed to add event\n");
+  } else if (papiUsingFile && totalAdded != CkpvAccess(numEvents)) {
+    CmiAbort("PAPI failed to read event\n");
+  } else if (totalAdded == 0) {
+    CmiAbort("PAPI failed to add or read any events\n");
   }
   if(CkMyPe()==0)
     {
@@ -1118,8 +1212,6 @@ void initPAPI() {
 	}
       CmiPrintf("\n");
     }
-  CkpvInitialize(LONG_LONG_PAPI*, papiValues);
-  CkpvAccess(papiValues) = (LONG_LONG_PAPI*)malloc(CkpvAccess(numEvents)*sizeof(LONG_LONG_PAPI));
   memset(CkpvAccess(papiValues), 0, CkpvAccess(numEvents)*sizeof(LONG_LONG_PAPI));
 #endif
 }

--- a/src/ck-perf/trace-common.h
+++ b/src/ck-perf/trace-common.h
@@ -125,14 +125,15 @@ extern "C" void (*registerMachineUserEvents())();
 #ifdef USE_SPP_PAPI
 #define NUMPAPIEVENTS 6
 #else
-#define NUMPAPIEVENTS 4
+#define NUMPAPIEVENTS 50
 #endif
 CkpvExtern(int, papiEventSet);
 CkpvExtern(LONG_LONG_PAPI*, papiValues);
 CkpvExtern(int, papiStarted);
 CkpvExtern(int, papiStopped);
-extern int papiEvents[NUMPAPIEVENTS];
-void initPAPI(); 
+CkpvExtern(int*, papiEvents);
+CkpvExtern(int, numEvents);
+void initPAPI();
 #endif
 
 #endif

--- a/src/ck-perf/trace-projections.C
+++ b/src/ck-perf/trace-projections.C
@@ -502,12 +502,12 @@ void LogPool::writeSts(void)
   fprintf(stsfp, "VERSION %s\n", PROJECTION_VERSION);
   fprintf(stsfp, "TOTAL_PHASES %d\n", numPhases);
 #if CMK_HAS_COUNTER_PAPI
-  fprintf(stsfp, "TOTAL_PAPI_EVENTS %d\n", NUMPAPIEVENTS);
-  // for now, use i, next time use papiEvents[i].
+  fprintf(stsfp, "TOTAL_PAPI_EVENTS %d\n", CkpvAccess(numEvents));
+  // for now, use i, next time use CkpvAccess(papiEvents)[i].
   // **CW** papi event names is a hack.
   char eventName[PAPI_MAX_STR_LEN];
-  for (i=0;i<NUMPAPIEVENTS;i++) {
-    PAPI_event_code_to_name(papiEvents[i], eventName);
+  for (i=0;i<CkpvAccess(numEvents);i++) {
+    PAPI_event_code_to_name(CkpvAccess(papiEvents)[i], eventName);
     fprintf(stsfp, "PAPI_EVENT %d %s\n", i, eventName);
   }
 #endif
@@ -871,7 +871,7 @@ void LogPool::modLastEntryTimestamp(double ts)
 //void LogEntry::addPapi(LONG_LONG_PAPI *papiVals)
 //{
 //#if CMK_HAS_COUNTER_PAPI
-//   memcpy(papiValues, papiVals, sizeof(LONG_LONG_PAPI)*NUMPAPIEVENTS);
+//   memcpy(papiValues, papiVals, sizeof(LONG_LONG_PAPI)*CkpvAccess(numEvents));
 //#endif
 //}
 
@@ -911,11 +911,11 @@ void LogEntry::pup(PUP::er &p)
       p|icputime;
 #if CMK_HAS_COUNTER_PAPI
       //p|numPapiEvents;
-      for (i=0; i<NUMPAPIEVENTS; i++) {
+      for (i=0; i<CkpvAccess(numEvents); i++) {
 	// not yet!!!
 	//	p|papiIDs[i]; 
 	p|papiValues[i];
-	
+
       }
 #else
       //p|numPapiEvents;     // non papi version has value 0
@@ -930,7 +930,7 @@ void LogEntry::pup(PUP::er &p)
       p|mIdx; p|eIdx; p|itime; p|event; p|pe; p|msglen; p|icputime;
 #if CMK_HAS_COUNTER_PAPI
       //p|numPapiEvents;
-      for (i=0; i<NUMPAPIEVENTS; i++) {
+      for (i=0; i<CkpvAccess(numEvents); i++) {
 	// not yet!!!
 	//	p|papiIDs[i];
 	p|papiValues[i];

--- a/src/ck-perf/trace-projections.h
+++ b/src/ck-perf/trace-projections.h
@@ -184,7 +184,7 @@ class LogEntry {
     // complementary function for adding papi data
     void addPapi(LONG_LONG_PAPI *papiVals){
 #if CMK_HAS_COUNTER_PAPI
-   	memcpy(papiValues, papiVals, sizeof(LONG_LONG_PAPI)*NUMPAPIEVENTS);
+      memcpy(papiValues, papiVals, sizeof(LONG_LONG_PAPI)*CkpvAccess(numEvents));
 #endif
     }
    


### PR DESCRIPTION
*Original author: Steven Qiou*
*Original date: 2018-03-13 00:47:53*
*Original PR: https://charm.cs.illinois.edu/gerrit/3796*

---

Initial implementation of CmiNodeBarrierCount() assumed a NodeAllBarrier
will complete before a NodeBarrier is called (and vice versa), however
the workers in initPAPI() need to call NodeBarrier before they can complete
the NodeAllBarrier previously called by comm threads. Original
CmiNodeBarrierCount could not handle this situation with one set of
synchronization variables, so I added a second copy of everything, allowing
CmiNodeBarrierCount to handle both barrier types at the same time.

The pairs of elements are stored as the first and last elements of arrays
that are large enough that the two elements will exist onseparate cache
lines as to avoid false sharing.

Change-Id: I3a4c154adb391f8e2361a53fa8411c749c720fb5