### PR TITLE
AMPI: Fail compilation when unable to get binary path

### DIFF
--- a/src/libs/ck-libs/ampi/ampi.C
+++ b/src/libs/ck-libs/ampi/ampi.C
@@ -987,6 +987,7 @@ static void getAmpiBinaryPath() noexcept
     ampi_binary_path[n] = '\0';
   }
 #else
+// FIXME: We do not need to abort here, only if user requests pipglobals or fsglobals
 #  error "AMPI: No known way to get path to current binary."
 #endif
 }

--- a/src/libs/ck-libs/ampi/ampi.C
+++ b/src/libs/ck-libs/ampi/ampi.C
@@ -987,7 +987,7 @@ static void getAmpiBinaryPath() noexcept
     ampi_binary_path[n] = '\0';
   }
 #else
-  CkAbort("Could not get path to current binary!");
+#  error "AMPI: No known way to get path to current binary."
 #endif
 }
 


### PR DESCRIPTION
In this case, any AMPI application would abort anyway on startup, so better to fail at AMPI compilation already.