### PR TITLE
fix #2268: undefined CthScheduled

### DIFF
--- a/src/conv-core/threads.C
+++ b/src/conv-core/threads.C
@@ -747,7 +747,7 @@ void CthSetStrategy(CthThread t, CthAwkFn awkfn, CthThFn chsfn)
 }
 
 #if CMK_OMP
-inline int CthScheduled(CthThread t) {
+int CthScheduled(CthThread t) {
   return B(t)->scheduled;
 }
 


### PR DESCRIPTION
When the CthScheduled function is inlined in the C file it cannot
be accessed via external linkage.  Removing the pointless (outside
of a header in C++) inline solves the problem.