### PR TITLE
Fix extern declarations of numZerocopyROops

### DIFF
--- a/src/ck-core/ckcheckpoint.C
+++ b/src/ck-core/ckcheckpoint.C
@@ -54,7 +54,12 @@ extern char *_shrinkexpand_basedir;
 #endif
 
 #if CMK_ONESIDED_IMPL
-extern UInt numZerocopyROops; // Required for broadcasting RO Data after recovering from failure
+// Required for broadcasting RO Data after recovering from failure
+#if CMK_SMP
+extern std::atomic<UInt> numZerocopyROops;
+#else
+extern UInt  numZerocopyROops; 
+#endif
 #endif
 
 void CkCreateLocalChare(int epIdx, envelope *env);
@@ -101,8 +106,14 @@ static void bdcastRO(void){
 	envelope *env = _allocEnv(RODataMsg, ps.size());
 	PUP::toMem pp((char *)EnvToUsr(env));
 #if CMK_ONESIDED_IMPL
-	pp|numZerocopyROops; // Messages of type 'RODataMsg' need to have numZerocopyROops pupped in order
-                       // to be processed inside _processRODataMsg
+	// Messages of type 'RODataMsg' need to have numZerocopyROops pupped in order
+	// to be processed inside _processRODataMsg
+#if CMK_SMP
+	UInt numZerocopyROopsTemp = numZerocopyROops.load(std::memory_order_relaxed);
+	pp|numZerocopyROopsTemp;
+#else
+	pp|numZerocopyROops;
+#endif
 #endif
 	for(i=0;i<_readonlyTable.size();i++) _readonlyTable[i]->pupData(pp);
 	

--- a/src/ck-core/ckrdma.C
+++ b/src/ck-core/ckrdma.C
@@ -1752,7 +1752,12 @@ void handleMsgOnInterimPostCompletionForRecvBcast(envelope *env, NcpyBcastInteri
 
 extern int _roRdmaDoneHandlerIdx,_initHandlerIdx;
 CksvExtern(int, _numPendingRORdmaTransfers);
-extern UInt numZerocopyROops, curROIndex;
+#if CMK_SMP
+extern std::atomic<UInt> numZerocopyROops;
+#else
+extern UInt  numZerocopyROops;
+#endif
+extern UInt curROIndex;
 extern bool usedCMAForROBcastTransfer;
 extern NcpyROBcastAckInfo *roBcastAckInfo;
 


### PR DESCRIPTION
This fixes the multicore-win-x86_64 and mpi-win-x86_64-smp autobuild
failures on 06/05/2019 by keeping the windows linker happy.