### PR TITLE
 Fix incorrect AtSync barrier check

### DIFF
--- a/src/ck-ldb/LBDBManager.C
+++ b/src/ck-ldb/LBDBManager.C
@@ -623,7 +623,6 @@ void LocalBarrier::CheckBarrier()
   if (!on) return;
 
   // If there are no clients, resume as soon as we're turned on
-
   if (client_count == 0) {
     cur_refcount++;
     CallReceivers();


### PR DESCRIPTION
This is a bug in LB, which had been incorrectly discussed in core in the past. This fix should make its way to the new LB framework as well.