### PR TITLE
Fix Charm4py registering extra entry methods, and some cleanup

### DIFF
--- a/src/ck-core/register.C
+++ b/src/ck-core/register.C
@@ -99,17 +99,17 @@ void CkRegisterGroupIrr(int chareIndex,int isIrr){
 #if CMK_CHARMPY
 
 // TODO give a unique name to entry methods when calling CkRegisterEp
+// (no need has appeared for this so this is very low priority)
+
 void CkRegisterGroupExt(const char *s, int numEntryMethods, int *chareIdx, int *startEpIdx) {
   int __idx = CkRegisterChare(s, sizeof(GroupExt), TypeGroup);
   CkRegisterBase(__idx, CkIndex_IrrGroup::__idx);
-  CkRegisterGroupIrr(__idx, true); // isIrreducible?
 
   int epIdxCtor = CkRegisterEp(s, GroupExt::__GroupExt, CkMarshallMsg::__idx, __idx, 0+CK_EP_NOKEEP);
   CkRegisterDefaultCtor(__idx, epIdxCtor);
 
-  for (int i=0; i < numEntryMethods; i++)
-    int epidx = CkRegisterEp(s, GroupExt::__entryMethod,
-                             CkMarshallMsg::__idx, __idx, 0+CK_EP_NOKEEP);
+  for (int i=1; i < numEntryMethods; i++)
+    CkRegisterEp(s, GroupExt::__entryMethod, CkMarshallMsg::__idx, __idx, 0+CK_EP_NOKEEP);
 
   *chareIdx = __idx;
   *startEpIdx = epIdxCtor;
@@ -117,22 +117,18 @@ void CkRegisterGroupExt(const char *s, int numEntryMethods, int *chareIdx, int *
 
 void CkRegisterArrayMapExt(const char *s, int numEntryMethods, int *chareIdx, int *startEpIdx) {
   int __idx = CkRegisterChare(s, sizeof(ArrayMapExt), TypeGroup);
-  //CkRegisterChareInCharm(__idx);
   CkRegisterBase(__idx, CkIndex_IrrGroup::__idx);
-  CkRegisterGroupIrr(__idx, true); // isIrreducible?
 
   int epIdxCtor = CkRegisterEp(s, ArrayMapExt::__ArrayMapExt, CkMarshallMsg::__idx, __idx, 0+CK_EP_NOKEEP);
   CkRegisterDefaultCtor(__idx, epIdxCtor);
 
-  for (int i=0; i < numEntryMethods; i++)
-    int epidx = CkRegisterEp(s, ArrayMapExt::__entryMethod,
-                             CkMarshallMsg::__idx, __idx, 0+CK_EP_NOKEEP);
+  for (int i=1; i < numEntryMethods; i++)
+    CkRegisterEp(s, ArrayMapExt::__entryMethod, CkMarshallMsg::__idx, __idx, 0+CK_EP_NOKEEP);
 
   *chareIdx = __idx;
   *startEpIdx = epIdxCtor;
 }
 
-// TODO give a unique name to entry methods when calling CkRegisterEp
 void CkRegisterArrayExt(const char *s, int numEntryMethods, int *chareIdx, int *startEpIdx) {
   int __idx = CkRegisterChare(s, sizeof(ArrayElemExt), TypeArray);
   CkRegisterBase(__idx, CkIndex_ArrayElement::__idx);
@@ -143,10 +139,10 @@ void CkRegisterArrayExt(const char *s, int numEntryMethods, int *chareIdx, int *
   int epidx = CkRegisterEp(s, ArrayElemExt::__CkMigrateMessage, 0, __idx, 0);
   CkRegisterMigCtor(__idx, epidx);
 
-  epidx = CkRegisterEp(s, ArrayElemExt::__AtSyncEntryMethod, 0, __idx, 0);
-  for (int i=0; i < numEntryMethods; i++)
-    epidx = CkRegisterEp(s, ArrayElemExt::__entryMethod, CkMarshallMsg::__idx,
-                         __idx, 0+CK_EP_NOKEEP);
+  CkRegisterEp(s, ArrayElemExt::__AtSyncEntryMethod, 0, __idx, 0);
+
+  for (int i=3; i < numEntryMethods; i++)
+    CkRegisterEp(s, ArrayElemExt::__entryMethod, CkMarshallMsg::__idx, __idx, 0+CK_EP_NOKEEP);
 
   *chareIdx = __idx;
   *startEpIdx = epIdxCtor;
@@ -171,7 +167,7 @@ int CkRegisterMainChare(int chareIdx, int entryIdx)
 }
 
 #if CMK_CHARMPY
-// TODO give a unique name to entry methods when calling CkRegisterEp
+
 void CkRegisterMainChareExt(const char *s, int numEntryMethods, int *chareIdx, int *startEpIdx) {
   int __idx = CkRegisterChare(s, sizeof(MainchareExt), TypeMainChare);
   CkRegisterBase(__idx, CkIndex_Chare::__idx);
@@ -180,9 +176,8 @@ void CkRegisterMainChareExt(const char *s, int numEntryMethods, int *chareIdx, i
   CkRegisterMessagePupFn(epIdxCtor, (CkMessagePupFn)CkArgMsg::ckDebugPup);
   CkRegisterMainChare(__idx, epIdxCtor);
 
-  for (int i=0; i < numEntryMethods; i++)
-    int epidx = CkRegisterEp(s, MainchareExt::__entryMethod, CkMarshallMsg::__idx,
-                             __idx, 0+CK_EP_NOKEEP);
+  for (int i=1; i < numEntryMethods; i++)
+    CkRegisterEp(s, MainchareExt::__entryMethod, CkMarshallMsg::__idx, __idx, 0+CK_EP_NOKEEP);
 
   *chareIdx = __idx;
   *startEpIdx = epIdxCtor;


### PR DESCRIPTION
Minor bug fixes and cleanup.

This is all code inside `#if CMK_CHARMPY` blocks.
