### PR TITLE
AMPI: Remove fsglobals and pipglobals from automated testing

### DIFF
--- a/tests/ampi/privatization/Makefile
+++ b/tests/ampi/privatization/Makefile
@@ -24,12 +24,12 @@ CANDIDATES := \
   swapglobals \
   tlsglobals \
 
-ifeq (1,$(CMK_SUPPORTS_FSGLOBALS))
-  CANDIDATES += fsglobals
-endif
-ifeq (1,$(CMK_SUPPORTS_PIPGLOBALS))
-  CANDIDATES += pipglobals
-endif
+# ifeq (1,$(CMK_SUPPORTS_FSGLOBALS))
+#   CANDIDATES += fsglobals
+# endif
+# ifeq (1,$(CMK_SUPPORTS_PIPGLOBALS))
+#   CANDIDATES += pipglobals
+# endif
 
 
 # Define what options to pass to charmc for each method.

--- a/tests/ampi/privatization/Makefile
+++ b/tests/ampi/privatization/Makefile
@@ -24,6 +24,7 @@ CANDIDATES := \
   swapglobals \
   tlsglobals \
 
+# Don't enable these for universal testing because they are not 100% portable to all platforms and toolchain versions.
 # ifeq (1,$(CMK_SUPPORTS_FSGLOBALS))
 #   CANDIDATES += fsglobals
 # endif


### PR DESCRIPTION
Several autobuild targets have been failing in these tests because older
platforms and toolchain versions are not as forgiving about loading a
binary as a shared object without explicitly building it as one. A
partial solution is possible by overhauling our build scripts to make
this happen, but it requires intensive and potentially fragile changes
to the build process of user applications, and at present the methods
would break entirely if Fortran module variables are present, with no
known workaround.