### PR TITLE
Change PICS configuration method to use PICS_configure

### DIFF
--- a/examples/charm++/PICS/ping/ping.C
+++ b/examples/charm++/PICS/ping/ping.C
@@ -60,7 +60,10 @@ public:
 
   void prepare() {
     char *names[] = {"PING"};
-    PICS_setNumOfPhases(true, 1, names);
+    PicsConfig pc;
+    pc.numPhases = 1;
+    pc.phaseNames = names;
+    PICS_configure(pc, CkCallbackResumeThread());
     //PICS_registerTunableParameterFields("PIPELINE_NUM", TP_INT, dv, minv, maxv, 1, PICS_EFF_GRAINSIZE, -1, OP_ADD, TS_SIMPLE, 1);
     thisProxy.run();
   }

--- a/src/ck-pics/picsautoperf.C
+++ b/src/ck-pics/picsautoperf.C
@@ -331,7 +331,7 @@ void TraceAutoPerfBOC::registerPerfGoal(int goalIndex) {
 
 void TraceAutoPerfBOC::setUserDefinedGoal(double value) { }
 
-void TraceAutoPerfBOC::setNumOfPhases(int num, const char names[]) {
+void TraceAutoPerfBOC::setNumOfPhases(int num, const char names[], CkCallback cb) {
   CkpvAccess(numOfPhases) = num;
   CkpvAccess(phaseNames).clear();
   CkpvAccess(phaseNames).resize(num);
@@ -341,6 +341,7 @@ void TraceAutoPerfBOC::setNumOfPhases(int num, const char names[]) {
     strcpy(name, names + i*40);
     CkpvAccess(phaseNames)[i] = name;
   }
+  contribute(0, NULL, CkReduction::nop, cb);
 }
 
 // set the call back function, which is invoked after auto perf is done
@@ -659,7 +660,6 @@ TraceAutoPerfBOC::TraceAutoPerfBOC() {
 
   if((isPeriodicalAnalysis))
   {
-    setNumOfPhases(1, "Default");
     startStep();
     startPhase(0);
     if(CkMyPe() == 0)
@@ -719,7 +719,6 @@ TraceAutoPerfInit::TraceAutoPerfInit(CkArgMsg* args)
   /* Starts a new phase without user call */
   autoPerfProxy.startStep();
   autoPerfProxy.startPhase(0);
-  autoPerfProxy.setNumOfPhases(1, "program");
 }
 
 extern "C" void traceAutoPerfExitFunction() {

--- a/src/ck-pics/picsautoperf.ci
+++ b/src/ck-pics/picsautoperf.ci
@@ -25,7 +25,7 @@ module TraceAutoPerf {
     entry void registerPerfGoal(int goalIndex);
     entry void setAutoPerfDoneCallback(CkCallback cb);
     entry void setUserDefinedGoal(double value);
-    entry void setNumOfPhases(int num, char names[num*40]);
+    entry void setNumOfPhases(int num, char names[num*40], CkCallback cb);
     entry [expedited,inline] void startStep();
     entry [expedited,inline] void endStep(bool fromGlobal, int pe, int incSteps);
     entry [expedited,inline] void endPhaseAndStep(bool fromGlobal, int pe);

--- a/src/ck-pics/picsautoperf.h
+++ b/src/ck-pics/picsautoperf.h
@@ -243,7 +243,7 @@ public:
   void PICS_markLDBStart(int appStep) ;
   void PICS_markLDBEnd() ;
 
-  void setNumOfPhases(int num, const char names[]);
+  void setNumOfPhases(int num, const char names[], CkCallback cb);
   void setProjectionsOutput();
   void recvGlobalSummary(CkReductionMsg *msg);
 

--- a/src/ck-pics/picsautoperfAPI.C
+++ b/src/ck-pics/picsautoperfAPI.C
@@ -20,18 +20,6 @@ void PICS_registerAutoPerfDone(CkCallback cb, int frameworkShouldAdvancePhase){
   autoPerfProxy.setAutoPerfDoneCallback(cb);
 }
 
-void PICS_setNumOfPhases(bool fromGlobal, int num, char *names[]) {
-  std::vector<char> seqNames(num*40);
-  for(int i=0; i<num; i++)
-  {
-    strcpy(&seqNames[0]+i*40, names[i]);
-  }
-  if(fromGlobal)
-    autoPerfProxy.setNumOfPhases(num, &seqNames[0]);
-  else
-    autoPerfProxy.ckLocalBranch()->setNumOfPhases(num, &seqNames[0]);
-}
-
 void PICS_startPhase( bool fromGlobal, int phaseId)
 {
   if(fromGlobal)
@@ -143,14 +131,6 @@ void setUserDefinedGoal(double value)
   autoPerfProxy.setUserDefinedGoal(value);
 }
 
-void PICS_setCollectionMode(int m) {
-   setCollectionMode(m); 
-}
-
-void PICS_setEvaluationMode(int m) {
-  setEvaluationMode(m);
-}
-
 void PICS_markLDBStart(int appStep) {
   autoPerfProxy.PICS_markLDBStart(appStep);
 }
@@ -159,11 +139,30 @@ void PICS_markLDBEnd(){
   autoPerfProxy.PICS_markLDBEnd();
 }
 
-void PICS_setWarmUpSteps(int steps){
-  WARMUP_STEP = steps;
-}
+void PICS_configure(PicsConfig config, CkCallback cb) {
+  if (config.warmupSteps != PICS_INVALID)
+    WARMUP_STEP = config.warmupSteps;
+  if (config.pauseSteps != PICS_INVALID)
+    PAUSE_STEP = config.pauseSteps;
+  if (config.collectionMode != PICS_INVALID)
+    setCollectionMode(config.collectionMode);
+  if (config.evaluationMode != PICS_INVALID)
+    setEvaluationMode(config.evaluationMode);
 
-
-void PICS_setPauseSteps(int steps){
-  PAUSE_STEP = steps;
+  if (config.numPhases != PICS_INVALID) {
+    std::vector<char> seqNames(config.numPhases*40);
+    for(int i = 0; i < config.numPhases; i++) {
+      strcpy(&seqNames[0]+i*40, config.phaseNames[i]);
+    }
+    if(config.fromGlobal)
+      autoPerfProxy.setNumOfPhases(config.numPhases, &seqNames[0], cb);
+    else
+      autoPerfProxy.ckLocalBranch()->setNumOfPhases(config.numPhases, &seqNames[0], cb);
+  } else {
+    char name[40] = "default";
+    if(config.fromGlobal)
+      autoPerfProxy.setNumOfPhases(1, &name[0], cb);
+    else
+      autoPerfProxy.ckLocalBranch()->setNumOfPhases(1, &name[0], cb);
+  }
 }

--- a/src/ck-pics/picsautoperfAPI.h
+++ b/src/ck-pics/picsautoperfAPI.h
@@ -7,8 +7,26 @@
     extern "C" {
 #endif
 
+struct PicsConfig {
+  bool fromGlobal;
+  int numPhases;
+  int collectionMode;
+  int evaluationMode;
+  int warmupSteps;
+  int pauseSteps;
+  char **phaseNames;
+  PicsConfig() {
+    fromGlobal = true;
+    numPhases = PICS_INVALID;
+    collectionMode = PICS_INVALID;
+    evaluationMode = PICS_INVALID;
+    warmupSteps = PICS_INVALID;
+    pauseSteps = PICS_INVALID;
+    phaseNames = nullptr;
+  }
+};
+
 void PICS_registerAutoPerfDone(CkCallback cb, int frameworkShouldAdvancePhase);
-void PICS_setNumOfPhases(bool fromGlobal, int num, char *names[]);
 
 void PICS_startStep(bool fromGlobal);
 void PICS_endStep(bool fromGlobal);
@@ -24,17 +42,11 @@ void PICS_autoPerfRunResumeCb(CkCallback cb);
 
 void PICS_SetAutoTimer();
 
-void PICS_setCollectionMode(int m) ;
-
-void PICS_setEvaluationMode(int m) ;
-
 void PICS_markLDBStart(int appStep);
 
 void PICS_markLDBEnd();
 
-void PICS_setWarmUpSteps(int steps);
-
-void PICS_setPauseSteps(int steps);
+void PICS_configure(PicsConfig config, CkCallback cb);
 
 #ifdef __cplusplus 
     }

--- a/src/ck-pics/picsdefs.h
+++ b/src/ck-pics/picsdefs.h
@@ -122,6 +122,7 @@ typedef enum Direction_t    Direction;
 #define PARALLEL  11
 #define SINGLE 20
 #define MULTIPLE 21
+#define PICS_INVALID -1
 
 #define   PERIOD_PERF 1
 


### PR DESCRIPTION
Previously, each PICS setting had its own function. However, this led to synchronization issues
due to the step starting before all the configuration was done. This change adds a centralized
PICS_configure function which takes in a struct PicsConfig which contains all the required
settings, and a callback which will be called once the configuration is done.