### PR TITLE
Require all Charm++ tests to meaningfully test SMP

### DIFF
--- a/tests/charm++/Makefile
+++ b/tests/charm++/Makefile
@@ -1,3 +1,5 @@
+-include ../../include/conv-mach-opt.mak
+
 DIRS = \
   megatest \
   alignment \
@@ -39,6 +41,13 @@ TESTDIRS = $(filter-out $(FTDIRS),$(DIRS))
 all: $(foreach i,$(DIRS),build-$i)
 
 test: $(foreach i,$(TESTDIRS),test-$i)
+ifeq ($(CMK_SMP),1)
+ifneq ($(CMK_MULTICORE),1)
+	make smptest
+endif
+endif
+
+smptest: $(foreach i,$(TESTDIRS),smptest-$i)
 
 bgtest: $(foreach i,$(filter $(BGDIRS),$(TESTDIRS)),bgtest-$i)
 
@@ -53,6 +62,9 @@ $(foreach i,$(DIRS),build-$i):
 
 $(foreach i,$(DIRS),test-$i):
 	$(MAKE) -C $(subst test-,,$@) test OPTS='$(OPTS)' TESTOPTS='$(TESTOPTS)'
+
+$(foreach i,$(DIRS),smptest-$i):
+	$(MAKE) -C $(subst smptest-,,$@) smptest OPTS='$(OPTS)' TESTOPTS='$(TESTOPTS)'
 
 $(foreach i,$(DIRS),bgtest-$i):
 	$(MAKE) -C $(subst bgtest-,,$@) bgtest OPTS='$(OPTS)' TESTOPTS='$(TESTOPTS)'

--- a/tests/charm++/alignment/Makefile
+++ b/tests/charm++/alignment/Makefile
@@ -19,3 +19,7 @@ alignmentCheck.o: alignmentCheck.C alignmentCheck.decl.h
 
 test: all
 	$(call run, +p2 ./alignmentCheck )
+
+smptest: all
+	$(call run, ./alignmentCheck +p2 ++ppn 2 )
+	$(call run, ./alignmentCheck +p4 ++ppn 2 )

--- a/tests/charm++/charmxi_parsing/Makefile
+++ b/tests/charm++/charmxi_parsing/Makefile
@@ -12,6 +12,7 @@ all: $(TARGETS)
 
 test: $(foreach i,$(TARGETS),test-$i)
 
+smptest: $(foreach i,$(TARGETS),smptest-$i)
 
 define TARGETRULES
 
@@ -21,7 +22,12 @@ $1: $1.o
 
 # test
 test-$1: $1
-	$$(call run,./$1)
+	$$(call run,./$1 +p1)
+	$$(call run,./$1 +p2)
+
+smptest-$1: $1
+	$$(call run,./$1 +p2 ++ppn 2)
+	$$(call run,./$1 +p4 ++ppn 2)
 
 # avoid deleting decl/def after building them
 .PRECIOUS: $1.decl.h $1.def.h

--- a/tests/charm++/chkpt/Makefile
+++ b/tests/charm++/chkpt/Makefile
@@ -31,6 +31,18 @@ test: all
 	-sync
 	$(call run, ./hello +p4 +restart log )
 
+smptest: all
+	-rm -fr log
+	$(call run, ./hello +p4 ++ppn 2 )
+	-sync
+	$(call run, ./hello +p4 +restart log ++ppn 4 )
+	$(call run, ./hello +p2 +restart log ++ppn 2 )
+	-sync
+	-rm -fr log
+	$(call run, ./hello +p2 ++ppn 2)
+	-sync
+	$(call run, ./hello +p4 +restart log ++ppn 4 )
+
 bgtest: all
 	-rm -fr log
 	$(call run, ./hello +p2 +x3 +y1 +z1 )

--- a/tests/charm++/ckAllocSysMsgTest/Makefile
+++ b/tests/charm++/ckAllocSysMsgTest/Makefile
@@ -26,6 +26,10 @@ test: all
 	$(call run, ./ckAllocSysMsgTest 40  5  2 3  +p2 )
 	$(call run, ./ckAllocSysMsgTest 30 10 10 3  +p4 )
 
+smptest: all
+	$(call run, ./ckAllocSysMsgTest 30 10 10 3  +p2 ++ppn 2)
+	$(call run, ./ckAllocSysMsgTest 40  5  2 3  +p2 ++ppn 2)
+	$(call run, ./ckAllocSysMsgTest 30 10 10 3  +p4 ++ppn 2)
 
 bgtest: all
 	$(call run, ./ckAllocSysMsgTest 30 10 10 3  +p4 +x2 +y2 +z2)

--- a/tests/charm++/delegation/Makefile
+++ b/tests/charm++/delegation/Makefile
@@ -7,6 +7,8 @@ all: $(foreach i,$(DIRS),build-$i)
 
 test: $(foreach i,$(TESTDIRS),test-$i)
 
+smptest: $(foreach i,$(TESTDIRS),smptest-$i)
+
 bgtest: $(foreach i,$(TESTDIRS),bgtest-$i)
 
 clean: $(foreach i,$(DIRS),clean-$i)
@@ -18,6 +20,9 @@ $(foreach i,$(DIRS),build-$i):
 
 $(foreach i,$(DIRS),test-$i):
 	$(MAKE) -C $(subst test-,,$@) test OPTS='$(OPTS)' TESTOPTS='$(TESTOPTS)'
+
+$(foreach i,$(DIRS),smptest-$i):
+	$(MAKE) -C $(subst smptest-,,$@) smptest OPTS='$(OPTS)' TESTOPTS='$(TESTOPTS)'
 
 $(foreach i,$(DIRS),bgtest-$i):
 	$(MAKE) -C $(subst bgtest-,,$@) bgtest OPTS='$(OPTS)' TESTOPTS='$(TESTOPTS)'

--- a/tests/charm++/delegation/multicast/Makefile
+++ b/tests/charm++/delegation/multicast/Makefile
@@ -18,6 +18,10 @@ hello.ci.stamp: hello.ci
 test: all
 	$(call run, +p3 ./hello 10 )
 
+smptest: all
+	$(call run, +p2 ./hello 10 ++ppn 2 )
+	$(call run, +p4 ./hello 10 ++ppn 2 )
+
 bgtest: all
 	$(call run, +p3 ./hello 10 +x1 +y1 +z3 )
 

--- a/tests/charm++/demand_creation/Makefile
+++ b/tests/charm++/demand_creation/Makefile
@@ -20,5 +20,9 @@ hello.o: hello.C hello.decl.h
 test: all
 	$(call run, ./hello +p4 10 )
 
+smptest: all
+	$(call run, ./hello +p2 10 ++ppn 2)
+	$(call run, ./hello +p4 10 ++ppn 2)
+
 bgtest: all
 	$(call run, ./hello +p4 10 +x2 +y2 +z2 +cth1 +wth1 +bglog )

--- a/tests/charm++/io/Makefile
+++ b/tests/charm++/io/Makefile
@@ -10,5 +10,9 @@ pgm: iotest.ci iotest.C
 test: pgm
 	$(call run, ./pgm +p4 4 )
 
+smptest: pgm
+	$(call run, ./pgm 4 +p2 ++ppn 2)
+	$(call run, ./pgm 4 +p4 ++ppn 2)
+
 clean:
 	rm -f *.o *.decl.h *.def.h pgm test*

--- a/tests/charm++/load_balancing/Makefile
+++ b/tests/charm++/load_balancing/Makefile
@@ -8,6 +8,8 @@ all: $(foreach i,$(DIRS),build-$i)
 
 test: $(foreach i,$(TESTDIRS),test-$i)
 
+smptest: $(foreach i,$(TESTDIRS),smptest-$i)
+
 bgtest: $(foreach i,$(TESTDIRS),bgtest-$i)
 
 clean: $(foreach i,$(DIRS),clean-$i)
@@ -19,6 +21,9 @@ $(foreach i,$(DIRS),build-$i):
 
 $(foreach i,$(DIRS),test-$i):
 	$(MAKE) -C $(subst test-,,$@) test OPTS='$(OPTS)' TESTOPTS='$(TESTOPTS)'
+
+$(foreach i,$(DIRS),smptest-$i):
+	$(MAKE) -C $(subst smptest-,,$@) smptest OPTS='$(OPTS)' TESTOPTS='$(TESTOPTS)'
 
 $(foreach i,$(DIRS),bgtest-$i):
 	$(MAKE) -C $(subst bgtest-,,$@) bgtest OPTS='$(OPTS)' TESTOPTS='$(TESTOPTS)'

--- a/tests/charm++/load_balancing/lb_test/Makefile
+++ b/tests/charm++/load_balancing/lb_test/Makefile
@@ -31,6 +31,12 @@ test:  lb_test
 	$(call run, +p4 ./lb_test 100 100 10 40 10 1000 ring +balancer GreedyLB +LBDebug 1 )
 	$(call run, +p4 ./lb_test 100 100 10 40 10 1000 ring +balancer CommLB +LBDebug 1 )
 
+smptest: lb_test
+	$(call run, +p2 ./lb_test 100 100 10 40 10 1000 ring +balancer GreedyLB +LBDebug 1 ++ppn 2)
+	$(call run, +p2 ./lb_test 100 100 10 40 10 1000 ring +balancer CommLB +LBDebug 1  ++ppn 2)
+	$(call run, +p4 ./lb_test 100 100 10 40 10 1000 ring +balancer GreedyLB +LBDebug 1 ++ppn 2)
+	$(call run, +p4 ./lb_test 100 100 10 40 10 1000 ring +balancer CommLB +LBDebug 1  ++ppn 2)
+
 test_every:  lb_test.every
 	$(call run, +p4 ./lb_test.every 100 100 10 40 10 1000 ring +balancer RecBipartLB +LBDebug 1 )
 

--- a/tests/charm++/load_balancing/meta_lb_test/Makefile
+++ b/tests/charm++/load_balancing/meta_lb_test/Makefile
@@ -13,10 +13,10 @@ test: period_selection
 	$(call run, +p1 ./period_selection +balancer RotateLB +LBPeriod 0.001 +MetaLB +LBObjOnly)
 	$(call run, +p2 ./period_selection +balancer RotateLB +LBPeriod 0.001 +MetaLB +LBObjOnly)
 	$(call run, +p4 ./period_selection +balancer RotateLB +LBPeriod 0.001 +MetaLB +LBObjOnly)
-ifeq ($(CMK_SMP),1)
+
+smptest: period_selection
 	$(call run, +p2 ./period_selection +balancer RotateLB +LBPeriod 0.001 +MetaLB +LBObjOnly ++ppn 2)
-	$(call run, +p4 ./period_selection +balancer RotateLB +LBPeriod 0.001 +MetaLB +LBOnjOnly ++ppn 2)
-endif
+	$(call run, +p4 ./period_selection +balancer RotateLB +LBPeriod 0.001 +MetaLB +LBObjOnly ++ppn 2)
 
 bgtest: period_selection
 	$(call run, +p4 ./period_selection +balancer RotateLB +LBPeriod 0.001 +MetaLB +LBObjOnly +x2 +y2 +z1 +cth1 +wth1 )

--- a/tests/charm++/megatest/Makefile
+++ b/tests/charm++/megatest/Makefile
@@ -110,6 +110,10 @@ test: pgm
 	$(call run, ./pgm +p3 )
 	$(call run, ./pgm +p4 )
 
+smptest: pgm
+	$(call run, ./pgm +p2 ++ppn 2 )
+	$(call run, ./pgm +p4 ++ppn 2 )
+
 depends:  $(CIFILES)
 	echo "Creating " $(DEPENDFILE) " ...";	\
         if [ -f $(DEPENDFILE) ]; then \

--- a/tests/charm++/method_templates/Makefile
+++ b/tests/charm++/method_templates/Makefile
@@ -47,6 +47,11 @@ test: all
 	@echo "########################################################################################"
 	$(call run, $(EXECFLAGS) ./$(TARGET) $(ARGS))
 
+smptest: all
+	@echo "########################################################################################"
+	$(call run, $(EXECFLAGS) ./$(TARGET) $(ARGS) ++ppn 2)
+	$(call run, $(EXECFLAGS) ./$(TARGET) $(ARGS) ++ppn 4)
+
 
 mylib.o: mylib.C mylib.h mylib.decl.h mylib.def.h
 pgm.o: pgm.C client.decl.h mylib.h mylib.decl.h mylib.def.h utils.h client.def.h

--- a/tests/charm++/partitions/Makefile
+++ b/tests/charm++/partitions/Makefile
@@ -27,5 +27,14 @@ else
 	$(call run, ./hello +p4 10 2 +partitions 2)
 endif
 
+smptest: all
+ifeq ($(CMK_NO_PARTITIONS),1)
+	echo "Skipping test since build does not support partitions"
+else ifeq ($(CMK_BLUEGENEQ),1)
+	echo "Skipping partitions test on BGQ"
+else
+	$(call run, ./hello +p4 10 2 +partitions 2 ++ppn 2)
+endif
+
 bgtest: all
 	$(call run, ./hello +p4 10 2 +x2 +y2 +z2 +cth1 +wth1 +partitions 2)

--- a/tests/charm++/provisioning/Makefile
+++ b/tests/charm++/provisioning/Makefile
@@ -3,7 +3,6 @@
 CHARMC=../../../bin/charmc $(OPTS)
 
 MACHINE_LAYER := $(CMK_GDIR)
-SMP := $(CMK_SMP)
 
 TARGET = launch
 
@@ -29,7 +28,13 @@ ifneq (,$(filter netlrts verbs,$(MACHINE_LAYER)))
 	$(call run, ./$(TARGET) ++processPerSocket 1)
 	$(call run, ./$(TARGET) ++processPerCore 1)
 	$(call run, ./$(TARGET) ++processPerPU 1)
-ifeq (1,$(SMP))
+	$(call run, ./$(TARGET) ++autoProvision)
+endif
+endif
+
+smptest:
+ifeq (,$(findstring +p,$(TESTOPTS)))
+ifneq (,$(filter netlrts verbs,$(MACHINE_LAYER)))
 	$(call run, ./$(TARGET) ++oneWthPerHost)
 	$(call run, ./$(TARGET) ++oneWthPerSocket)
 	$(call run, ./$(TARGET) ++oneWthPerCore)
@@ -44,8 +49,6 @@ ifeq (1,$(SMP))
 	$(call run, ./$(TARGET) ++processPerCore 1 ++oneWthPerCore)
 	$(call run, ./$(TARGET) ++processPerCore 1 ++oneWthPerPU)
 	$(call run, ./$(TARGET) ++processPerPU 1 ++oneWthPerPU)
-endif
-	$(call run, ./$(TARGET) ++autoProvision)
 endif
 endif
 

--- a/tests/charm++/queue/Makefile
+++ b/tests/charm++/queue/Makefile
@@ -8,6 +8,8 @@ test: $(TARGETS)
 	$(call run, ./pgm  +p1)
 	$(call run, ./msgqtest  +p1)
 
+smptest: $(TARGETS)
+
 pgm.C: main.decl.h
 
 msgqtest.C: main.decl.h

--- a/tests/charm++/reductionTesting/Makefile
+++ b/tests/charm++/reductionTesting/Makefile
@@ -9,6 +9,8 @@ all: $(foreach i,$(DIRS),build-$i)
 
 test: $(foreach i,$(TESTDIRS),test-$i)
 
+smptest: $(foreach i,$(TESTDIRS),smptest-$i)
+
 clean: $(foreach i,$(DIRS),clean-$i)
 	rm -f TAGS #*#
 	rm -f core *~
@@ -18,6 +20,9 @@ $(foreach i,$(DIRS),build-$i):
 
 $(foreach i,$(DIRS),test-$i):
 	$(MAKE) -C $(subst test-,,$@) test OPTS='$(OPTS)' TESTOPTS='$(TESTOPTS)'
+
+$(foreach i,$(DIRS),smptest-$i):
+	$(MAKE) -C $(subst smptest-,,$@) smptest OPTS='$(OPTS)' TESTOPTS='$(TESTOPTS)'
 
 $(foreach i,$(DIRS),clean-$i):
 	$(MAKE) -C $(subst clean-,,$@) clean OPTS='$(OPTS)'

--- a/tests/charm++/reductionTesting/reductionTesting1D/Makefile
+++ b/tests/charm++/reductionTesting/reductionTesting1D/Makefile
@@ -23,6 +23,10 @@ sectionReduction.decl.h sectionReduction.def.h: sectionReduction.ci
 test: all
 	$(call run, ./pgm +p4 20 5 )
 
+smptest: all
+	$(call run, ./pgm 20 5 +p2 ++ppn 2)
+	$(call run, ./pgm 20 5 +p4 ++ppn 2)
+
 clean:
 	rm -f *.decl.h *.def.h *.o
 	rm -f pgm charmrun

--- a/tests/charm++/reductionTesting/reductionTesting2D/Makefile
+++ b/tests/charm++/reductionTesting/reductionTesting2D/Makefile
@@ -23,6 +23,10 @@ sectionReduction.decl.h sectionReduction.def.h: sectionReduction.ci
 test: all
 	$(call run, ./pgm +p4 20 10 5 )
 
+smptest: all
+	$(call run, ./pgm 20 10 5 +p2 ++ppn 2)
+	$(call run, ./pgm 20 10 5 +p4 ++ppn 2)
+
 clean:
 	rm -f *.decl.h *.def.h *.o
 	rm -f pgm charmrun

--- a/tests/charm++/reductionTesting/reductionTesting3D/Makefile
+++ b/tests/charm++/reductionTesting/reductionTesting3D/Makefile
@@ -23,6 +23,10 @@ sectionReduction.decl.h sectionReduction.def.h: sectionReduction.ci
 test: all
 	$(call run, ./pgm +p4 20 20 20 5 )
 
+smptest: all
+	$(call run, ./pgm 20 20 20 5 +p2 ++ppn 2)
+	$(call run, ./pgm 20 20 20 5 +p4 ++ppn 2)
+
 clean:
 	rm -f *.decl.h *.def.h *.o
 	rm -f pgm charmrun

--- a/tests/charm++/simplearrayhello/Makefile
+++ b/tests/charm++/simplearrayhello/Makefile
@@ -20,5 +20,9 @@ hello.o: hello.C hello.decl.h
 test: all
 	$(call run, ./hello +p4 10 )
 
+smptest: all
+	$(call run, ./hello 10 +p2 ++ppn 2 )
+	$(call run, ./hello 10 +p4 ++ppn 2 )
+
 bgtest: all
 	$(call run, ./hello +p4 10 +x2 +y2 +z2 +cth1 +wth1 )

--- a/tests/charm++/sparse/Makefile
+++ b/tests/charm++/sparse/Makefile
@@ -22,3 +22,8 @@ sparse.o: sparse.C sparse.h cifiles
 test: all
 	@echo "Testing bulk construction of sparse arrays..."
 	$(call run, ./sparse +p4 )
+
+smptest: all
+	@echo "Testing bulk construction of sparse arrays..."
+	$(call run, ./sparse +p2 ++ppn 2 )
+	$(call run, ./sparse +p4 ++ppn 2 )

--- a/tests/charm++/startupTest/Makefile
+++ b/tests/charm++/startupTest/Makefile
@@ -22,5 +22,9 @@ test: all
 	$(call run, ./startupTest 200 10 0.0001 1  +p2)
 	$(call run, ./startupTest 200 10 0.0001 1  +p4)
 
+smptest: all
+	$(call run, ./startupTest 200 10 0.0001 1  +p2 ++ppn 2)
+	$(call run, ./startupTest 200 10 0.0001 1  +p4 ++ppn 2)
+
 bgtest: all
 	$(call run, ./startupTest 20 10 0.01 1 +p4 +x2 +y2 +z2)

--- a/tests/charm++/topology/Makefile
+++ b/tests/charm++/topology/Makefile
@@ -20,3 +20,6 @@ rtc.o: rtc.C topo.decl.h
 test: all
 	$(call run, ./rtc +p4 )
 
+smptest: all
+	$(call run, ./rtc +p2 ++ppn 2)
+	$(call run, ./rtc +p4 ++ppn 2)

--- a/tests/charm++/within_node_bcast/Makefile
+++ b/tests/charm++/within_node_bcast/Makefile
@@ -16,9 +16,7 @@ clean:
 test: all
 	$(call run, ./within_node_bcast +p1)
 	$(call run, ./within_node_bcast +p2)
-ifeq ($(CMK_SMP),1)
-ifneq ($(CMK_MULTICORE),1)
+
+smptest:
 	$(call run, ./within_node_bcast +p2 ++ppn 2)
 	$(call run, ./within_node_bcast +p4 ++ppn 2)
-endif
-endif

--- a/tests/charm++/zerocopy/Makefile
+++ b/tests/charm++/zerocopy/Makefile
@@ -12,6 +12,8 @@ all: $(foreach i,$(DIRS),build-$i)
 
 test: $(foreach i,$(TESTDIRS),test-$i)
 
+smptest: $(foreach i,$(TESTDIRS),smptest-$i)
+
 clean: $(foreach i,$(DIRS),clean-$i)
 	rm -f TAGS #*#
 	rm -f core *~
@@ -21,6 +23,9 @@ $(foreach i,$(DIRS),build-$i):
 
 $(foreach i,$(DIRS),test-$i):
 	$(MAKE) -C $(subst test-,,$@) test OPTS='$(OPTS)' TESTOPTS='$(TESTOPTS)'
+
+$(foreach i,$(DIRS),smptest-$i):
+	$(MAKE) -C $(subst smptest-,,$@) smptest OPTS='$(OPTS)' TESTOPTS='$(TESTOPTS)'
 
 $(foreach i,$(DIRS),clean-$i):
 	$(MAKE) -C $(subst clean-,,$@) clean OPTS='$(OPTS)'

--- a/tests/charm++/zerocopy/bcast_nonzero_root/Makefile
+++ b/tests/charm++/zerocopy/bcast_nonzero_root/Makefile
@@ -25,6 +25,12 @@ test: all
 	$(call run, +p4 ./bcast_nonzero_root +noCMAForZC)
 	$(call run, +p6 ./bcast_nonzero_root +noCMAForZC)
 
+smptest: all
+	$(call run, +p4 ./bcast_nonzero_root ++ppn 4)
+	$(call run, +p6 ./bcast_nonzero_root ++ppn 3)
+	$(call run, +p4 ./bcast_nonzero_root +noCMAforZC ++ppn 4)
+	$(call run, +p6 ./bcast_nonzero_root +noCMAForZC ++ppn 3)
+
 clean:
 	rm -f *.decl.h *.def.h *.o
 	rm -f bcast_nonzero_root charmrun cifiles

--- a/tests/charm++/zerocopy/dereg_and_nodereg/Makefile
+++ b/tests/charm++/zerocopy/dereg_and_nodereg/Makefile
@@ -23,6 +23,10 @@ test: all
 	$(call run, +p4 ./dereg_and_nodereg 50 +noCMAForZC)
 	$(call run, +p6 ./dereg_and_nodereg 100 +noCMAForZC)
 
+smptest: all
+	$(call run, +p4 ./dereg_and_nodereg 50 ++ppn 4)
+	$(call run, +p6 ./dereg_and_nodereg 100 ++ppn 3)
+
 clean:
 	rm -f *.decl.h *.def.h *.o
 	rm -f dereg_and_nodereg charmrun cifiles

--- a/tests/charm++/zerocopy/dereg_and_nodereg/Makefile
+++ b/tests/charm++/zerocopy/dereg_and_nodereg/Makefile
@@ -26,6 +26,8 @@ test: all
 smptest: all
 	$(call run, +p4 ./dereg_and_nodereg 50 ++ppn 4)
 	$(call run, +p6 ./dereg_and_nodereg 100 ++ppn 3)
+	$(call run, +p4 ./dereg_and_nodereg 50 +noCMAForZC ++ppn 4)
+	$(call run, +p6 ./dereg_and_nodereg 100 +noCMAForZC ++ppn 3)
 
 clean:
 	rm -f *.decl.h *.def.h *.o

--- a/tests/charm++/zerocopy/direct_api/Makefile
+++ b/tests/charm++/zerocopy/direct_api/Makefile
@@ -21,6 +21,10 @@ test: all
 	$(call run, +p4 ./direct_api 100)
 	$(call run, +p4 ./direct_api 100 +noCMAForZC)
 
+smptest: all
+	$(call run, +p2 ./direct_api 60 ++ppn 2)
+	$(call run, +p4 ./direct_api 100 ++ppn 2)
+
 clean:
 	rm -f *.decl.h *.def.h *.o
 	rm -f direct_api charmrun cifiles

--- a/tests/charm++/zerocopy/direct_api/Makefile
+++ b/tests/charm++/zerocopy/direct_api/Makefile
@@ -24,6 +24,8 @@ test: all
 smptest: all
 	$(call run, +p2 ./direct_api 60 ++ppn 2)
 	$(call run, +p4 ./direct_api 100 ++ppn 2)
+	$(call run, +p2 ./direct_api 60 +noCMAForZC ++ppn 2)
+	$(call run, +p4 ./direct_api 100 +noCMAForZC ++ppn 2)
 
 clean:
 	rm -f *.decl.h *.def.h *.o

--- a/tests/charm++/zerocopy/largedata/Makefile
+++ b/tests/charm++/zerocopy/largedata/Makefile
@@ -30,6 +30,10 @@ test: all
 	$(call run, ./pgm +p4 200000 10 +noCMAForZC)
 	$(call run, ./pgm +p6 200000 10 +noCMAForZC)
 
+smptest: all
+	$(call run, ./pgm +p4 200000 10 ++ppn 2)
+	$(call run, ./pgm +p4 200000 10 ++ppn 4)
+
 test-bench: all
 	$(call run, ./pgm +p10)
 

--- a/tests/charm++/zerocopy/largedata/Makefile
+++ b/tests/charm++/zerocopy/largedata/Makefile
@@ -33,6 +33,8 @@ test: all
 smptest: all
 	$(call run, ./pgm +p4 200000 10 ++ppn 2)
 	$(call run, ./pgm +p4 200000 10 ++ppn 4)
+	$(call run, ./pgm +p4 200000 10 +noCMAForZC ++ppn 2)
+	$(call run, ./pgm +p4 200000 10 +noCMAForZC ++ppn 4)
 
 test-bench: all
 	$(call run, ./pgm +p10)

--- a/tests/charm++/zerocopy/zc_post_modify_size/Makefile
+++ b/tests/charm++/zerocopy/zc_post_modify_size/Makefile
@@ -21,6 +21,10 @@ test: all
 	$(call run, +p4 ./zc_post_modify_size)
 	$(call run, +p4 ./zc_post_modify_size +noCMAForZC)
 
+smptest: all
+	$(call run, +p2 ./zc_post_modify_size ++ppn 2)
+	$(call run, +p4 ./zc_post_modify_size ++ppn 2)
+
 clean:
 	rm -f *.decl.h *.def.h *.o
 	rm -f zc_post_modify_size charmrun cifiles

--- a/tests/charm++/zerocopy/zc_post_modify_size/Makefile
+++ b/tests/charm++/zerocopy/zc_post_modify_size/Makefile
@@ -24,6 +24,8 @@ test: all
 smptest: all
 	$(call run, +p2 ./zc_post_modify_size ++ppn 2)
 	$(call run, +p4 ./zc_post_modify_size ++ppn 2)
+	$(call run, +p2 ./zc_post_modify_size +noCMAForZC ++ppn 2)
+	$(call run, +p4 ./zc_post_modify_size +noCMAForZC ++ppn 2)
 
 clean:
 	rm -f *.decl.h *.def.h *.o

--- a/tests/charm++/zerocopy/zerocopy_with_qd/Makefile
+++ b/tests/charm++/zerocopy/zerocopy_with_qd/Makefile
@@ -23,6 +23,10 @@ test: all
 	$(call run, +p4 ./zerocopy_with_qd 100 +noCMAForZC)
 	$(call run, +p6 ./zerocopy_with_qd 142 +noCMAForZC)
 
+smptest: all
+	$(call run, +p4 ./zerocopy_with_qd 100 ++ppn 4)
+	$(call run, +p6 ./zerocopy_with_qd 142 ++ppn 3)
+
 clean:
 	rm -f *.decl.h *.def.h *.o
 	rm -f zerocopy_with_qd charmrun cifiles

--- a/tests/charm++/zerocopy/zerocopy_with_qd/Makefile
+++ b/tests/charm++/zerocopy/zerocopy_with_qd/Makefile
@@ -26,6 +26,8 @@ test: all
 smptest: all
 	$(call run, +p4 ./zerocopy_with_qd 100 ++ppn 4)
 	$(call run, +p6 ./zerocopy_with_qd 142 ++ppn 3)
+	$(call run, +p4 ./zerocopy_with_qd 100 +noCMAForZC ++ppn 4)
+	$(call run, +p6 ./zerocopy_with_qd 142 +noCMAForZC ++ppn 3)
 
 clean:
 	rm -f *.decl.h *.def.h *.o


### PR DESCRIPTION
This is the first step in a larger effort to cleanup/improve Charm++ tests.
This adds a new make target, smptest, which is run on every test. Tests that
don't define it will fail. Almost all existing tests now also run on a single
multi-PE process (+p2 ++ppn 2) and mutliple multi-PE processes (+p4 ++ppn 2).