### PR TITLE
Propagate main()'s return code in AMPI

### DIFF
--- a/src/libs/ck-libs/ampi/ampi.C
+++ b/src/libs/ck-libs/ampi/ampi.C
@@ -825,10 +825,14 @@ FLINKAGE void FTN_NAME(MPI_MAIN,mpi_main)(void);
 CLINKAGE
 void AMPI_Fallback_Main(int argc,char **argv)
 {
-  AMPI_Main_cpp();
-  AMPI_Main_cpp(argc,argv);
-  AMPI_Main_c(argc,argv);
-  FTN_NAME(MPI_MAIN,mpi_main)();
+  int ret = 0;
+  // Only one of the following four main functions actually runs application code,
+  // the others are stubs provided by compat_ampi*.
+  ret += AMPI_Main_cpp();
+  ret += AMPI_Main_cpp(argc,argv);
+  ret += AMPI_Main_c(argc,argv);
+  FTN_NAME(MPI_MAIN,mpi_main)(); // returns void
+  AMPI_Exit(ret);
 }
 
 void ampiCreateMain(MPI_MainFn mainFn, const char *name,int nameLen);

--- a/src/libs/ck-libs/ampi/ampi.h
+++ b/src/libs/ck-libs/ampi/ampi.h
@@ -85,7 +85,7 @@ extern "C" {
 #endif
 
 int AMPI_Main(); /* declaration for C main routine (not a strict prototype!) */
-void AMPI_Main_c(int argc,char **argv); /* C wrapper for calling AMPI_Main() from C++ */
+int AMPI_Main_c(int argc,char **argv); /* C wrapper for calling AMPI_Main() from C++ */
 
 typedef void (*MPI_MainFn) (int,char**);
 

--- a/src/libs/ck-libs/ampi/compat_ampi.c
+++ b/src/libs/ck-libs/ampi/compat_ampi.c
@@ -5,12 +5,12 @@
 #ifdef __cplusplus
 extern "C"
 #endif
-void AMPI_Main(int argc, char **argv);
+int AMPI_Main(int argc, char **argv);
 
 #ifdef __cplusplus
 extern "C"
 #endif
-void AMPI_Main_c(int argc, char **argv)
+int AMPI_Main_c(int argc, char **argv)
 {
-	AMPI_Main(argc, argv); /* call C main routine */
+	return AMPI_Main(argc, argv); /* call C main routine */
 }


### PR DESCRIPTION
AMPI renames the application’s `main` function to `AMPI_Main`.
The return value from `AMPI_Main` is ignored, i.e. the runtime always assumes a return code 0.

Workaround: change `return` to `exit()`.

We need to propagate the real return code throughout AMPI and TCharm.

~~Potential issue:
How to handle `AMPI_Main` without return? E.g. when defined as void main(...), or with implied return 0 at end.
This might then return a random value from the stack.~~

Edit: 
- `void main()` doesn't work with AMPI (even without this PR).
- implied return 0 does actually return 0, so seems to be fine.
