### PR TITLE
charm4py: fix CkMigrateExt by calling ckMigrate

### DIFF
--- a/src/ck-core/ck.C
+++ b/src/ck-core/ck.C
@@ -2423,7 +2423,7 @@ void CkMigrateExt(int aid, int ndims, int *index, int toPe) {
   CProxyElement_ArrayBase arrayProxy = CProxyElement_ArrayBase(gId, arrayIndex);
   ArrayElement* arrayElement = arrayProxy.ckLocal();
   CkAssert(arrayElement != NULL);
-  arrayElement->migrateMe(toPe);
+  arrayElement->ckMigrate(toPe);
 }
 
 void CkArrayDoneInsertingExt(int aid) {


### PR DESCRIPTION
In charm4py, Chares have a method called migrate(toPe) which
previously lead directly to ArrayElement::migrateMe() in Charm++,
and with this patch now leads to ArrayElement::ckMigrate().

Although I haven't documented Chare.migrate() in the manual yet
(because I'm not sure it's useful for users), if I do document it
I'll just recommend to call it as an entry method, for example:
self.thisProxy[self.thisIndex].migrate(toPe), which I think also
makes the semantics clearer, because the user sees that it is
going to be scheduled and therefore not happen immediately.

If necessary, I can throw an error if it's not called as an entry
method, or make it so that it schedules an entry method
internally, but I'll leave that for later.