### PR TITLE
bugfix (#1473) : fix ancient ordering bug in benchmark

### DIFF
--- a/benchmarks/charm++/communication_overhead/overhead_test.C
+++ b/benchmarks/charm++/communication_overhead/overhead_test.C
@@ -154,10 +154,10 @@ public:
       delete msg;
       if (++nReceived == kFactor) {
         nReceived = 0;
-        operationFinished(NULL);
         msg = new (msgSize) SimpleMessage();
 	msg->size = msgSize;
         thisProxy[neighbor].operationFinished(msg);
+        operationFinished(NULL);
       }
     }
     else {


### PR DESCRIPTION
Test has always incorrectly ordered the local call
to operationFinished in the timed allocation case
to be before the remote message send. Whereas it should
always be after, as it is in the untimed allocation case.
Bug revealed by Phil's introduction of size testing in 2017.
Falsely attributed to verbs, as this bug is invariant
with network layer.