### PR TITLE
ZC Post API Test: Rename identifiers for successful compilation on Windows

### DIFF
--- a/tests/charm++/zerocopy/zc_post_modify_size/zc_post_modify_size.C
+++ b/tests/charm++/zerocopy/zc_post_modify_size/zc_post_modify_size.C
@@ -3,9 +3,9 @@
 #define NUM_ELEMENTS_PER_PE 10
 #define CONSTANT 188
 
-CProxy_arr1 arrProxy;
-CProxy_grp1 grpProxy;
-CProxy_nodegrp1 ngProxy;
+CProxy_arr arrProxy;
+CProxy_grp grpProxy;
+CProxy_nodegrp ngProxy;
 CProxy_tester chareProxy;
 
 void assignValuesToIndex(int *arr, int size);
@@ -19,13 +19,13 @@ class main : public CBase_main {
       delete m;
 
       // Create a chare array
-      arrProxy = CProxy_arr1::ckNew(CkNumPes() * NUM_ELEMENTS_PER_PE);
+      arrProxy = CProxy_arr::ckNew(CkNumPes() * NUM_ELEMENTS_PER_PE);
 
       // Create a group
-      grpProxy = CProxy_grp1::ckNew();
+      grpProxy = CProxy_grp::ckNew();
 
       // Create a nodegroup
-      ngProxy = CProxy_nodegrp1::ckNew();
+      ngProxy = CProxy_nodegrp::ckNew();
 
       // Create the tester chare
       chareProxy = CProxy_tester::ckNew();
@@ -70,10 +70,10 @@ class tester : public CBase_tester {
     }
 };
 
-class arr1 : public CBase_arr1 {
+class arr : public CBase_arr {
   int *destBuffer;
   public:
-    arr1() {
+    arr() {
       destBuffer = new int[SIZE];
       assignValuesToIndex(destBuffer, SIZE);
     }
@@ -105,10 +105,10 @@ class arr1 : public CBase_arr1 {
     }
 };
 
-class grp1 : public CBase_grp1 {
+class grp : public CBase_grp {
   int *destBuffer;
   public:
-    grp1() {
+    grp() {
       destBuffer = new int[SIZE];
       assignValuesToIndex(destBuffer, SIZE);
     }
@@ -140,10 +140,10 @@ class grp1 : public CBase_grp1 {
     }
 };
 
-class nodegrp1 : public CBase_nodegrp1 {
+class nodegrp : public CBase_nodegrp {
   int *destBuffer;
   public:
-    nodegrp1() {
+    nodegrp() {
       destBuffer = new int[SIZE/2];
       assignValuesToIndex(destBuffer, SIZE/2);
     }

--- a/tests/charm++/zerocopy/zc_post_modify_size/zc_post_modify_size.ci
+++ b/tests/charm++/zerocopy/zc_post_modify_size/zc_post_modify_size.ci
@@ -1,9 +1,9 @@
 mainmodule zc_post_modify_size
 {
 
-  readonly CProxy_arr1 arrProxy;
-  readonly CProxy_grp1 grpProxy;
-  readonly CProxy_nodegrp1 ngProxy;
+  readonly CProxy_arr arrProxy;
+  readonly CProxy_grp grpProxy;
+  readonly CProxy_nodegrp ngProxy;
   readonly CProxy_tester chareProxy;
 
   mainchare main
@@ -17,18 +17,18 @@ mainmodule zc_post_modify_size
     entry [reductiontarget] void bcastDone();
   };
 
-  array [1D] arr1{
-    entry arr1();
+  array [1D] arr{
+    entry arr();
     entry void recv_zerocopy(nocopypost int buffer[size], size_t size, bool isBcast);
   };
 
-  group grp1{
-    entry grp1();
+  group grp{
+    entry grp();
     entry void recv_zerocopy(nocopypost int buffer[size], size_t size, bool isBcast);
   };
 
-  nodegroup nodegrp1{
-    entry nodegrp1();
+  nodegroup nodegrp{
+    entry nodegrp();
     entry void recv_zerocopy(nocopypost int buffer[size], size_t size, bool isBcast);
   };
 }


### PR DESCRIPTION
Previously, the group was named 'grp1', which was a global namespace
macro on Windows. The group is renamed from 'grp1' to 'grp'. For
consistency, the chare array was renamed from 'arr1' to 'arr' and
the nodegroup was renamed from 'nodegrp1' to 'nodegrp'.