### PR TITLE
Bug #2241: Delete .gitreview

### DIFF
--- a/.gitreview
+++ b/.gitreview
@@ -1,5 +1,0 @@
-[gerrit]
-host = charm.cs.illinois.edu
-port = 9418
-project = charm.git
-defaultbranch = charm


### PR DESCRIPTION
This configuration file was used for Gerrit, which is not longer being used in favor of Github.