### PR TITLE
Fix breakages in UTH from recent changes

### DIFF
--- a/src/arch/uth/machine.C
+++ b/src/arch/uth/machine.C
@@ -240,6 +240,28 @@ void CmiFreeBroadcastAllFn(int size, char *msg)
 #endif
 }
 
+void CmiWithinNodeBroadcastFn(int size, char* msg) {
+  int nodeFirst = CmiNodeFirst(CmiMyNode());
+  int nodeLast = nodeFirst + CmiNodeSize(CmiMyNode());
+  if (CMI_MSG_NOKEEP(msg)) {
+    for (int i = nodeFirst; i < CmiMyPe(); i++) {
+      CmiReference(msg);
+      CmiFreeSendFn(i, size, msg);
+    }
+    for (int i = CmiMyPe() + 1; i < nodeLast; i++) {
+      CmiReference(msg);
+      CmiFreeSendFn(i, size, msg);
+    }
+  } else {
+    for (int i = nodeFirst; i < CmiMyPe(); i++) {
+      CmiSyncSendFn(i, size, msg);
+    }
+    for (int i = CmiMyPe() + 1; i < nodeLast; i++) {
+      CmiSyncSendFn(i, size, msg);
+    }
+  }
+  CmiSyncSendAndFree(CmiMyPe(), size, msg);
+}
 
 int CmiBarrier(void)
 {

--- a/src/conv-core/converse.h
+++ b/src/conv-core/converse.h
@@ -1258,6 +1258,8 @@ void          CmiSyncBroadcastAllFn(int, char *);
 CmiCommHandle CmiAsyncBroadcastAllFn(int, char *);
 void          CmiFreeBroadcastAllFn(int, char *);
 
+void          CmiWithinNodeBroadcastFn(int, char*);
+
 void          CmiSyncListSendFn(int, const int *, int, char*);
 CmiCommHandle CmiAsyncListSendFn(int, const int *, int, char*);
 void          CmiFreeListSendFn(int, const int *, int, char*);
@@ -1385,8 +1387,6 @@ void          CmiFreeNodeBroadcastFn(int, char *);
 void          CmiSyncNodeBroadcastAllFn(int, char *);
 CmiCommHandle CmiAsyncNodeBroadcastAllFn(int, char *);
 void          CmiFreeNodeBroadcastAllFn(int, char *);
-
-void          CmiWithinNodeBroadcastFn(int, char*);
 
 /* if node queue is available, adding inter partition counterparts */
 void          CmiInterSyncNodeSendFn(int, int, int, char *);

--- a/tests/charm++/load_balancing/meta_lb_test/period_selection.C
+++ b/tests/charm++/load_balancing/meta_lb_test/period_selection.C
@@ -41,10 +41,15 @@ public:
     if (iteration < MAX_ITER) {
       arrayProxy.balance(iteration);
     } else {
-      if (CkNumPes() > 1 && migrations != 10) {
+      int expected_migrations = 10;
+      if (CkNumPes() == 1) {
+        expected_migrations = 0;
+      }
+#if CMK_UTH_VERSION
+      expected_migrations = 0;
+#endif
+      if (migrations != expected_migrations) {
         CkAbort("Did not do expected number of migrations!\n");
-      } else if (CkNumPes() == 1 && migrations > 0) {
-        CkAbort("Should not be any migration with one PE!\n");
       }
       CkExit();
     }


### PR DESCRIPTION
Within node broadcasts need to be defined for the UTH layer and the MetaLB test
must assume 0 migrations when running on UTH.