### PR TITLE
Fix MetaLB test so that it starts balanced

### DIFF
--- a/tests/charm++/load_balancing/meta_lb_test/Makefile
+++ b/tests/charm++/load_balancing/meta_lb_test/Makefile
@@ -10,12 +10,12 @@ period_selection.decl.h: period_selection.ci
 	$(CHARMC) period_selection.ci
 
 test: period_selection
-	$(call run, +p1 ./period_selection +balancer RotateLB +LBPeriod 0.001 +MetaLB)
-	$(call run, +p2 ./period_selection +balancer RotateLB +LBPeriod 0.001 +MetaLB)
-	$(call run, +p4 ./period_selection +balancer RotateLB +LBPeriod 0.001 +MetaLB)
+	$(call run, +p1 ./period_selection +balancer RotateLB +LBPeriod 0.001 +MetaLB +LBObjOnly)
+	$(call run, +p2 ./period_selection +balancer RotateLB +LBPeriod 0.001 +MetaLB +LBObjOnly)
+	$(call run, +p4 ./period_selection +balancer RotateLB +LBPeriod 0.001 +MetaLB +LBObjOnly)
 ifeq ($(CMK_SMP),1)
-	$(call run, +p2 ./period_selection +balancer RotateLB +LBPeriod 0.001 +MetaLB ++ppn 2)
-	$(call run, +p4 ./period_selection +balancer RotateLB +LBPeriod 0.001 +MetaLB ++ppn 2)
+	$(call run, +p2 ./period_selection +balancer RotateLB +LBPeriod 0.001 +MetaLB +LBObjOnly ++ppn 2)
+	$(call run, +p4 ./period_selection +balancer RotateLB +LBPeriod 0.001 +MetaLB +LBOnjOnly ++ppn 2)
 endif
 
 clean:

--- a/tests/charm++/load_balancing/meta_lb_test/period_selection.C
+++ b/tests/charm++/load_balancing/meta_lb_test/period_selection.C
@@ -47,6 +47,9 @@ public:
       arrayProxy.balance(iteration);
     } else {
       int expected_migrations = MAX_ITER / ITER_MOD;
+      if (MAX_ITER % ITER_MOD == 0) {
+        expected_migrations--;
+      }
       if (CkNumPes() == 1) {
         expected_migrations = 0;
       }
@@ -79,7 +82,7 @@ public:
   void balance(int iteration) {
     // Cause artificial imbalance every ITER_MOD iterations
     // This should trigger MetaBalancer to run the balancer
-    if (iteration % ITER_MOD == 0) {
+    if (iteration && iteration % ITER_MOD == 0) {
       load = CkMyPe();
     }
     AtSync();


### PR DESCRIPTION
MetaLB makes a vague assumption about load starting balanced and uses that in
its decision process. This probably shouldn't be the case, but for now the test
starting imbalanced can cause issues.