### PR TITLE
Autobuild fixes after merging dereg support for ZC Direct API

### DIFF
--- a/benchmarks/charm++/zerocopy/direct_api/prereg/pingpong/pingpong.C
+++ b/benchmarks/charm++/zerocopy/direct_api/prereg/pingpong/pingpong.C
@@ -107,11 +107,11 @@ class Ping1 : public CBase_Ping1
   void setupGetGetPingpong(int size) {
     // Source callback and Ncpy object
     CkCallback srcCb = CkCallback(CkCallback::ignore);
-    mySrc = CkNcpyBuffer(nocopyMsg, sizeof(char)*size, srcCb, CK_BUFFER_PREREG);
+    mySrc = CkNcpyBuffer(nocopyMsg, sizeof(char)*size, srcCb, CK_BUFFER_PREREG, CK_BUFFER_NODEREG);
 
     // Destination callback and Ncpy object
     CkCallback destCb = CkCallback(CkIndex_Ping1::callbackGetGetPingpong(), thisProxy[thisIndex]);
-    myDest = CkNcpyBuffer(otherMsg, sizeof(char)*size, destCb, CK_BUFFER_PREREG);
+    myDest = CkNcpyBuffer(otherMsg, sizeof(char)*size, destCb, CK_BUFFER_PREREG, CK_BUFFER_NODEREG);
 
     thisProxy[0].beginGetGetPingpong();
   }
@@ -165,11 +165,11 @@ class Ping1 : public CBase_Ping1
 
     // Source callback and Ncpy object
     CkCallback srcCb = CkCallback(CkCallback::ignore);
-    mySrc = CkNcpyBuffer(nocopyMsg, sizeof(char)*size, srcCb, CK_BUFFER_PREREG);
+    mySrc = CkNcpyBuffer(nocopyMsg, sizeof(char)*size, srcCb, CK_BUFFER_PREREG, CK_BUFFER_NODEREG);
 
     // Destination callback and Ncpy object
     CkCallback destCb = CkCallback(CkIndex_Ping1::callbackPutPutPingpong(), thisProxy[thisIndex]);
-    myDest = CkNcpyBuffer(otherMsg, sizeof(char)*size, destCb, CK_BUFFER_PREREG);
+    myDest = CkNcpyBuffer(otherMsg, sizeof(char)*size, destCb, CK_BUFFER_PREREG, CK_BUFFER_NODEREG);
 
     thisProxy[0].beginPutPutPingpong();
   }

--- a/benchmarks/charm++/zerocopy/direct_api/reg/pingpong/pingpong.C
+++ b/benchmarks/charm++/zerocopy/direct_api/reg/pingpong/pingpong.C
@@ -107,11 +107,11 @@ class Ping1 : public CBase_Ping1
   void setupGetGetPingpong(int size) {
     // Source callback and Ncpy object
     CkCallback srcCb = CkCallback(CkCallback::ignore);
-    mySrc = CkNcpyBuffer(nocopyMsg, sizeof(char)*size, srcCb); // CK_BUFFER_REG
+    mySrc = CkNcpyBuffer(nocopyMsg, sizeof(char)*size, srcCb, CK_BUFFER_REG, CK_BUFFER_NODEREG); // NODEREG is used to avoid de-reg
 
     // Destination callback and Ncpy object
     CkCallback destCb = CkCallback(CkIndex_Ping1::callbackGetGetPingpong(), thisProxy[thisIndex]);
-    myDest = CkNcpyBuffer(otherMsg, sizeof(char)*size, destCb); // CK_BUFFER_REG
+    myDest = CkNcpyBuffer(otherMsg, sizeof(char)*size, destCb, CK_BUFFER_REG, CK_BUFFER_NODEREG); // NODEREG is used to avoid de-reg
 
     thisProxy[0].beginGetGetPingpong();
   }
@@ -165,11 +165,11 @@ class Ping1 : public CBase_Ping1
 
     // Source callback and Ncpy object
     CkCallback srcCb = CkCallback(CkCallback::ignore);
-    mySrc = CkNcpyBuffer(nocopyMsg, sizeof(char)*size, srcCb); // CK_BUFFER_REG
+    mySrc = CkNcpyBuffer(nocopyMsg, sizeof(char)*size, srcCb, CK_BUFFER_REG, CK_BUFFER_NODEREG); // NODEREG is used to avoid de-reg
 
     // Destination callback and Ncpy object
     CkCallback destCb = CkCallback(CkIndex_Ping1::callbackPutPutPingpong(), thisProxy[thisIndex]);
-    myDest = CkNcpyBuffer(otherMsg, sizeof(char)*size, destCb); // CK_BUFFER_REG
+    myDest = CkNcpyBuffer(otherMsg, sizeof(char)*size, destCb, CK_BUFFER_REG, CK_BUFFER_NODEREG); // NODEREG is used to avoid de-reg
 
     thisProxy[0].beginPutPutPingpong();
   }

--- a/benchmarks/charm++/zerocopy/direct_api/unreg/pingpong/pingpong.C
+++ b/benchmarks/charm++/zerocopy/direct_api/unreg/pingpong/pingpong.C
@@ -107,11 +107,11 @@ class Ping1 : public CBase_Ping1
   void setupGetGetPingpong(int size) {
     // Source callback and Ncpy object
     CkCallback srcCb = CkCallback(CkCallback::ignore);
-    mySrc = CkNcpyBuffer(nocopyMsg, sizeof(char)*size, srcCb, CK_BUFFER_UNREG);
+    mySrc = CkNcpyBuffer(nocopyMsg, sizeof(char)*size, srcCb, CK_BUFFER_UNREG, CK_BUFFER_NODEREG);
 
     // Destination callback and Ncpy object
     CkCallback destCb = CkCallback(CkIndex_Ping1::callbackGetGetPingpong(), thisProxy[thisIndex]);
-    myDest = CkNcpyBuffer(otherMsg, sizeof(char)*size, destCb, CK_BUFFER_UNREG);
+    myDest = CkNcpyBuffer(otherMsg, sizeof(char)*size, destCb, CK_BUFFER_UNREG, CK_BUFFER_NODEREG);
 
     thisProxy[0].beginGetGetPingpong();
   }
@@ -165,11 +165,11 @@ class Ping1 : public CBase_Ping1
 
     // Source callback and Ncpy object
     CkCallback srcCb = CkCallback(CkCallback::ignore);
-    mySrc = CkNcpyBuffer(nocopyMsg, sizeof(char)*size, srcCb, CK_BUFFER_UNREG);
+    mySrc = CkNcpyBuffer(nocopyMsg, sizeof(char)*size, srcCb, CK_BUFFER_UNREG, CK_BUFFER_NODEREG);
 
     // Destination callback and Ncpy object
     CkCallback destCb = CkCallback(CkIndex_Ping1::callbackPutPutPingpong(), thisProxy[thisIndex]);
-    myDest = CkNcpyBuffer(otherMsg, sizeof(char)*size, destCb, CK_BUFFER_UNREG);
+    myDest = CkNcpyBuffer(otherMsg, sizeof(char)*size, destCb, CK_BUFFER_UNREG, CK_BUFFER_NODEREG);
 
     thisProxy[0].beginPutPutPingpong();
   }

--- a/benchmarks/charm++/zerocopy/p2pPingpong/megaZCPingpong.C
+++ b/benchmarks/charm++/zerocopy/p2pPingpong/megaZCPingpong.C
@@ -229,10 +229,10 @@ class Ping1 : public CBase_Ping1 {
       iterations = _iterations;
 
       CkCallback srcCb = CkCallback(CkCallback::ignore);
-      src = CkNcpyBuffer(nocopySrcBuffer, sizeof(char) * size, srcCb, CK_BUFFER_UNREG);
+      src = CkNcpyBuffer(nocopySrcBuffer, sizeof(char) * size, srcCb, CK_BUFFER_UNREG, CK_BUFFER_NODEREG);
 
       CkCallback destCb = CkCallback(CkIndex_Ping1::getCompleteDest1(), thisProxy[thisIndex]);
-      dest = CkNcpyBuffer(nocopyDestBuffer, sizeof(char) * size, destCb, CK_BUFFER_UNREG);
+      dest = CkNcpyBuffer(nocopyDestBuffer, sizeof(char) * size, destCb, CK_BUFFER_UNREG, CK_BUFFER_NODEREG);
 
       thisProxy[0].beginDirectPingpong1();
     }
@@ -272,10 +272,10 @@ class Ping1 : public CBase_Ping1 {
       iterations = _iterations;
 
       CkCallback srcCb = CkCallback(CkCallback::ignore);
-      src = CkNcpyBuffer(nocopySrcBuffer, sizeof(char) * size, srcCb, CK_BUFFER_REG);
+      src = CkNcpyBuffer(nocopySrcBuffer, sizeof(char) * size, srcCb, CK_BUFFER_REG, CK_BUFFER_NODEREG);
 
       CkCallback destCb = CkCallback(CkIndex_Ping1::getCompleteDest2(), thisProxy[thisIndex]);
-      dest = CkNcpyBuffer(nocopyDestBuffer, sizeof(char) * size, destCb, CK_BUFFER_REG);
+      dest = CkNcpyBuffer(nocopyDestBuffer, sizeof(char) * size, destCb, CK_BUFFER_REG, CK_BUFFER_NODEREG);
 
       thisProxy[0].beginDirectPingpong2();
     }
@@ -312,10 +312,10 @@ class Ping1 : public CBase_Ping1 {
       iterations = _iterations;
 
       CkCallback srcCb = CkCallback(CkCallback::ignore);
-      src = CkNcpyBuffer(nocopySrcBufferReg, sizeof(char) * size, srcCb, CK_BUFFER_PREREG);
+      src = CkNcpyBuffer(nocopySrcBufferReg, sizeof(char) * size, srcCb, CK_BUFFER_PREREG, CK_BUFFER_NODEREG);
 
       CkCallback destCb = CkCallback(CkIndex_Ping1::getCompleteDest3(), thisProxy[thisIndex]);
-      dest = CkNcpyBuffer(nocopyDestBufferReg, sizeof(char) * size, destCb, CK_BUFFER_PREREG);
+      dest = CkNcpyBuffer(nocopyDestBufferReg, sizeof(char) * size, destCb, CK_BUFFER_PREREG, CK_BUFFER_NODEREG);
 
       thisProxy[0].beginDirectPingpong3();
     }
@@ -352,10 +352,10 @@ class Ping1 : public CBase_Ping1 {
       iterations = _iterations;
 
       CkCallback srcCb = CkCallback(CkCallback::ignore);
-      src = CkNcpyBuffer(nocopySrcBuffer, sizeof(char) * size, srcCb, CK_BUFFER_REG);
+      src = CkNcpyBuffer(nocopySrcBuffer, sizeof(char) * size, srcCb, CK_BUFFER_REG, CK_BUFFER_NODEREG);
 
       CkCallback destCb = CkCallback(CkIndex_Ping1::getCompleteDest4(), thisProxy[thisIndex]);
-      dest = CkNcpyBuffer(nocopyDestBuffer, sizeof(char) * size, destCb, CK_BUFFER_REG);
+      dest = CkNcpyBuffer(nocopyDestBuffer, sizeof(char) * size, destCb, CK_BUFFER_REG, CK_BUFFER_NODEREG);
 
       thisProxy[0].beginDirectPingpong4();
     }


### PR DESCRIPTION
The failures were caused after merging https://github.com/UIUC-PPL/charm/commit/97572b27ca70235dd5013d9184ba85215f02f775. 

This PR includes two fixes:

1. Pingpong benchmarks, which use the same set of buffers need to use CK_BUFFER_NODEREG to avoid RTS de-registration

2. QD counters have to be updated for de-reg messages. 