### PR TITLE
ZC API: set isRegistered after registration/de-registration

### DIFF
--- a/src/arch/gni/machine.C
+++ b/src/arch/gni/machine.C
@@ -2349,6 +2349,8 @@ static void PumpNetworkSmsg()
                                                                 newNcpyOpInfo->srcSize,
                                                                 GNI_MEM_READ_ONLY);
 
+                newNcpyOpInfo->isSrcRegistered = 1; // Set isSrcRegistered to 1 after registration
+
                 post_rdma((uint64_t)newNcpyOpInfo->destPtr,
                           ((CmiGNIRzvRdmaPtr_t *)((char *)(newNcpyOpInfo->destLayerInfo) + CmiGetRdmaCommonInfoSize()))->mem_hndl,
                           (uint64_t)newNcpyOpInfo->srcPtr,
@@ -2376,8 +2378,10 @@ static void PumpNetworkSmsg()
 
                 ((CmiGNIRzvRdmaPtr_t *)((char *)(newNcpyOpInfo->destLayerInfo) + CmiGetRdmaCommonInfoSize()))->mem_hndl =
                                               registerDirectMem(newNcpyOpInfo->destPtr,
-                                                                newNcpyOpInfo->srcSize,
+                                                                newNcpyOpInfo->destSize,
                                                                 GNI_MEM_READWRITE);
+
+                newNcpyOpInfo->isDestRegistered = 1; // Set isDestRegistered to 1 after registration
 
                 post_rdma((uint64_t)newNcpyOpInfo->srcPtr,
                           ((CmiGNIRzvRdmaPtr_t *)((char *)(newNcpyOpInfo->srcLayerInfo) + CmiGetRdmaCommonInfoSize()))->mem_hndl,

--- a/src/arch/ofi/machine-onesided.C
+++ b/src/arch/ofi/machine-onesided.C
@@ -141,6 +141,8 @@ void process_onesided_reg_and_put(struct fi_cq_tagged_entry *e, OFIRequest *req)
                        ncpyOpInfo->srcPtr,
                        ncpyOpInfo->srcSize);
 
+  ncpyOpInfo->isSrcRegistered = 1; // Set isSrcRegistered to 1 after registration
+
   const char *rbuf  = (FI_MR_SCALABLE == context.mr_mode) ? 0 : (const char*)(ncpyOpInfo->destPtr);
 
   // Allocate a completion object for tracking write completion and ack handling
@@ -176,7 +178,9 @@ void process_onesided_reg_and_get(struct fi_cq_tagged_entry *e, OFIRequest *req)
 
   registerDirectMemory(ncpyOpInfo->destLayerInfo + CmiGetRdmaCommonInfoSize(),
                        ncpyOpInfo->destPtr,
-                       ncpyOpInfo->srcSize);
+                       ncpyOpInfo->destSize);
+
+  ncpyOpInfo->isDestRegistered = 1; // Set isDestRegistered to 1 after registration
 
   const char *rbuf  = (FI_MR_SCALABLE == context.mr_mode) ? 0 : (const char*)(ncpyOpInfo->srcPtr);
 

--- a/src/arch/verbs/machine-ibverbs.C
+++ b/src/arch/verbs/machine-ibverbs.C
@@ -1904,7 +1904,7 @@ static inline void processRecvWC(struct ibv_wc *recvWC,const int toBuffer){
 		
 		registerDirectMemory(newNcpyOpInfo->destLayerInfo + CmiGetRdmaCommonInfoSize(),
 		                     newNcpyOpInfo->destPtr,
-		                     newNcpyOpInfo->srcSize);
+		                     newNcpyOpInfo->destSize);
 		// Set the destination as registered
 		newNcpyOpInfo->isDestRegistered = 1;
 		

--- a/src/ck-core/ckrdma.C
+++ b/src/ck-core/ckrdma.C
@@ -1349,10 +1349,8 @@ void handleBcastReverseEntryMethodApiCompletion(NcpyOperationInfo *info) {
   }
 #if CMK_REG_REQUIRED
   // De-register source for reverse operations when regMode == UNREG and deregMode == DEREG
-  if(info->isSrcRegistered == 1 && info->srcRegMode == CK_BUFFER_UNREG && info->srcDeregMode == CK_BUFFER_DEREG) {
-    CmiDeregisterMem(info->srcPtr, info->srcLayerInfo + CmiGetRdmaCommonInfoSize(), info->srcPe, info->srcRegMode);
-    info->isSrcRegistered = 0; // Set isSrcRegistered to 0 after de-registration
-  }
+  if(info->isSrcRegistered == 1 && info->srcRegMode == CK_BUFFER_UNREG && info->srcDeregMode == CK_BUFFER_DEREG)
+    deregisterSrcBuffer(info);
 #endif
 
   if(info->freeMe == CMK_FREE_NCPYOPINFO)

--- a/src/ck-core/ckrdma.C
+++ b/src/ck-core/ckrdma.C
@@ -1348,7 +1348,7 @@ void handleBcastReverseEntryMethodApiCompletion(NcpyOperationInfo *info) {
     invokeRemoteNcpyAckHandler(info->destPe, info->refPtr, ncpyHandlerIdx::EM_ACK);
   }
 #if CMK_REG_REQUIRED
-  // De-register source for reverse operations when regMode = UNREG and deregeMode = DEREG
+  // De-register source for reverse operations when regMode == UNREG and deregMode == DEREG
   if(info->isSrcRegistered == 1 && info->srcRegMode == CK_BUFFER_UNREG && info->srcDeregMode == CK_BUFFER_DEREG) {
     CmiDeregisterMem(info->srcPtr, info->srcLayerInfo + CmiGetRdmaCommonInfoSize(), info->srcPe, info->srcRegMode);
     info->isSrcRegistered = 0; // Set isSrcRegistered to 0 after de-registration

--- a/src/ck-core/ckrdma.C
+++ b/src/ck-core/ckrdma.C
@@ -461,6 +461,21 @@ inline bool isDeregReady(CkNcpyBuffer &buffInfo) {
   return false;
 }
 
+inline void deregisterBuffer(CkNcpyBuffer &buffInfo) {
+  CmiDeregisterMem(buffInfo.ptr, buffInfo.layerInfo + CmiGetRdmaCommonInfoSize(), buffInfo.pe, buffInfo.regMode);
+  buffInfo.isRegistered = false;
+}
+
+inline void deregisterDestBuffer(NcpyOperationInfo *ncpyOpInfo) {
+  CmiDeregisterMem(ncpyOpInfo->destPtr, ncpyOpInfo->destLayerInfo + CmiGetRdmaCommonInfoSize(), ncpyOpInfo->destPe, ncpyOpInfo->destRegMode);
+  ncpyOpInfo->isDestRegistered = 0;
+}
+
+inline void deregisterSrcBuffer(NcpyOperationInfo *ncpyOpInfo) {
+  CmiDeregisterMem(ncpyOpInfo->srcPtr, ncpyOpInfo->srcLayerInfo + CmiGetRdmaCommonInfoSize(), ncpyOpInfo->srcPe, ncpyOpInfo->srcRegMode);
+  ncpyOpInfo->isSrcRegistered = 0;
+}
+
 // Method called on completion of an Zcpy EM API (Send or Recv, P2P or BCAST)
 void CkRdmaEMAckHandler(int destPe, void *ack) {
 
@@ -489,7 +504,7 @@ void CkRdmaEMAckHandler(int destPe, void *ack) {
     NcpyOperationInfo *ncpyOpInfo = &(emBuffInfo->ncpyOpInfo);
 
     // De-register the destination buffer
-    CmiDeregisterMem(ncpyOpInfo->destPtr, ncpyOpInfo->destLayerInfo + CmiGetRdmaCommonInfoSize(), ncpyOpInfo->destPe, ncpyOpInfo->destRegMode);
+    deregisterDestBuffer(ncpyOpInfo);
 
   } else if(ncpyEmInfo->mode == ncpyEmApiMode::P2P_RECV ||
            (ncpyEmInfo->mode == ncpyEmApiMode::BCAST_RECV && t.child_count == 0)) {  // EM P2P Post API or EM BCAST Post API
@@ -497,7 +512,7 @@ void CkRdmaEMAckHandler(int destPe, void *ack) {
 
     // De-register only if destDeregMode is CK_BUFFER_DEREG
     if(ncpyOpInfo->destDeregMode == CK_BUFFER_DEREG) {
-      CmiDeregisterMem(ncpyOpInfo->destPtr, ncpyOpInfo->destLayerInfo + CmiGetRdmaCommonInfoSize(), ncpyOpInfo->destPe, ncpyOpInfo->destRegMode);
+      deregisterDestBuffer(ncpyOpInfo);
     }
   }
 #endif
@@ -532,11 +547,11 @@ void performEmApiMemcpy(CkNcpyBuffer &source, CkNcpyBuffer &dest, ncpyEmApiMode 
 
     // De-register source
     if(isDeregReady(source))
-      CmiDeregisterMem(source.ptr, source.layerInfo + CmiGetRdmaCommonInfoSize(), source.pe, source.regMode);
+      deregisterBuffer(source);
 
     // De-register destination for p2p Post API
     if(emMode == ncpyEmApiMode::P2P_RECV && isDeregReady(dest))
-      CmiDeregisterMem(dest.ptr, dest.layerInfo + CmiGetRdmaCommonInfoSize(), dest.pe, dest.regMode);
+      deregisterBuffer(dest);
 
     // Invoke source callback
     source.cb.send(sizeof(CkNcpyBuffer), &source);
@@ -548,7 +563,7 @@ void performEmApiMemcpy(CkNcpyBuffer &source, CkNcpyBuffer &dest, ncpyEmApiMode 
 
     // De-register dest if it has been registered
     if(emMode == ncpyEmApiMode::BCAST_RECV && isDeregReady(dest))
-      CmiDeregisterMem(dest.ptr, dest.layerInfo + CmiGetRdmaCommonInfoSize(), dest.pe, dest.regMode);
+      deregisterBuffer(dest);
   }
 }
 
@@ -560,7 +575,7 @@ void performEmApiCmaTransfer(CkNcpyBuffer &source, CkNcpyBuffer &dest, int child
 
     // De-register destination for p2p Post API
     if(emMode == ncpyEmApiMode::P2P_RECV && isDeregReady(dest))
-      CmiDeregisterMem(dest.ptr, dest.layerInfo + CmiGetRdmaCommonInfoSize(), dest.pe, dest.regMode);
+      deregisterBuffer(dest);
 
     if(source.refAckInfo == NULL) { // Not a part of a de-registration group
       // Invoke source callback
@@ -578,7 +593,7 @@ void performEmApiCmaTransfer(CkNcpyBuffer &source, CkNcpyBuffer &dest, int child
     } else {
       // De-register dest on child nodes if it has been registered
       if(emMode == ncpyEmApiMode::BCAST_RECV && isDeregReady(dest))
-        CmiDeregisterMem(dest.ptr, dest.layerInfo + CmiGetRdmaCommonInfoSize(), dest.pe, dest.regMode);
+        deregisterBuffer(dest);
     }
   }
 }
@@ -759,8 +774,7 @@ void handleReverseEntryMethodApiCompletion(NcpyOperationInfo *info) {
 #if CMK_REG_REQUIRED
   // De-register source only when srcDeregMode == CK_BUFFER_DEREG
   if(info->srcDeregMode == CK_BUFFER_DEREG) {
-    CmiDeregisterMem(info->srcPtr, info->srcLayerInfo + CmiGetRdmaCommonInfoSize(), info->srcPe, info->srcRegMode);
-    info->isSrcRegistered = 0; // Set isSrcRegistered to 0 after de-registration
+    deregisterSrcBuffer(info);
   }
 #endif
 
@@ -849,6 +863,12 @@ envelope* CkRdmaIssueRgets(envelope *env, ncpyEmApiMode emMode, void *forwardMsg
 
     //Update the CkRdmaWrapper pointer of the new message
     source.ptr = buf;
+
+    source.isRegistered = dest.isRegistered;
+
+    source.regMode = dest.regMode;
+
+    source.deregMode = dest.deregMode;
 
     memcpy(source.layerInfo, dest.layerInfo, layerInfoSize);
 
@@ -969,6 +989,12 @@ void CkRdmaIssueRgets(envelope *env, ncpyEmApiMode emMode, void *forwardMsg, int
     //Update the CkRdmaWrapper pointer of the new message
     source.ptr = arrPtrs[i];
 
+    source.isRegistered = dest.isRegistered;
+
+    source.regMode = dest.regMode;
+
+    source.deregMode = dest.deregMode;
+
     memcpy(source.layerInfo, dest.layerInfo, layerInfoSize);
 
     p|source;
@@ -1051,7 +1077,7 @@ void CkRdmaEMDeregAndAckHandler(void *ack) {
     CkNcpyBuffer &source = p2pAckInfo->src[i];
 
     // De-register source buffer
-    CmiDeregisterMem(source.ptr, source.layerInfo + CmiGetRdmaCommonInfoSize(), source.pe, source.regMode);
+    deregisterBuffer(source);
 
     // Invoke Callback
     invokeCallback(source);
@@ -1194,8 +1220,8 @@ void CkRdmaEMBcastAckHandler(void *ack) {
       for(int i=0; i<bcastRootAckInfo->numops; i++) {
 #if CMK_REG_REQUIRED
         // Deregister source buffer respecting source buffer's dereg mode
-        if(bcastRootAckInfo->src[i].deregMode == CK_BUFFER_DEREG)
-          bcastRootAckInfo->src[i].deregisterMem();
+        if(isDeregReady(bcastRootAckInfo->src[i]))
+          deregisterBuffer(bcastRootAckInfo->src[i]);
 #endif
 
         invokeCallback(&(bcastRootAckInfo->src[i].cb),
@@ -1321,6 +1347,14 @@ void handleBcastReverseEntryMethodApiCompletion(NcpyOperationInfo *info) {
     // Invoke the remote ackhandler function
     invokeRemoteNcpyAckHandler(info->destPe, info->refPtr, ncpyHandlerIdx::EM_ACK);
   }
+#if CMK_REG_REQUIRED
+  // De-register source for reverse operations when regMode = UNREG and deregeMode = DEREG
+  if(info->isSrcRegistered == 1 && info->srcRegMode == CK_BUFFER_UNREG && info->srcDeregMode == CK_BUFFER_DEREG) {
+    CmiDeregisterMem(info->srcPtr, info->srcLayerInfo + CmiGetRdmaCommonInfoSize(), info->srcPe, info->srcRegMode);
+    info->isSrcRegistered = 0; // Set isSrcRegistered to 0 after de-registration
+  }
+#endif
+
   if(info->freeMe == CMK_FREE_NCPYOPINFO)
     CmiFree(info);
 }
@@ -1340,9 +1374,8 @@ void deregisterMemFromMsg(envelope *env, bool isRecv) {
 
     // De-register the destination buffer when isRecv is false (i.e. using ZC Bcast Send API) or
     // when isRecv is true, respect deregMode and de-register
-    if( (!isRecv) || (isRecv && dest.deregMode == CMK_BUFFER_DEREG) ) {
-      CmiDeregisterMem(dest.ptr, (char *)dest.layerInfo + CmiGetRdmaCommonInfoSize(), dest.pe, dest.regMode);
-    }
+    if( (!isRecv) || (isRecv && dest.deregMode == CMK_BUFFER_DEREG) )
+      deregisterBuffer(dest);
 
     p|dest;
   }
@@ -1779,7 +1812,7 @@ void readonlyGet(CkNcpyBuffer &src, CkNcpyBuffer &dest, void *refPtr) {
     if(t.child_count != 0)  // Intermediate Node
       readonlyCreateOnSource(dest);
     else // Child Node - deregister dest buffer
-      CmiDeregisterMem(dest.ptr, dest.layerInfo + CmiGetRdmaCommonInfoSize(), dest.pe, dest.regMode);
+      deregisterBuffer(dest);
 
     // When all pending RO Rdma transfers are complete
     if(CksvAccess(_numPendingRORdmaTransfers) == 0) {
@@ -1862,7 +1895,7 @@ void readonlyGetCompleted(NcpyOperationInfo *ncpyOpInfo) {
   CksvAccess(_numPendingRORdmaTransfers)--;
 
   if(t.child_count == 0) // deregister dest buffer on the child node
-    CmiDeregisterMem(ncpyOpInfo->destPtr, ncpyOpInfo->destLayerInfo + CmiGetRdmaCommonInfoSize(), ncpyOpInfo->destPe, ncpyOpInfo->destRegMode);
+    deregisterDestBuffer(ncpyOpInfo);
 
   // When all pending RO Rdma transfers are complete
   if(CksvAccess(_numPendingRORdmaTransfers) == 0) {

--- a/src/ck-core/ckrdma.h
+++ b/src/ck-core/ckrdma.h
@@ -264,6 +264,7 @@ class CkNcpyBuffer{
 
   friend void deregisterMemFromMsg(envelope *env, bool isRecv);
   friend void CkRdmaEMDeregAndAckHandler(void *ack);
+  friend inline void deregisterBuffer(CkNcpyBuffer &buffInfo);
 };
 
 // Ack handler for the Zerocopy Direct API


### PR DESCRIPTION
This commit also adds the code for de-registration of source
buffers for Bcast operations implemented using reverse operations
when the buffer information object's mode is CK_BUFFER_UNREG.

Change-Id: Icea8bb56425b4d1a014b47bb795f4e34e220e99a