### PR TITLE
Fix de-registration bug in benchmarks/charm++/pingpong/

### DIFF
--- a/benchmarks/charm++/pingpong/pingpong.C
+++ b/benchmarks/charm++/pingpong/pingpong.C
@@ -464,10 +464,10 @@ public:
     double OOB=9999999999.0;
 
     CkCallback srcCb(CkCallback::ignore);
-    mySrcInfo = CkNcpyBuffer(sourceBuffer, payload * sizeof(char), srcCb);
+    mySrcInfo = CkNcpyBuffer(sourceBuffer, payload * sizeof(char), srcCb, CK_BUFFER_REG, CK_BUFFER_NODEREG);
 
     CkCallback destCb(CkIndex_PingN::destRDMACompleted(NULL), thisProxy[thisIndex]);
-    CkNcpyBuffer myDestInfo = CkNcpyBuffer(destBuffer, payload * sizeof(char), destCb);
+    CkNcpyBuffer myDestInfo = CkNcpyBuffer(destBuffer, payload * sizeof(char), destCb, CK_BUFFER_REG, CK_BUFFER_NODEREG);
 
     thisProxy[nbr].recvHandle(myDestInfo);
   }


### PR DESCRIPTION
This commit changes the deregMode of the buffer info objects using
the Direct API in benchmarks/charm++/pingpong to CK_BUFFER_NODEREG.
This is required to ensure that the buffers are not de-registered
after the completion of the operation.