### PR TITLE
Ignore ++local in MPI and OFI charmrun instead of running as standalone

### DIFF
--- a/src/arch/mpi/charmrun
+++ b/src/arch/mpi/charmrun
@@ -12,7 +12,6 @@ pes=1
 ppn=1
 machinefile=""
 QUIET=0
-LOCAL=0
 
 while [ $# -gt 0 ]
 do
@@ -52,12 +51,8 @@ do
 	++no-quiet)
 		QUIET=0
 		;;
-	++local)
-		LOCAL=1
-		# Don't pass this option to the application, as ++local is not supported by the MPI layer
-		;;
-	++no-local)
-		LOCAL=0
+	++local|++no-local)
+		# ignore
 		;;
 	*)
 		args=$args" "$1
@@ -82,11 +77,7 @@ fi
 
 test $QUIET -eq 0 && printf "\nRunning on $pes processors: $args\n"
 
-if [ $LOCAL -eq 1 ]
-then
-  test $QUIET -eq 0 && echo $args +p $pes
-  $args +p $pes
-elif [ -n "$PBS_NODEFILE" ]
+if [ -n "$PBS_NODEFILE" ]
 then
 # we are in a job shell
   aprun=`which aprun 2>/dev/null`

--- a/src/arch/ofi/charmrun
+++ b/src/arch/ofi/charmrun
@@ -12,7 +12,6 @@ pes=1
 ppn=1
 machinefile=""
 QUIET=0
-LOCAL=0
 
 while [ $# -gt 0 ]
 do
@@ -52,11 +51,8 @@ do
 	++no-quiet)
 		QUIET=0
 		;;
-	++local)
-		LOCAL=1
-		;;
-	++no-local)
-		LOCAL=0
+	++local|++no-local)
+		# ignore
 		;;
 	*)
 		args=$args" "$1
@@ -66,7 +62,6 @@ do
 done
 
 test $QUIET -eq 1 && charm_args=$charm_args" "++quiet
-test $LOCAL -eq 1 && charm_args=$charm_args" "++local
 
 args=$args" "$charm_args
 
@@ -82,11 +77,7 @@ fi
 
 test $QUIET -eq 0 && printf "\nRunning on $pes processors: $args\n"
 
-if [ $LOCAL -eq 1 ]
-then
-  test $QUIET -eq 0 && echo $args +p $pes
-  $args +p $pes
-elif [ -n "$PBS_NODEFILE" ]
+if [ -n "$PBS_NODEFILE" ]
 then
 # we are in a job shell
   aprun=`which aprun 2>/dev/null`


### PR DESCRIPTION
Solves an abort in `tests/charm++/partitions` when running with `++local`