### PR TITLE
add multiple ppn option for +ppn to handle hetergenous

### DIFF
--- a/src/arch/gni/machine.c
+++ b/src/arch/gni/machine.c
@@ -3895,6 +3895,7 @@ void LrtsInit(int *argc, char ***argv, int *numNodes, int *myNodeID)
     *myNodeID = myrank;
     *numNodes = mysize;
   
+    SetupPPN(argv);
 #if MULTI_THREAD_SEND
     /* Currently, we only consider the case that comm. thread will only recv msgs */
     Cmi_smp_mode_setting = COMM_WORK_THREADS_SEND_RECV;

--- a/src/arch/mpi/machine.c
+++ b/src/arch/mpi/machine.c
@@ -1293,6 +1293,7 @@ void LrtsInit(int *argc, char ***argv, int *numNodes, int *myNodeID) {
       MPI_Comm_rank(charmComm, myNodeID);
     }
 
+    SetupPPN(argv);
     MPI_Bcast(&_Cmi_mynodesize, 1, MPI_INT, 0, charmComm);
 
     myNID = *myNodeID;

--- a/src/arch/netlrts/machine.c
+++ b/src/arch/netlrts/machine.c
@@ -1976,6 +1976,7 @@ void LrtsInit(int *argc, char ***argv, int *numNodes, int *myNodeID)
   if (Cmi_charmrun_fd==-1) /*Don't bother with check in standalone mode*/
       Cmi_check_delay=1.0e30;
 
+  SetupPPN(argv);
   for(i = 0; i < _Cmi_mynodesize; i++)
     inProgress[i] = 0;
 

--- a/src/arch/verbs/machine.c
+++ b/src/arch/verbs/machine.c
@@ -2010,6 +2010,7 @@ void LrtsInit(int *argc, char ***argv, int *numNodes, int *myNodeID)
   if (Cmi_charmrun_fd==-1) /*Don't bother with check in standalone mode*/
       Cmi_check_delay=1.0e30;
 
+  SetupPPN(argv);
   for(i = 0; i < _Cmi_mynodesize; i++)
       inProgress[i] = 0;
 


### PR DESCRIPTION
*Original author: YanhuaSun*
*Original date: 2015-02-05 05:22:51*
*Original PR: https://charm.cs.illinois.edu/gerrit/383*

---

using ppn following with multiple numbers seperate by comma.
This works with node allocations, where continuous processes
have different ppns and then the pattern repeats.

Change-Id: I88e733d71e25110021480d9d6d8766d539491c80