### PR TITLE
Charm4py: support new sections implementation

### DIFF
--- a/src/ck-core/charm++.h
+++ b/src/ck-core/charm++.h
@@ -1159,6 +1159,51 @@ public:
   }
 };
 
+class SectionManagerExt: public GroupExt {
+public:
+
+  SectionManagerExt(void *impl_msg) : GroupExt(impl_msg) {}
+
+  static void __SectionManagerExt(void *impl_msg, void *impl_obj_void) {
+    new (impl_obj_void) SectionManagerExt(impl_msg);
+  }
+
+  // entry methods of SectionManager other than sendToSection
+  static void __entryMethod(void *impl_msg, void *impl_obj_void) {
+    SectionManagerExt *obj = static_cast<SectionManagerExt *>(impl_obj_void);
+    CkMarshallMsg *impl_msg_typed = (CkMarshallMsg *)impl_msg;
+    char *impl_buf = impl_msg_typed->msgBuf;
+    PUP::fromMem implP(impl_buf);
+    int msgSize; implP|msgSize;
+    implP|obj->ep;
+    int dcopy_start; implP|dcopy_start;
+    GroupMsgRecvExtCallback(obj->thisgroup.idx, obj->ep, msgSize, impl_buf+(3*sizeof(int)),
+                            dcopy_start);
+  }
+
+  // sendToSection entry method
+  static void __sendToSection(void *impl_msg, void *impl_obj_void) {
+    SectionManagerExt *obj = static_cast<SectionManagerExt *>(impl_obj_void);
+    obj->msg = impl_msg; // store msg for forwarding to children in multicast spanning tree
+    SectionManagerExt::__entryMethod(impl_msg, impl_obj_void);
+    // if msg != null because I haven't forwarded it (I'm a leaf) delete it now
+    CkFreeMsg(obj->msg);
+  }
+
+  // Used by Charm4py SectionManager to forward a multicast msg to its children without copying.
+  // The msg was received by SectionManagerExt::__sendToSection. When forwardMulticastMsg is reached, we
+  // are still inside the GroupMsgRecvExtCallback call, so the msg has not been deleted yet
+  void forwardMulticastMsg(int num_children, const int *children) {
+    CkSendMsgBranchMulti(ep, msg, thisgroup, num_children, children);
+    // CkSendMsgBranchMulti deletes the msg, so mark it as null to not delete it again
+    msg = nullptr;
+  }
+
+private:
+  int ep;
+  void *msg;
+};
+
 #endif
 
 class CkQdMsg {

--- a/src/ck-core/charm.h
+++ b/src/ck-core/charm.h
@@ -139,7 +139,8 @@ extern void CkSetMigratable(int aid, int ndims, int *index, char migratable);
 extern void CkStartQDExt_ChareCallback(int onPE, void* objPtr, int epIdx, int fid);
 extern void CkStartQDExt_GroupCallback(int gid, int pe, int epIdx, int fid);
 extern void CkStartQDExt_ArrayCallback(int aid, int* idx, int ndims, int epIdx, int fid);
-extern void registerCreateCallbackMsgExtCallback(void (*cb)(void*, int, int, int, char**, int*));
+extern void CkStartQDExt_SectionCallback(int sid_pe, int sid_cnt, int rootPE, int ep);
+extern void registerCreateCallbackMsgExtCallback(void (*cb)(void*, int, int, int, int *, char**, int*));
 extern void registerPyReductionExtCallback(int (*cb)(char**, int*, int, char**));
 
 #endif
@@ -211,6 +212,7 @@ extern void CkRegisterBase(int derivedIdx, int baseIdx);
 #if CMK_CHARMPY
 extern void CkRegisterMainChareExt(const char *s, int numEntryMethods, int *chareIdx, int *startEpIdx);
 extern void CkRegisterGroupExt(const char *s, int numEntryMethods, int *chareIdx, int *startEpIdx);
+extern void CkRegisterSectionManagerExt(const char *s, int numEntryMethods, int *chareIdx, int *startEpIdx);
 extern void CkRegisterArrayMapExt(const char *s, int numEntryMethods, int *chareIdx, int *startEpIdx);
 extern void CkRegisterArrayExt(const char *s, int numEntryMethods, int *chareIdx, int *startEpIdx);
 extern void CkRegisterReadonlyExt(const char *name, const char *type, size_t msgSize, char *msg);
@@ -408,6 +410,7 @@ extern void CkChareExtSend_multi(int onPE, void *objPtr, int epIdx, int num_bufs
 extern void CkGroupExtSend(int gid, int npes, const int *pes, int epIdx, char *msg, int msgSize);
 /// Send msg to group copying data into CkMessage from multiple input buffers
 extern void CkGroupExtSend_multi(int gid, int npes, const int *pes, int epIdx, int num_bufs, char **bufs, int *buf_sizes);
+extern void CkForwardMulticastMsg(int gid, int num_children, const int *children);
 /// Send msg to array with ID 'aid'. idx is index of destination and ndims the number
 /// of dimensions of the index. If ndims <= 0, msg will be broadcasted to all array elements
 extern void CkArrayExtSend(int aid, int *idx, int ndims, int epIdx, char *msg, int msgSize);

--- a/src/ck-core/ckcallback.C
+++ b/src/ck-core/ckcallback.C
@@ -178,6 +178,7 @@ CkCallback::CkCallback(int ep,const CProxyElement_ArrayBase &arrElt,bool forceIn
         d.array.refnum = 0;
 }
 
+#if !CMK_CHARMPY
 CkCallback::CkCallback(int ep,CProxySection_ArrayBase &sectElt,bool forceInline) {
 #if CMK_ERROR_CHECKING
       memset(this, 0, sizeof(CkCallback));
@@ -208,6 +209,7 @@ CkCallback::CkCallback(int ep, CkSectionID &id) {
       d.section.hasRefnum = false;
       d.section.refnum = 0;
 }
+#endif
 
 CkCallback::CkCallback(ArrayElement *p, int ep,bool forceInline) {
 #if CMK_ERROR_CHECKING
@@ -227,7 +229,7 @@ CkCallback::CkCallback(ArrayElement *p, int ep,bool forceInline) {
 // to guarantee best performance for non-charm4py applications
 
 // function pointer to interact with Charm4py to generate callback msg
-extern void (*CreateCallbackMsgExt)(void*, int, int, int, char**, int*);
+extern void (*CreateCallbackMsgExt)(void*, int, int, int, int *, char**, int*);
 
 static void CkCallbackSendExt(const CkCallback &cb, void *msg)
 {
@@ -245,37 +247,51 @@ static void CkCallbackSendExt(const CkCallback &cb, void *msg)
   }
 
   int _pe = -1;
+  int sectionInfo[3] = {-1, 0, 0};
   switch (cb.type) {
     case CkCallback::sendChare: // Send message to a chare
-      CreateCallbackMsgExt(data, dataLen, reducerType, cb.d.chare.refnum,
+      CreateCallbackMsgExt(data, dataLen, reducerType, cb.d.chare.refnum, sectionInfo,
                                   extResultMsgData, extResultMsgDataSizes);
       CkChareExtSend_multi(cb.d.chare.id.onPE, cb.d.chare.id.objPtr, cb.d.chare.ep,
                            2, extResultMsgData, extResultMsgDataSizes);
       break;
     case CkCallback::sendGroup: // Send message to a group element
-      CreateCallbackMsgExt(data, dataLen, reducerType, cb.d.group.refnum,
+      CreateCallbackMsgExt(data, dataLen, reducerType, cb.d.group.refnum, sectionInfo,
                                   extResultMsgData, extResultMsgDataSizes);
       CkGroupExtSend_multi(cb.d.group.id.idx, 1, &(cb.d.group.onPE), cb.d.group.ep,
                            2, extResultMsgData, extResultMsgDataSizes);
       break;
     case CkCallback::sendArray: // Send message to an array element
-      CreateCallbackMsgExt(data, dataLen, reducerType, cb.d.array.refnum,
+      CreateCallbackMsgExt(data, dataLen, reducerType, cb.d.array.refnum, sectionInfo,
                                   extResultMsgData, extResultMsgDataSizes);
       CkArrayExtSend_multi(cb.d.array.id.idx, cb.d.array.idx.asChild().data(), cb.d.array.idx.dimension,
                            cb.d.array.ep, 2, extResultMsgData, extResultMsgDataSizes);
       break;
     case CkCallback::bcastGroup:
-      CreateCallbackMsgExt(data, dataLen, reducerType, cb.d.group.refnum,
+      CreateCallbackMsgExt(data, dataLen, reducerType, cb.d.group.refnum, sectionInfo,
                                   extResultMsgData, extResultMsgDataSizes);
       // onPE is set to -1 since its a bcast
       CkGroupExtSend_multi(cb.d.group.id.idx, 1, &_pe, cb.d.group.ep, 2, extResultMsgData, extResultMsgDataSizes);
       break;
     case CkCallback::bcastArray:
-      CreateCallbackMsgExt(data, dataLen, reducerType, cb.d.array.refnum,
+      CreateCallbackMsgExt(data, dataLen, reducerType, cb.d.array.refnum, sectionInfo,
                                   extResultMsgData, extResultMsgDataSizes);
       // numDimensions is set to 0 since its bcast
       CkArrayExtSend_multi(cb.d.array.id.idx, cb.d.array.idx.asChild().data(), 0,
                            cb.d.array.ep, 2, extResultMsgData, extResultMsgDataSizes);
+      break;
+    case CkCallback::bcastSection: // Send message to a section
+      sectionInfo[0] = cb.d.section.sid_pe;
+      sectionInfo[1] = cb.d.section.sid_cnt;
+      sectionInfo[2] = cb.d.section.ep;
+      CreateCallbackMsgExt(data, dataLen, reducerType, 0, sectionInfo,
+                           extResultMsgData, extResultMsgDataSizes);
+      // after CreateCallbackMsgExt:
+      // sectionInfo[0] contains SectionManager gid
+      // sectionInfo[1] contains SectionManager ep (for sending section broadcasts)
+      // send to SectionManager on root PE
+      CkGroupExtSend_multi(sectionInfo[0], 1, &(cb.d.section.rootPE), sectionInfo[1],
+                           2, extResultMsgData, extResultMsgDataSizes);
       break;
     default:
       CkAbort("Unsupported callback for ext reduction, or corrupted callback");
@@ -401,6 +417,7 @@ void CkCallback::send(void *msg) const
                 if (d.array.hasRefnum) CkSetRefNum(msg, d.array.refnum);
 		CkBroadcastMsgArray(d.array.ep, msg, d.array.id);
 		break;
+#if !CMK_CHARMPY
 	case bcastSection: {
 		if(!msg)msg=CkAllocSysMsg();
                 if (d.section.hasRefnum) CkSetRefNum(msg, d.section.refnum);
@@ -409,6 +426,7 @@ void CkCallback::send(void *msg) const
 		CkBroadcastMsgSection(d.section.ep, msg, secID);
 		break;
              }
+#endif
 	case replyCCS: { /* Send CkDataMsg as a CCS reply */
 		void *data=NULL;
 		int length=0;
@@ -507,13 +525,18 @@ bool CkCallback::containsPointer() const {
   case bcastGroup:
   case bcastNodeGroup:
   case bcastArray:
+#if CMK_CHARMPY
+  case bcastSection:
+#endif
     return false;
 
   case resumeThread:
   case callCFn:
   case call1Fn:
   case replyCCS:
+#if !CMK_CHARMPY
   case bcastSection:
+#endif
     return true;
 
   case sendChare:

--- a/src/ck-core/ckcallback.h
+++ b/src/ck-core/ckcallback.h
@@ -117,6 +117,14 @@ private:
 		CMK_REFNUM_TYPE refnum; // Reference number to set on the message
 		bool hasRefnum;
 	} array;
+#if CMK_CHARMPY
+	struct s_section {
+		int sid_pe; // section ID
+		int sid_cnt; // section ID
+		int rootPE; // PE where the root of the section's multicast tree is located
+		int ep; // Entry point to call in section elements
+	} section;
+#else
 	struct s_section {
                 CkArrayIndex *_elems;
                 int *pelist;
@@ -127,6 +135,7 @@ private:
 		CMK_REFNUM_TYPE refnum; // Reference number to set on the message
 		bool hasRefnum;
 	} section;
+#endif
 
 	struct s_ccsReply {
 		CcsDelayedReply reply;
@@ -192,6 +201,12 @@ public:
 		  d.cfn.onPE == other.d.cfn.onPE &&
 		  d.cfn.param == other.d.cfn.param);
 	    case bcastSection:
+#if CMK_CHARMPY
+	      return (d.section.sid_pe == other.d.section.sid_pe &&
+		d.section.sid_cnt == other.d.section.sid_cnt &&
+		d.section.rootPE == other.d.section.rootPE &&
+		d.section.ep == other.d.section.ep);
+#else
 	      return (d.section._elems == other.d.section._elems &&
 		d.section.pelist && other.d.section.pelist &&
 		d.section.sinfo == other.d.section.sinfo &&
@@ -200,6 +215,7 @@ public:
 		d.section.ep == other.d.section.ep &&
 		((d.section.hasRefnum && other.d.section.hasRefnum) &&
 		 (d.section.refnum == other.d.section.refnum)));
+#endif
 	    case ignore:
 	    case ckExit:
 	    case invalid:
@@ -317,9 +333,11 @@ public:
     // Bcast to array
 	CkCallback(int ep,const CProxyElement_ArrayBase &arrElt,bool forceInline=false);
 	
+#if !CMK_CHARMPY
 	//Bcast to section
 	CkCallback(int ep,CProxySection_ArrayBase &sectElt,bool forceInline=false);
 	CkCallback(int ep, CkSectionID &sid);
+#endif
 	
 	// Send to chare
 	CkCallback(Chare *p, int ep, bool forceInline=false);
@@ -343,7 +361,7 @@ public:
 
 #if CMK_CHARMPY
 
-  CkCallback(int onPE, void* objPtr, int ep, int fid) {
+  CkCallback(int onPE, void* objPtr, int ep, CMK_REFNUM_TYPE fid) {
     CkChareID id;
     id.onPE = onPE;
     id.objPtr = objPtr;
@@ -355,7 +373,7 @@ public:
     isExtCallback = true;
   }
 
-  CkCallback(int gid, int pe, int ep, int fid) {
+  CkCallback(int gid, int pe, int ep, CMK_REFNUM_TYPE fid) {
     CkGroupID id;
     id.idx = gid;
     if (pe == -1) {
@@ -371,7 +389,7 @@ public:
     isExtCallback = true;
   }
 
-  CkCallback(int aid, int* idx, int ndims, int ep, int fid) {
+  CkCallback(int aid, int* idx, int ndims, int ep, CMK_REFNUM_TYPE fid) {
     CkGroupID id;
     id.idx = aid;
     if (ndims > 0) {
@@ -384,6 +402,15 @@ public:
     d.array.id = CkArrayID(id);
     d.array.hasRefnum = (fid > 0);
     d.array.refnum = fid;
+    isExtCallback = true;
+  }
+
+  CkCallback(int sid_pe, int sid_cnt, int rootPE, int ep) {
+    type = bcastSection;
+    d.section.sid_pe = sid_pe;
+    d.section.sid_cnt = sid_cnt;
+    d.section.rootPE = rootPE;
+    d.section.ep = ep;
     isExtCallback = true;
   }
 
@@ -461,10 +488,12 @@ public:
                   d.array.refnum = refnum;
                   break;
 
+#if !CMK_CHARMPY
                 case bcastSection:
                   d.section.hasRefnum = true;
                   d.section.refnum = refnum;
                   break;
+#endif
 
                 default:
                   CkAbort("Tried to set a refnum on a callback not directed at an entry method");

--- a/src/ck-core/ckreduction.C
+++ b/src/ck-core/ckreduction.C
@@ -1933,6 +1933,7 @@ extern "C" {
 void CkExtContributeToChare(CkExtContributeInfo* contribute_params, int onPE, void* objPtr);
 void CkExtContributeToArray(CkExtContributeInfo* contribute_params, int aid, int* idx, int ndims);
 void CkExtContributeToGroup(CkExtContributeInfo* contribute_params, int gid, int pe);
+void CkExtContributeToSection(CkExtContributeInfo* contribute_params, int sid_pe, int sid_cnt, int rootPE);
 }
 
 // Generic function to extract CkExtContributeInfo and perform reduction
@@ -1952,10 +1953,10 @@ void CkExtContribute(CkExtContributeInfo* contribute_params, CkCallback& cb)
 void CkExtContributeTo(CkExtContributeInfo* contribute_params, CkCallback& cb)
 {
     switch (contribute_params->contributorType) {
-        case extContributorType::array :
+        case extContributorType::array:
             CkExtContribute<ArrayElement>(contribute_params, cb);
             break;
-        case extContributorType::group :
+        case extContributorType::group:
             CkExtContribute<Group>(contribute_params, cb);
             break;
         default : CkAbort("Invalid external contributor type!\n");
@@ -1965,21 +1966,27 @@ void CkExtContributeTo(CkExtContributeInfo* contribute_params, CkCallback& cb)
 // When a reduction contributes to a singleton chare
 void CkExtContributeToChare(CkExtContributeInfo* contribute_params, int onPE, void* objPtr)
 {
-    CkCallback cb(onPE, objPtr, contribute_params->cbEpIdx, contribute_params->fid);
+    CkCallback cb(onPE, objPtr, contribute_params->cbEpIdx, (CMK_REFNUM_TYPE)contribute_params->fid);
     CkExtContributeTo(contribute_params, cb);
 }
 
 // When a reduction contributes to an array element or broadcasts result to an array
 void CkExtContributeToArray(CkExtContributeInfo* contribute_params, int aid, int* idx, int ndims)
 {
-    CkCallback cb(aid, idx, ndims, contribute_params->cbEpIdx, contribute_params->fid);
+    CkCallback cb(aid, idx, ndims, contribute_params->cbEpIdx, (CMK_REFNUM_TYPE)contribute_params->fid);
     CkExtContributeTo(contribute_params, cb);
 }
 
 // When a reduction contributes to a group chare element or broadcasts result to group
 void CkExtContributeToGroup(CkExtContributeInfo* contribute_params, int gid, int pe)
 {
-    CkCallback cb(gid, pe, contribute_params->cbEpIdx, contribute_params->fid);
+    CkCallback cb(gid, pe, contribute_params->cbEpIdx, (CMK_REFNUM_TYPE)contribute_params->fid);
+    CkExtContributeTo(contribute_params, cb);
+}
+
+void CkExtContributeToSection(CkExtContributeInfo* contribute_params, int sid_pe, int sid_cnt, int rootPE)
+{
+    CkCallback cb(sid_pe, sid_cnt, rootPE, contribute_params->cbEpIdx);
     CkExtContributeTo(contribute_params, cb);
 }
 

--- a/src/ck-core/register.C
+++ b/src/ck-core/register.C
@@ -115,6 +115,22 @@ void CkRegisterGroupExt(const char *s, int numEntryMethods, int *chareIdx, int *
   *startEpIdx = epIdxCtor;
 }
 
+void CkRegisterSectionManagerExt(const char *s, int numEntryMethods, int *chareIdx, int *startEpIdx) {
+  int __idx = CkRegisterChare(s, sizeof(SectionManagerExt), TypeGroup);
+  CkRegisterBase(__idx, CkIndex_IrrGroup::__idx);
+
+  int epIdxCtor = CkRegisterEp(s, SectionManagerExt::__SectionManagerExt, CkMarshallMsg::__idx, __idx, 0+CK_EP_NOKEEP);
+  CkRegisterDefaultCtor(__idx, epIdxCtor);
+
+  CkRegisterEp(s, SectionManagerExt::__sendToSection, CkMarshallMsg::__idx, __idx, 0);
+
+  for (int i=2; i < numEntryMethods; i++)
+    CkRegisterEp(s, SectionManagerExt::__entryMethod, CkMarshallMsg::__idx, __idx, 0+CK_EP_NOKEEP);
+
+  *chareIdx = __idx;
+  *startEpIdx = epIdxCtor;
+}
+
 void CkRegisterArrayMapExt(const char *s, int numEntryMethods, int *chareIdx, int *startEpIdx) {
   int __idx = CkRegisterChare(s, sizeof(ArrayMapExt), TypeGroup);
   CkRegisterBase(__idx, CkIndex_IrrGroup::__idx);


### PR DESCRIPTION
This adds support for a new sections implementation in Charm4py,
which I have tested internally, but would like other users to try
it. It doesn't interfere with existing functionality.

This removes Charm++ sections-related code from ckcallback when
building with CMK_CHARMPY. The rest of the changes only affect
CMK_CHARMPY code.