### PR TITLE
Charm4py: support sending same msg copy to multiple PEs in a Group

### DIFF
--- a/src/ck-core/charm.h
+++ b/src/ck-core/charm.h
@@ -405,9 +405,9 @@ extern void CkChareExtSend(int onPE, void *objPtr, int epIdx, char *msg, int msg
 extern void CkChareExtSend_multi(int onPE, void *objPtr, int epIdx, int num_bufs, char **bufs, int *buf_sizes);
 /// Send msg to group with ID 'gid'. if pe == -1, msg will be broadcasted, else
 /// it will go to the group instance in that PE
-extern void CkGroupExtSend(int gid, int pe, int epIdx, char *msg, int msgSize);
+extern void CkGroupExtSend(int gid, int npes, const int *pes, int epIdx, char *msg, int msgSize);
 /// Send msg to group copying data into CkMessage from multiple input buffers
-extern void CkGroupExtSend_multi(int gid, int pe, int epIdx, int num_bufs, char **bufs, int *buf_sizes);
+extern void CkGroupExtSend_multi(int gid, int npes, const int *pes, int epIdx, int num_bufs, char **bufs, int *buf_sizes);
 /// Send msg to array with ID 'aid'. idx is index of destination and ndims the number
 /// of dimensions of the index. If ndims <= 0, msg will be broadcasted to all array elements
 extern void CkArrayExtSend(int aid, int *idx, int ndims, int epIdx, char *msg, int msgSize);

--- a/src/ck-core/ckcallback.C
+++ b/src/ck-core/ckcallback.C
@@ -244,6 +244,7 @@ static void CkCallbackSendExt(const CkCallback &cb, void *msg)
     reducerType = redMsg->getReducer();
   }
 
+  int _pe = -1;
   switch (cb.type) {
     case CkCallback::sendChare: // Send message to a chare
       CreateCallbackMsgExt(data, dataLen, reducerType, cb.d.chare.refnum,
@@ -254,7 +255,7 @@ static void CkCallbackSendExt(const CkCallback &cb, void *msg)
     case CkCallback::sendGroup: // Send message to a group element
       CreateCallbackMsgExt(data, dataLen, reducerType, cb.d.group.refnum,
                                   extResultMsgData, extResultMsgDataSizes);
-      CkGroupExtSend_multi(cb.d.group.id.idx, cb.d.group.onPE, cb.d.group.ep,
+      CkGroupExtSend_multi(cb.d.group.id.idx, 1, &(cb.d.group.onPE), cb.d.group.ep,
                            2, extResultMsgData, extResultMsgDataSizes);
       break;
     case CkCallback::sendArray: // Send message to an array element
@@ -267,7 +268,7 @@ static void CkCallbackSendExt(const CkCallback &cb, void *msg)
       CreateCallbackMsgExt(data, dataLen, reducerType, cb.d.group.refnum,
                                   extResultMsgData, extResultMsgDataSizes);
       // onPE is set to -1 since its a bcast
-      CkGroupExtSend_multi(cb.d.group.id.idx, -1, cb.d.group.ep, 2, extResultMsgData, extResultMsgDataSizes);
+      CkGroupExtSend_multi(cb.d.group.id.idx, 1, &_pe, cb.d.group.ep, 2, extResultMsgData, extResultMsgDataSizes);
       break;
     case CkCallback::bcastArray:
       CreateCallbackMsgExt(data, dataLen, reducerType, cb.d.array.refnum,


### PR DESCRIPTION
This essentially exposes CkSendMsgBranchMulti to Charm4py, useful
for list sends, and sending the same msg to children in a spanning
tree.