### PR TITLE
ZC Bcast Post API: Fix verbs-smp crash on intermediate nodes

### DIFF
--- a/src/ck-core/ckrdma.C
+++ b/src/ck-core/ckrdma.C
@@ -1245,6 +1245,9 @@ void CkRdmaEMBcastAckHandler(void *ack) {
         if(CmiMyNodeSize() > 1 && myMsg->getMsgtype() != ForNodeBocMsg) {
           sendRecvDoneMsgToPeers(myMsg, mgr);
         } else {
+          // Set zcMsgType to CMK_ZC_BCAST_RECV_ALL_DONE_MSG to signal to charmxi
+          // that this is the final message containing the posted pointers
+          CMI_ZC_MSGTYPE(env) = CMK_ZC_BCAST_RECV_ALL_DONE_MSG;
           if(myMsg->getMsgtype() == ForArrayEltMsg) {
             myMsg->setMsgtype(ForBocMsg);
             myMsg->getsetArrayEp() = mgr->getRecvBroadcastEpIdx();
@@ -1252,6 +1255,8 @@ void CkRdmaEMBcastAckHandler(void *ack) {
           enqueueNcpyMessage(bcastAckInfo->pe, myMsg);
         }
 #else
+        // Set zcMsgType to CMK_ZC_BCAST_RECV_ALL_DONE_MSG to signal to charmxi
+        // that this is the final message containing the posted pointers
         CMI_ZC_MSGTYPE(myMsg) = CMK_ZC_BCAST_RECV_ALL_DONE_MSG;
 
         if(myMsg->getMsgtype() == ForArrayEltMsg) {


### PR DESCRIPTION
This fixes the verbs-smp autobuild failures seen in zc_post_modify_size. (http://charm.cs.illinois.edu/autobuild/old.2019_05_31__01_01/verbs-linux-x86_64-smp.txt)