### PR TITLE
Bug 388: mlogft make sure the destPE is positive before sending msg to chare

### DIFF
--- a/src/ck-core/ck.C
+++ b/src/ck-core/ck.C
@@ -1646,8 +1646,8 @@ void CkSendMsg(int entryIdx, void *msg,const CkChareID *pCid, int opts)
 #if (defined(_FAULT_MLOG_) || defined(_FAULT_CAUSAL_))
   if (destPE!=-1) {
     CpvAccess(_qd)->create();
+    sendChareMsg(env,destPE,_infoIdx,pCid);
   }
-	sendChareMsg(env,destPE,_infoIdx,pCid);
 #else
   _TRACE_CREATION_1(env);
   if (destPE!=-1) {


### PR DESCRIPTION
*Original date: 2015-02-20 02:50:15*
*Original PR: https://charm.cs.illinois.edu/gerrit/558*

---

Change-Id: I6e09d90cb15c9da54d60701f88f30ad30ca96074