### PR TITLE
 ZC P2P API: Deregister buffers after completion of memcpy and CMA transfers

### DIFF
--- a/src/ck-core/ck.C
+++ b/src/ck-core/ck.C
@@ -1433,8 +1433,10 @@ void _skipCldEnqueue(int pe,envelope *env, int infoFn)
 
 #if CMK_ONESIDED_IMPL
   // Store source information to handle acknowledgements on completion
-  if(CMI_IS_ZC_BCAST(env))
-    CkRdmaPrepareBcastMsg(env);
+  if(CMI_IS_ZC(env)) {
+    int node = CkNodeOf(pe);
+    CkRdmaPrepareZCMsg(env, node);
+  }
 #endif
 
 #if CMK_FAULT_EVAC
@@ -1540,8 +1542,10 @@ static void _noCldEnqueue(int pe, envelope *env)
 
 #if CMK_ONESIDED_IMPL
   // Store source information to handle acknowledgements on completion
-  if(CMI_IS_ZC_BCAST(env))
-    CkRdmaPrepareBcastMsg(env);
+  if(CMI_IS_ZC(env)) {
+    int node = CkNodeOf(pe);
+    CkRdmaPrepareZCMsg(env, node);
+  }
 #endif
 
   CkPackMessage(&env);
@@ -1569,8 +1573,8 @@ void _noCldNodeEnqueue(int node, envelope *env)
 
 #if CMK_ONESIDED_IMPL
   // Store source information to handle acknowledgements on completion
-  if(CMI_IS_ZC_BCAST(env))
-    CkRdmaPrepareBcastMsg(env);
+  if(CMI_IS_ZC(env))
+    CkRdmaPrepareZCMsg(env, node);
 #endif
 
   CkPackMessage(&env);

--- a/src/ck-core/ck.h
+++ b/src/ck-core/ck.h
@@ -31,8 +31,10 @@ inline void _CldEnqueue(int pe, void *msg, int infofn) {
 #if CMK_ONESIDED_IMPL
   envelope *env = (envelope *)msg;
   // Store source information to handle acknowledgements on completion
-  if(CMI_IS_ZC_BCAST(msg))
-    CkRdmaPrepareBcastMsg(env);
+  if(CMI_IS_ZC(msg)) {
+    int node = CkNodeOf(pe);
+    CkRdmaPrepareZCMsg(env, node);
+  }
 #endif
   CldEnqueue(pe, msg, infofn);
 }
@@ -58,8 +60,8 @@ inline void _CldNodeEnqueue(int node, void *msg, int infofn) {
 #if CMK_ONESIDED_IMPL
   envelope *env = (envelope *)msg;
   // Store source information to handle acknowledgements on completion
-  if(CMI_IS_ZC_BCAST(msg))
-    CkRdmaPrepareBcastMsg(env);
+  if(CMI_IS_ZC(msg))
+    CkRdmaPrepareZCMsg(env, node);
 #endif
   CldNodeEnqueue(node, msg, infofn);
 }
@@ -69,8 +71,10 @@ inline void _CldEnqueue(int pe, void *msg, int infofn) {
 #if CMK_ONESIDED_IMPL
   envelope *env = (envelope *)msg;
   // Store source information to handle acknowledgements on completion
-  if(CMI_IS_ZC_BCAST(msg))
-    CkRdmaPrepareBcastMsg(env);
+  if(CMI_IS_ZC(msg)) {
+    int node = CmiNodeOf(pe);
+    CkRdmaPrepareZCMsg(env, node);
+  }
 #endif
   CldEnqueue(pe, msg, infofn);
 }
@@ -79,8 +83,8 @@ inline void _CldNodeEnqueue(int node, void *msg, int infofn) {
 #if CMK_ONESIDED_IMPL
   envelope *env = (envelope *)msg;
   // Store source information to handle acknowledgements on completion
-  if(CMI_IS_ZC_BCAST(msg))
-    CkRdmaPrepareBcastMsg(env);
+  if(CMI_IS_ZC(msg))
+    CkRdmaPrepareZCMsg(env, node);
 #endif
   CldNodeEnqueue(node, msg, infofn);
 }

--- a/src/ck-core/ckrdma.h
+++ b/src/ck-core/ckrdma.h
@@ -116,10 +116,10 @@ class CkNcpyBuffer{
   // reference pointer
   const void *ref;
 
-  // bcast ack handling pointer
-  const void *bcastAckInfo;
+  // ack handling pointer used for bcast and CMA p2p transfers
+  const void *refAckInfo;
 
-  CkNcpyBuffer() : isRegistered(false), ptr(NULL), cnt(0), pe(-1), regMode(CK_BUFFER_REG), deregMode(CK_BUFFER_DEREG), ref(NULL), bcastAckInfo(NULL) {}
+  CkNcpyBuffer() : isRegistered(false), ptr(NULL), cnt(0), pe(-1), regMode(CK_BUFFER_REG), deregMode(CK_BUFFER_DEREG), ref(NULL), refAckInfo(NULL) {}
 
   explicit CkNcpyBuffer(const void *ptr_, size_t cnt_, unsigned short int regMode_=CK_BUFFER_REG, unsigned short int deregMode_=CK_BUFFER_DEREG) {
     cb = CkCallback(CkCallback::ignore);
@@ -131,7 +131,7 @@ class CkNcpyBuffer{
   }
 
   void print() {
-    CkPrintf("[%d][%d][%d] CkNcpyBuffer print: ptr:%p, size:%d, pe:%d, regMode=%d, deregMode=%d, ref:%p, bcastAckInfo:%p\n", CmiMyPe(), CmiMyNode(), CmiMyRank(), ptr, cnt, pe, regMode, deregMode, ref, bcastAckInfo);
+    CkPrintf("[%d][%d][%d] CkNcpyBuffer print: ptr:%p, size:%d, pe:%d, regMode=%d, deregMode=%d, ref:%p, refAckInfo:%p\n", CmiMyPe(), CmiMyNode(), CmiMyRank(), ptr, cnt, pe, regMode, deregMode, ref, refAckInfo);
   }
 
   void init(const void *ptr_, size_t cnt_, CkCallback &cb_, unsigned short int regMode_=CK_BUFFER_REG, unsigned short int deregMode_=CK_BUFFER_DEREG) {
@@ -155,6 +155,9 @@ class CkNcpyBuffer{
     // Ensure that deregMode is valid
     checkDeregModeIsValid();
 #endif
+
+    ref = NULL;
+    refAckInfo = NULL;
 
     // Register memory everytime new values are initialized
     if(cnt > 0)
@@ -227,7 +230,7 @@ class CkNcpyBuffer{
   void pup(PUP::er &p) {
     p((char *)&ptr, sizeof(ptr));
     p((char *)&ref, sizeof(ref));
-    p((char *)&bcastAckInfo, sizeof(bcastAckInfo));
+    p((char *)&refAckInfo, sizeof(refAckInfo));
     p|cnt;
     p|cb;
     p|pe;
@@ -257,7 +260,10 @@ class CkNcpyBuffer{
 
   friend void performEmApiCmaTransfer(CkNcpyBuffer &source, CkNcpyBuffer &dest, int child_count, ncpyEmApiMode emMode);
 
+  friend void performEmApiMemcpy(CkNcpyBuffer &source, CkNcpyBuffer &dest, ncpyEmApiMode emMode);
+
   friend void deregisterMemFromMsg(envelope *env, bool isRecv);
+  friend void CkRdmaEMDeregAndAckHandler(void *ack);
 };
 
 // Ack handler for the Zerocopy Direct API
@@ -295,7 +301,13 @@ static inline CkNcpyBuffer CkSendBuffer(const void *ptr_, unsigned short int reg
 // ncpyHandlerIdx::EM_ACK tag is used to remotely invoke CkRdmaEMAckHandler
 // ncpyHandlerIdx::BCAST_ACK tag is used to remotely invoke CkRdmaEMBcastAckHandler
 // ncpyHandlerIdx::BCAST_POST_ACK is used to remotely invoke CkRdmaEMBcastPostAckHandler
-enum class ncpyHandlerIdx: char { EM_ACK, BCAST_ACK, BCAST_POST_ACK };
+// ncpyHandlerIdx::CMA_DEREG_ACK is used to remotely invoke CkRdmaEMDeregAndAckHandler
+enum class ncpyHandlerIdx: char {
+  EM_ACK,
+  BCAST_ACK,
+  BCAST_POST_ACK,
+  CMA_DEREG_ACK
+};
 
 // Converse message to invoke the Ncpy handler on a remote process
 struct ncpyHandlerMsg{
@@ -372,7 +384,7 @@ struct NcpyBcastRecvPeerAckInfo{
 #if CMK_SMP
     int getNumPeers() const {
        return numPeers.load(std::memory_order_acquire);
-    } 
+    }
     void setNumPeers(int r) {
        return numPeers.store(r, std::memory_order_release);
     }
@@ -391,7 +403,11 @@ struct NcpyBcastRecvPeerAckInfo{
 
 };
 
-
+// Structure is used for storing source buffer info to de-reg and invoke acks after completion of CMA operations
+struct NcpyP2PAckInfo{
+  int numOps;
+  CkNcpyBuffer src[0];
+};
 
 /***************************** Zerocopy Bcast Entry Method API ****************************/
 struct NcpyBcastAckInfo{
@@ -446,6 +462,12 @@ struct NcpyBcastInterimAckInfo : public NcpyBcastAckInfo {
 
 // Method called on the bcast source to store some information for ack handling
 void CkRdmaPrepareBcastMsg(envelope *env);
+
+// Method called on the p2p source to store information for de-reg and ack handling for CMA transfers
+void CkRdmaPrepareZCMsg(envelope *env, int &pe);
+
+// Method called on ZC API source (internally calls CkRdmaPrepareBcastMsg or CkRdmaPrepareZCMsg)
+void CkRdmaPrepareP2PMsg(envelope *env);
 
 void CkReplaceSourcePtrsInBcastMsg(envelope *env, NcpyBcastInterimAckInfo *bcastAckInfo, int origPe);
 
@@ -550,6 +572,12 @@ void CmiInvokeRemoteDeregAckHandler(int pe, NcpyOperationInfo *info);
 #endif
 
 inline void invokeRemoteNcpyAckHandler(int pe, void *ref, ncpyHandlerIdx opMode);
+
+// Handler method invoked on the ZC p2p API source for de-registration and ack handling for CMA transfers
+void CkRdmaEMDeregAndAckHandler(void *ack);
+
+
+inline bool isDeregReady(CkNcpyBuffer &buffInfo);
 
 #endif /* End of CMK_ONESIDED_IMPL */
 

--- a/src/conv-core/converse.h
+++ b/src/conv-core/converse.h
@@ -63,8 +63,10 @@
 
 #if CMK_ONESIDED_IMPL
 #define CMI_ZC_MSGTYPE(msg)                  ((CmiMsgHeaderBasic *)msg)->zcMsgType
+#define CMI_IS_ZC_P2P(msg)                   (CMI_ZC_MSGTYPE(msg) == CMK_ZC_P2P_SEND_MSG || CMI_ZC_MSGTYPE(msg) == CMK_ZC_P2P_RECV_MSG)
 #define CMI_IS_ZC_BCAST(msg)                 (CMI_ZC_MSGTYPE(msg) == CMK_ZC_BCAST_SEND_MSG || CMI_ZC_MSGTYPE(msg) == CMK_ZC_BCAST_RECV_MSG)
 #define CMI_IS_ZC_RECV(msg)                  (CMI_ZC_MSGTYPE(msg) == CMK_ZC_P2P_RECV_MSG || CMI_ZC_MSGTYPE(msg) == CMK_ZC_BCAST_RECV_MSG)
+#define CMI_IS_ZC(msg)                       (CMI_IS_ZC_P2P(msg) || CMI_IS_ZC_BCAST(msg))
 #endif
 
 #define CMIALIGN(x,n)       (size_t)((~((size_t)n-1))&((x)+(n-1)))

--- a/src/util/pup.h
+++ b/src/util/pup.h
@@ -436,6 +436,10 @@ class mem : public er { //Memory-buffer packers and unpackers
     return reinterpret_cast<char*>(origBuf);
   }
 
+  inline void reset() {
+    buf = origBuf;
+  }
+
   inline void advance(size_t const offset) {
     buf += offset;
   }


### PR DESCRIPTION
Previously, buffers were de-registered after completion of RDMA transfers.
However, when buffers are declared with CK_BUFFER_REG (and PREREG for verbs
and ucx), it is required to de-register these buffers after the completion
of the memcpy and CMA transfers to avoid leaking of pinned memory.