### PR TITLE
ZC RO Bcast: Send message to CmiNodeFirst(t.parent) instead of t.parent

### DIFF
--- a/src/ck-core/init.C
+++ b/src/ck-core/init.C
@@ -997,7 +997,7 @@ static void _roRdmaDoneHandler(envelope *env) {
           envelope *compEnv = _allocEnv(ROChildCompletionMsg);
           compEnv->setSrcPe(CkMyPe());
           CmiSetHandler(compEnv, _roRdmaDoneHandlerIdx);
-          CmiSyncSendAndFree(t.parent, compEnv->getTotalsize(), (char *)compEnv);
+          CmiSyncSendAndFree(CmiNodeFirst(t.parent), compEnv->getTotalsize(), (char *)compEnv);
         }
         // Free the roBcastAckInfo allocated inside readonlyAllocateOnSource
         CmiFree(roBcastAckInfo);


### PR DESCRIPTION
t.parent represents the logical node, which is the parent of my node.
However, CmiSyncSendAndFree expects a PE for its first argument and for that
reason, the ROChildCompletionMsg should be sent to the first PE of the parent.

This fixes the crash seen in https://github.com/UIUC-PPL/charm/issues/2286. 

However, the hang seen in https://github.com/UIUC-PPL/charm/issues/2286 is still unfixed because of QD support missing/being incorrect for the ZC API. 