### PR TITLE
 PAPI: dynamically check for availability of highest cache level events to add

### DIFF
--- a/src/ck-core/ck.C
+++ b/src/ck-core/ck.C
@@ -1089,7 +1089,7 @@ static inline void _deliverForBocMsg(CkCoreState *ck,int epIdx,envelope *env,Irr
   _invokeEntry(epIdx,env,obj);
 
 #if CMK_ONESIDED_IMPL && CMK_SMP
-  if(msgType == CMK_ZC_BCAST_RECV_DONE_MSG && CmiMyRank()!=0) {
+  if(msgType == CMK_ZC_BCAST_RECV_DONE_MSG) {
     updatePeerCounterAndPush(env);
   }
 #endif

--- a/src/ck-perf/trace-common.C
+++ b/src/ck-perf/trace-common.C
@@ -1004,7 +1004,6 @@ void initPAPI() {
 #else
   // just uses { PAPI_L2_DCM, PAPI_FP_OPS } the 2 initialized PAPI_EVENTS
 #endif
-  //papiRetValue = PAPI_add_events(CkpvAccess(papiEventSet), papiEvents, NUMPAPIEVENTS);
   if (PAPI_query_event(PAPI_L1_TCM) == PAPI_OK && PAPI_query_event(PAPI_L1_TCA) == PAPI_OK) {
     PAPI_add_event(CkpvAccess(papiEventSet), PAPI_L1_TCM);
     PAPI_add_event(CkpvAccess(papiEventSet), PAPI_L1_TCA);

--- a/src/ck-perf/trace-common.C
+++ b/src/ck-perf/trace-common.C
@@ -1037,7 +1037,7 @@ void initPAPI() {
     {
       CmiPrintf("Registered %d PAPI counters: ",PAPI_num_events(CkpvAccess(papiEventSet)));
       char nameBuf[PAPI_MAX_STR_LEN];
-      for(int i=0;i<2;i++)
+      for(int i = 0;i < NUMPAPIEVENTS; i++)
 	{
 	  PAPI_event_code_to_name(papiEvents[i], nameBuf);
 	  CmiPrintf("%s ",nameBuf);

--- a/src/ck-perf/trace-common.C
+++ b/src/ck-perf/trace-common.C
@@ -1021,7 +1021,7 @@ void initPAPI() {
     papiEvents[0] = PAPI_L3_TCM;
     papiEvents[1] = PAPI_L3_TCA;
   } else {
-    CmiPrintf("PAPI: no cache miss/access events supported on any level!\n");
+    CmiAbort("PAPI: no cache miss/access events supported on any level!\n");
   }
   if (papiRetValue < 0) {
     if (papiRetValue == PAPI_ECNFLCT) {
@@ -1035,7 +1035,7 @@ void initPAPI() {
   }
   if(CkMyPe()==0)
     {
-      CmiPrintf("Registered %d PAPI counters: ",PAPI_num_events(CkpvAccess(papiEventSet)));
+      CmiPrintf("Registered %d PAPI counters: ", NUMPAPIEVENTS);
       char nameBuf[PAPI_MAX_STR_LEN];
       for(int i = 0;i < NUMPAPIEVENTS; i++)
 	{

--- a/src/ck-perf/trace-common.h
+++ b/src/ck-perf/trace-common.h
@@ -124,7 +124,7 @@ void (*registerMachineUserEvents())();
 #ifdef USE_SPP_PAPI
 #define NUMPAPIEVENTS 6
 #else
-#define NUMPAPIEVENTS 4
+#define NUMPAPIEVENTS 2
 #endif
 CkpvExtern(int, papiEventSet);
 CkpvExtern(LONG_LONG_PAPI*, papiValues);


### PR DESCRIPTION
In some systems PAPI is unable to read cache events in certain cache levels, thus the highest cache level which can be read must be used.