### PR TITLE
ZC GNI PUT: Remove immediate error checking for smsg send

### DIFF
--- a/src/arch/gni/machine-onesided.C
+++ b/src/arch/gni/machine-onesided.C
@@ -277,7 +277,6 @@ void LrtsIssueRput(NcpyOperationInfo *ncpyOpInfo) {
                               ncpyOpInfo->ncpyOpInfoSize,
                               RDMA_REG_AND_GET_MD_DIRECT_TAG,
                               0, NULL, CHARM_SMSG, 1);
-    GNI_RC_CHECK("Sending REG & GET metadata msg failed!", status);
 #if !CMK_SMSGS_FREE_AFTER_EVENT
     if(status == GNI_RC_SUCCESS) {
       CmiFree(ncpyOpInfo);


### PR DESCRIPTION
In some cases, the small message send doesn't return SUCCESS and in
such cases, the message is buffered and sent later. This commit removes
the error checking code which checks for SUCCESS immediately after a
REG_AND_GET message is sent from LrtsIssueRput in gni/machine-onesided.C.

Change-Id: I82c9e6fe9bd7dab94754c4262f6c7032f96123ff