### PR TITLE
AMPI #2233: Improve robustness of PMPI weak symbol definitions

### DIFF
--- a/src/libs/ck-libs/ampi/ampi.h
+++ b/src/libs/ck-libs/ampi/ampi.h
@@ -16,7 +16,7 @@
 #define AMPI
 
 /* Declare the conditions under which AMPI supports PMPI. */
-#if defined __linux__ && !defined __clang__
+#if defined __linux__
 # define AMPI_HAVE_PMPI 1
 #else
 # define AMPI_HAVE_PMPI 0

--- a/src/libs/ck-libs/ampi/ampi_noimpl.C
+++ b/src/libs/ck-libs/ampi/ampi_noimpl.C
@@ -18,10 +18,10 @@ unsupported in AMPI. Calling these functions aborts the application.
 #if AMPI_HAVE_PMPI
   #define AMPI_FUNC_NOIMPL(ret, name, ...) \
     CLINKAGE \
-    __attribute((weak, alias(STRINGIFY(name)))) \
+    __attribute__((weak, alias(STRINGIFY(name)))) \
     ret P##name(__VA_ARGS__); \
     CLINKAGE \
-    __attribute((weak)) \
+    __attribute__((weak)) \
     ret name(__VA_ARGS__) \
     AMPI_NOIMPL_BODY(name)
 #else

--- a/src/libs/ck-libs/ampi/ampi_noimpl.C
+++ b/src/libs/ck-libs/ampi/ampi_noimpl.C
@@ -17,9 +17,11 @@ unsupported in AMPI. Calling these functions aborts the application.
 // keep in sync with ampiimpl.h
 #if AMPI_HAVE_PMPI
   #define AMPI_FUNC_NOIMPL(ret, name, ...) \
-    _Pragma(STRINGIFY(weak name)) \
-    _Pragma(STRINGIFY(weak P##name = name)) \
     CLINKAGE \
+    __attribute((weak, alias(STRINGIFY(name)))) \
+    ret P##name(__VA_ARGS__); \
+    CLINKAGE \
+    __attribute((weak)) \
     ret name(__VA_ARGS__) \
     AMPI_NOIMPL_BODY(name)
 #else

--- a/src/libs/ck-libs/ampi/ampiimpl.h
+++ b/src/libs/ck-libs/ampi/ampiimpl.h
@@ -32,10 +32,10 @@ using std::vector;
 #if AMPI_HAVE_PMPI
   #define AMPI_API_IMPL(ret, name, ...) \
     CLINKAGE \
-    __attribute((weak, alias(STRINGIFY(name)))) \
+    __attribute__((weak, alias(STRINGIFY(name)))) \
     ret P##name(__VA_ARGS__); \
     CLINKAGE \
-    __attribute((weak)) \
+    __attribute__((weak)) \
     ret name(__VA_ARGS__)
 #else // not Linux (no PMPI support):
   #define AMPI_API_IMPL(ret, name, ...) \

--- a/src/libs/ck-libs/ampi/ampiimpl.h
+++ b/src/libs/ck-libs/ampi/ampiimpl.h
@@ -31,9 +31,11 @@ using std::vector;
 // keep in sync with ampi_noimpl.C
 #if AMPI_HAVE_PMPI
   #define AMPI_API_IMPL(ret, name, ...) \
-    _Pragma(STRINGIFY(weak name)) \
-    _Pragma(STRINGIFY(weak P##name = name)) \
     CLINKAGE \
+    __attribute((weak, alias(STRINGIFY(name)))) \
+    ret P##name(__VA_ARGS__); \
+    CLINKAGE \
+    __attribute((weak)) \
     ret name(__VA_ARGS__)
 #else // not Linux (no PMPI support):
   #define AMPI_API_IMPL(ret, name, ...) \


### PR DESCRIPTION
This resolves the issue with PMPI, the function pointer shim, and clang.

#2233 