### PR TITLE
BigSim: workaround AMPI zero copy API issue in MPI_Issend

### DIFF
--- a/tests/ampi/megampi/Makefile
+++ b/tests/ampi/megampi/Makefile
@@ -1,7 +1,7 @@
 -include ../../common.mk
 CHARMC=../../../bin/ampicxx $(OPTS)
 
-all: pgm
+all: pgm bg_pgm
 
 pgm: test.o
 	$(CHARMC) -o pgm test.o -balancer RandCentLB
@@ -9,12 +9,18 @@ pgm: test.o
 test.o: test.C
 	$(CHARMC) -c test.C
 
+bg_pgm: bg_test.o
+	$(CHARMC) -o bg_pgm bg_test.o -balancer RandCentLB
+
+bg_test.o: test.C
+	$(CHARMC) -DBIGSIM_TEST=1 -o bg_test.o -c test.C
+
 #
 #
 # clean up .o, .mod, .exe and EMACS backup files
 #
 clean:
-	rm -f *.o *.mod pgm *~ conv-host charmrun test.o pgm.exe pgm.pdb pgm.ilk ampirun
+	rm -f *.o *.mod pgm bg_* *~ conv-host charmrun test.o pgm.exe pgm.pdb pgm.ilk ampirun
 
 test: pgm
 	$(call run, ./pgm +p1 +vp1 )
@@ -24,10 +30,10 @@ test: pgm
 	$(call run, ./pgm +p2 +vp4 )
 	$(call run, ./pgm +p2 +vp1 )
 
-bgtest: pgm
-	$(call run, ./pgm +p1 +vp1 +x1 +y1 +z1 )
-	$(call run, ./pgm +p1 +vp2 +x1 +y1 +z1 )
-	$(call run, ./pgm +p1 +vp4 +x1 +y1 +z1 )
-	$(call run, ./pgm +p2 +vp2 +x2 +y1 +z1 )
-	$(call run, ./pgm +p2 +vp4 +x2 +y1 +z1 )
-	$(call run, ./pgm +p2 +vp1 +x2 +y1 +z1 )
+bgtest: bg_pgm
+	$(call run, ./bg_pgm +p1 +vp1 +x1 +y1 +z1 )
+	$(call run, ./bg_pgm +p1 +vp2 +x1 +y1 +z1 )
+	$(call run, ./bg_pgm +p1 +vp4 +x1 +y1 +z1 )
+	$(call run, ./bg_pgm +p2 +vp2 +x2 +y1 +z1 )
+	$(call run, ./bg_pgm +p2 +vp4 +x2 +y1 +z1 )
+	$(call run, ./bg_pgm +p2 +vp1 +x2 +y1 +z1 )

--- a/tests/ampi/megampi/test.C
+++ b/tests/ampi/megampi/test.C
@@ -139,6 +139,9 @@ void MPI_Tester::test(void)
 	int prev=(rank-1+size)%size;
 	int tag=12387, recvVal=-1;
 
+	// There is a known issue with using the Zero Copy API with BigSim.
+	// AMPI implements MPI_(I)Ssend's and large messages using the Zero
+	// Copy API, so we avoid testing those paths when using BigSim.
 #if !BIGSIM_TEST
 	// Forward around ring:
 	MPI_Isend(&rank,1,MPI_INT,next,tag,comm,&req);

--- a/tests/ampi/megampi/test.C
+++ b/tests/ampi/megampi/test.C
@@ -138,12 +138,13 @@ void MPI_Tester::test(void)
 	int next=(rank+1)%size;
 	int prev=(rank-1+size)%size;
 	int tag=12387, recvVal=-1;
-	
+
+#if !BIGSIM_TEST
 	// Forward around ring:
 	MPI_Isend(&rank,1,MPI_INT,next,tag,comm,&req);
 	testEqual(recv(prev,tag),prev,"Received rank (using prev as source)");
 	MPI_Wait(&req, MPI_STATUS_IGNORE);
-	
+
 	// Forward around ring:
         if (size >= 2) {
 	  if (rank == 0) {
@@ -153,7 +154,7 @@ void MPI_Tester::test(void)
 	  else if (rank == 1)
 	    testEqual(recv(prev,tag),prev,"Received rank (using prev as source)");
 	}
-
+#endif
 	// Simultaneous forward and backward (large messages):
 	const int msgSize = 32768;
 	MPI_Request sendReq[2], recvReq[2];


### PR DESCRIPTION
After merging the changes to AMPI to use the zero copy direct API
for all MPI_(I)Ssend's and for all large messages, we saw aborts
in the bgtest target for tests/ampi/megampi/ from BgMyRank being
called by the RTS on the scheduler thread inside CmiIssueRput().
This commit disables the tests for MPI_Issend when testing BigSim.