### PR TITLE
ZC API: Allow users to pass switch +noCMAForZC to not use CMA for ZC

### DIFF
--- a/benchmarks/charm++/zerocopy/bcastPingAll/Makefile
+++ b/benchmarks/charm++/zerocopy/bcastPingAll/Makefile
@@ -18,10 +18,12 @@ ping_all.o: ping_all.C cifiles
 test: all
 	$(call run, +p1 ./ping_all 1024 8192 2 1 1)
 	$(call run, +p2 ./ping_all 1024 8192 2 1 1)
+	$(call run, +p2 ./ping_all 1024 8192 2 1 1 +noCMAForZC)
 
 test-bench: all
 	$(call run, ./ping_all +p1)
 	$(call run, ./ping_all +p2)
+	$(call run, ./ping_all +p2 +noCMAForZC)
 
 clean:
 	rm -f *.decl.h *.def.h conv-host *.o ping_all charmrun cifiles

--- a/benchmarks/charm++/zerocopy/p2pPingpong/Makefile
+++ b/benchmarks/charm++/zerocopy/p2pPingpong/Makefile
@@ -18,10 +18,12 @@ megaZCPingpong.o: megaZCPingpong.C cifiles
 test: all
 	$(call run, +p1 ./megaZCPingpong 1024 8192 2 1 1)
 	$(call run, +p2 ./megaZCPingpong 1024 8192 2 1 1)
+	$(call run, +p2 ./megaZCPingpong 1024 8192 2 1 1 +noCMAForZC)
 
 test-bench: all
 	$(call run, ./megaZCPingpong +p1)
 	$(call run, ./megaZCPingpong +p2)
+	$(call run, ./megaZCPingpong +p2 +noCMAForZC)
 
 clean:
 	rm -f *.decl.h *.def.h conv-host *.o megaZCPingpong charmrun cifiles

--- a/examples/charm++/zerocopy/direct_api/misc/zcpy_immediate/Makefile
+++ b/examples/charm++/zerocopy/direct_api/misc/zcpy_immediate/Makefile
@@ -18,6 +18,7 @@ zcpy_immediate.o: zcpy_immediate.C cifiles
 test: all
 	$(call run, +p1 ./zcpy_immediate 20 )
 	$(call run, +p2 ./zcpy_immediate 20 )
+	$(call run, +p2 ./zcpy_immediate 20 +noCMAForZC )
 
 clean:
 	rm -f *.decl.h *.def.h conv-host *.o zcpy_immediate charmrun cifiles

--- a/examples/charm++/zerocopy/direct_api/prereg/get_put_pingpong/Makefile
+++ b/examples/charm++/zerocopy/direct_api/prereg/get_put_pingpong/Makefile
@@ -18,6 +18,7 @@ get_put_pingpong.o: get_put_pingpong.C cifiles
 test: all
 	$(call run, +p1 ./get_put_pingpong 20 )
 	$(call run, +p2 ./get_put_pingpong 20 )
+	$(call run, +p2 ./get_put_pingpong 20 +noCMAForZC )
 
 clean:
 	rm -f *.decl.h *.def.h conv-host *.o get_put_pingpong charmrun cifiles

--- a/examples/charm++/zerocopy/direct_api/prereg/simple_get/Makefile
+++ b/examples/charm++/zerocopy/direct_api/prereg/simple_get/Makefile
@@ -18,6 +18,7 @@ simple_get.o: simple_get.C cifiles
 test: all
 	$(call run, +p1 ./simple_get 20 )
 	$(call run, +p2 ./simple_get 20 )
+	$(call run, +p2 ./simple_get 20 +noCMAForZC )
 
 clean:
 	rm -f *.decl.h *.def.h conv-host *.o simple_get charmrun cifiles

--- a/examples/charm++/zerocopy/direct_api/prereg/simple_put/Makefile
+++ b/examples/charm++/zerocopy/direct_api/prereg/simple_put/Makefile
@@ -18,6 +18,7 @@ simple_put.o: simple_put.C cifiles
 test: all
 	$(call run, +p1 ./simple_put 20 )
 	$(call run, +p2 ./simple_put 20 )
+	$(call run, +p2 ./simple_put 20 +noCMAForZC)
 
 clean:
 	rm -f *.decl.h *.def.h conv-host *.o simple_put charmrun cifiles

--- a/examples/charm++/zerocopy/direct_api/reg/get_put_pingpong/Makefile
+++ b/examples/charm++/zerocopy/direct_api/reg/get_put_pingpong/Makefile
@@ -18,6 +18,7 @@ get_put_pingpong.o: get_put_pingpong.C cifiles
 test: all
 	$(call run, +p1 ./get_put_pingpong 20 )
 	$(call run, +p2 ./get_put_pingpong 20 )
+	$(call run, +p2 ./get_put_pingpong 20 +noCMAForZC )
 
 clean:
 	rm -f *.decl.h *.def.h conv-host *.o get_put_pingpong charmrun cifiles

--- a/examples/charm++/zerocopy/direct_api/reg/simple_get/Makefile
+++ b/examples/charm++/zerocopy/direct_api/reg/simple_get/Makefile
@@ -18,6 +18,7 @@ simple_get.o: simple_get.C cifiles
 test: all
 	$(call run, +p1 ./simple_get 20 )
 	$(call run, +p2 ./simple_get 20 )
+	$(call run, +p2 ./simple_get 20 +noCMAForZC )
 
 clean:
 	rm -f *.decl.h *.def.h conv-host *.o simple_get charmrun cifiles

--- a/examples/charm++/zerocopy/direct_api/reg/simple_put/Makefile
+++ b/examples/charm++/zerocopy/direct_api/reg/simple_put/Makefile
@@ -18,6 +18,7 @@ simple_put.o: simple_put.C cifiles
 test: all
 	$(call run, +p1 ./simple_put 20 )
 	$(call run, +p2 ./simple_put 20 )
+	$(call run, +p2 ./simple_put 20 +noCMAForZC )
 
 clean:
 	rm -f *.decl.h *.def.h conv-host *.o simple_put charmrun cifiles

--- a/examples/charm++/zerocopy/direct_api/unreg/get_put_pingpong/Makefile
+++ b/examples/charm++/zerocopy/direct_api/unreg/get_put_pingpong/Makefile
@@ -18,6 +18,7 @@ get_put_pingpong.o: get_put_pingpong.C cifiles
 test: all
 	$(call run, +p1 ./get_put_pingpong 20 )
 	$(call run, +p2 ./get_put_pingpong 20 )
+	$(call run, +p2 ./get_put_pingpong 20 +noCMAForZC )
 
 clean:
 	rm -f *.decl.h *.def.h conv-host *.o get_put_pingpong charmrun cifiles

--- a/examples/charm++/zerocopy/direct_api/unreg/simple_get/Makefile
+++ b/examples/charm++/zerocopy/direct_api/unreg/simple_get/Makefile
@@ -18,6 +18,7 @@ simple_get.o: simple_get.C cifiles
 test: all
 	$(call run, +p1 ./simple_get 20 )
 	$(call run, +p2 ./simple_get 20 )
+	$(call run, +p2 ./simple_get 20 +noCMAForZC )
 
 clean:
 	rm -f *.decl.h *.def.h conv-host *.o simple_get charmrun cifiles

--- a/examples/charm++/zerocopy/direct_api/unreg/simple_put/Makefile
+++ b/examples/charm++/zerocopy/direct_api/unreg/simple_put/Makefile
@@ -18,6 +18,7 @@ simple_put.o: simple_put.C cifiles
 test: all
 	$(call run, +p1 ./simple_put 20 )
 	$(call run, +p2 ./simple_put 20 )
+	$(call run, +p2 ./simple_put 20 +noCMAForZC )
 
 clean:
 	rm -f *.decl.h *.def.h conv-host *.o simple_put charmrun cifiles

--- a/examples/charm++/zerocopy/entry_method_api/misc/simpleVec/Makefile
+++ b/examples/charm++/zerocopy/entry_method_api/misc/simpleVec/Makefile
@@ -15,6 +15,7 @@ simpleZCVec.o : simpleZCVec.C cifiles
 
 test: all
 	$(call run, +p4 ./simpleZCVec 32)
+	$(call run, +p4 ./simpleZCVec 32 +noCMAForZC)
 
 clean:
 	rm -f *.def.h *.decl.h *.o *~ *.exe cifiles charmrun simpleZCVec

--- a/examples/charm++/zerocopy/entry_method_api/prereg/simpleZeroCopy/Makefile
+++ b/examples/charm++/zerocopy/entry_method_api/prereg/simpleZeroCopy/Makefile
@@ -16,6 +16,8 @@ simpleZeroCopy.o : simpleZeroCopy.C cifiles
 test: all
 	$(call run, +p4 ./simpleZeroCopy 32 +balancer RotateLB)
 	$(call run, +p4 ./simpleZeroCopy 32 +balancer GreedyLB)
+	$(call run, +p4 ./simpleZeroCopy 32 +balancer RotateLB +noCMAForZC)
+	$(call run, +p4 ./simpleZeroCopy 32 +balancer GreedyLB +noCMAForZC)
 
 clean:
 	rm -f *.def.h *.decl.h *.o *~ *.exe cifiles charmrun simpleZeroCopy

--- a/examples/charm++/zerocopy/entry_method_api/prereg/stencil3d/Makefile
+++ b/examples/charm++/zerocopy/entry_method_api/prereg/stencil3d/Makefile
@@ -24,8 +24,10 @@ clean:
 	rm -f *.decl.h *.def.h conv-host *.o stencil3d stencil3d.prj charmrun *~
 
 test: stencil3d
-	$(call run, +p4 ./stencil3d 64 32 +balancer RefineLB )
-	$(call run, +p4 ./stencil3d 64 32 +balancer GreedyLB )
+	$(call run, +p4 ./stencil3d 64 32 +balancer RefineLB)
+	$(call run, +p4 ./stencil3d 64 32 +balancer GreedyLB)
+	$(call run, +p4 ./stencil3d 64 32 +balancer RefineLB +noCMAForZC)
+	$(call run, +p4 ./stencil3d 64 32 +balancer GreedyLB +noCMAForZC)
 
 bgtest: stencil3d
 	$(call run, +p4 ./stencil3d 32 16 +balancer CommLB +x2 +y2 +z1 +cth1 +wth1 )

--- a/examples/charm++/zerocopy/entry_method_api/reg/simpleZeroCopy/Makefile
+++ b/examples/charm++/zerocopy/entry_method_api/reg/simpleZeroCopy/Makefile
@@ -16,6 +16,8 @@ simpleZeroCopy.o : simpleZeroCopy.C cifiles
 test: all
 	$(call run, +p4 ./simpleZeroCopy 32 +balancer RotateLB)
 	$(call run, +p4 ./simpleZeroCopy 32 +balancer GreedyLB)
+	$(call run, +p4 ./simpleZeroCopy 32 +balancer RotateLB +noCMAForZC)
+	$(call run, +p4 ./simpleZeroCopy 32 +balancer GreedyLB +noCMAForZC)
 
 clean:
 	rm -f *.def.h *.decl.h *.o *~ *.exe cifiles charmrun simpleZeroCopy

--- a/examples/charm++/zerocopy/entry_method_api/reg/stencil3d/Makefile
+++ b/examples/charm++/zerocopy/entry_method_api/reg/stencil3d/Makefile
@@ -26,6 +26,8 @@ clean:
 test: stencil3d
 	$(call run, +p4 ./stencil3d 64 32 +balancer RefineLB )
 	$(call run, +p4 ./stencil3d 64 32 +balancer GreedyLB )
+	$(call run, +p4 ./stencil3d 64 32 +balancer RefineLB +noCMAForZC )
+	$(call run, +p4 ./stencil3d 64 32 +balancer GreedyLB +noCMAForZC )
 
 bgtest: stencil3d
 	$(call run, +p4 ./stencil3d 32 16 +balancer CommLB +x2 +y2 +z1 +cth1 +wth1 )

--- a/examples/charm++/zerocopy/entry_method_api/unreg/simpleZeroCopy/Makefile
+++ b/examples/charm++/zerocopy/entry_method_api/unreg/simpleZeroCopy/Makefile
@@ -16,6 +16,8 @@ simpleZeroCopy.o : simpleZeroCopy.C cifiles
 test: all
 	$(call run, +p4 ./simpleZeroCopy 32 +balancer RotateLB)
 	$(call run, +p4 ./simpleZeroCopy 32 +balancer GreedyLB)
+	$(call run, +p4 ./simpleZeroCopy 32 +balancer RotateLB +noCMAForZC)
+	$(call run, +p4 ./simpleZeroCopy 32 +balancer GreedyLB +noCMAForZC)
 
 clean:
 	rm -f *.def.h *.decl.h *.o *~ *.exe cifiles charmrun simpleZeroCopy

--- a/examples/charm++/zerocopy/entry_method_api/unreg/stencil3d/Makefile
+++ b/examples/charm++/zerocopy/entry_method_api/unreg/stencil3d/Makefile
@@ -26,6 +26,8 @@ clean:
 test: stencil3d
 	$(call run, +p4 ./stencil3d 64 32 +balancer RefineLB )
 	$(call run, +p4 ./stencil3d 64 32 +balancer GreedyLB )
+	$(call run, +p4 ./stencil3d 64 32 +balancer RefineLB +noCMAForZC )
+	$(call run, +p4 ./stencil3d 64 32 +balancer GreedyLB +noCMAForZC )
 
 bgtest: stencil3d
 	$(call run, +p4 ./stencil3d 32 16 +balancer CommLB +x2 +y2 +z1 +cth1 +wth1 )

--- a/examples/charm++/zerocopy/entry_method_bcast_api/prereg/simpleBcast/Makefile
+++ b/examples/charm++/zerocopy/entry_method_bcast_api/prereg/simpleBcast/Makefile
@@ -16,6 +16,8 @@ simpleBcast.o : simpleBcast.C cifiles
 test: all
 	$(call run, +p4 ./simpleBcast)
 	$(call run, +p6 ./simpleBcast)
+	$(call run, +p4 ./simpleBcast +noCMAForZC)
+	$(call run, +p6 ./simpleBcast +noCMAForZC)
 
 clean:
 	rm -f *.def.h *.decl.h *.o *~ *.exe cifiles charmrun simpleBcast

--- a/examples/charm++/zerocopy/entry_method_bcast_api/reg/simpleBcast/Makefile
+++ b/examples/charm++/zerocopy/entry_method_bcast_api/reg/simpleBcast/Makefile
@@ -16,6 +16,8 @@ simpleBcast.o : simpleBcast.C cifiles
 test: all
 	$(call run, +p4 ./simpleBcast)
 	$(call run, +p6 ./simpleBcast)
+	$(call run, +p4 ./simpleBcast +noCMAForZC)
+	$(call run, +p6 ./simpleBcast +noCMAForZC)
 
 clean:
 	rm -f *.def.h *.decl.h *.o *~ *.exe cifiles charmrun simpleBcast

--- a/examples/charm++/zerocopy/entry_method_bcast_api/unreg/simpleBcast/Makefile
+++ b/examples/charm++/zerocopy/entry_method_bcast_api/unreg/simpleBcast/Makefile
@@ -16,6 +16,8 @@ simpleBcast.o : simpleBcast.C cifiles
 test: all
 	$(call run, +p4 ./simpleBcast)
 	$(call run, +p6 ./simpleBcast)
+	$(call run, +p4 ./simpleBcast +noCMAForZC)
+	$(call run, +p6 ./simpleBcast +noCMAForZC)
 
 clean:
 	rm -f *.def.h *.decl.h *.o *~ *.exe cifiles charmrun simpleBcast

--- a/examples/charm++/zerocopy/entry_method_bcast_post_api/prereg/simpleBcastPost/Makefile
+++ b/examples/charm++/zerocopy/entry_method_bcast_post_api/prereg/simpleBcastPost/Makefile
@@ -16,6 +16,8 @@ simpleBcastPost.o : simpleBcastPost.C cifiles
 test: all
 	$(call run, +p4 ./simpleBcastPost)
 	$(call run, +p6 ./simpleBcastPost)
+	$(call run, +p4 ./simpleBcastPost +noCMAForZC)
+	$(call run, +p6 ./simpleBcastPost +noCMAForZC)
 
 clean:
 	rm -f *.def.h *.decl.h *.o *~ *.exe cifiles charmrun simpleBcastPost

--- a/examples/charm++/zerocopy/entry_method_bcast_post_api/reg/simpleBcastPost/Makefile
+++ b/examples/charm++/zerocopy/entry_method_bcast_post_api/reg/simpleBcastPost/Makefile
@@ -16,6 +16,8 @@ simpleBcastPost.o : simpleBcastPost.C cifiles
 test: all
 	$(call run, +p4 ./simpleBcastPost)
 	$(call run, +p6 ./simpleBcastPost)
+	$(call run, +p4 ./simpleBcastPost +noCMAForZC)
+	$(call run, +p6 ./simpleBcastPost +noCMAForZC)
 
 clean:
 	rm -f *.def.h *.decl.h *.o *~ *.exe cifiles charmrun simpleBcastPost

--- a/examples/charm++/zerocopy/entry_method_bcast_post_api/unreg/simpleBcastPost/Makefile
+++ b/examples/charm++/zerocopy/entry_method_bcast_post_api/unreg/simpleBcastPost/Makefile
@@ -16,6 +16,8 @@ simpleBcastPost.o : simpleBcastPost.C cifiles
 test: all
 	$(call run, +p4 ./simpleBcastPost)
 	$(call run, +p6 ./simpleBcastPost)
+	$(call run, +p4 ./simpleBcastPost +noCMAForZC)
+	$(call run, +p6 ./simpleBcastPost +noCMAForZC)
 
 clean:
 	rm -f *.def.h *.decl.h *.o *~ *.exe cifiles charmrun simpleBcastPost

--- a/examples/charm++/zerocopy/entry_method_post_api/prereg/nodegroupTest/Makefile
+++ b/examples/charm++/zerocopy/entry_method_post_api/prereg/nodegroupTest/Makefile
@@ -19,6 +19,7 @@ ifeq ($(CMK_MULTICORE),1)
 	echo "Skipping nodegroupTest test on MULTICORE builds as it has to be run on even number of logical nodes"
 else
 	$(call run, +p4 ./nodegroupTest)
+	$(call run, +p4 ./nodegroupTest +noCMAForZC)
 endif
 
 clean:

--- a/examples/charm++/zerocopy/entry_method_post_api/prereg/simpleZeroCopy/Makefile
+++ b/examples/charm++/zerocopy/entry_method_post_api/prereg/simpleZeroCopy/Makefile
@@ -16,6 +16,8 @@ simpleZeroCopy.o : simpleZeroCopy.C cifiles
 test: all
 	$(call run, +p4 ./simpleZeroCopy 32 +balancer RotateLB)
 	$(call run, +p4 ./simpleZeroCopy 32 +balancer GreedyLB)
+	$(call run, +p4 ./simpleZeroCopy 32 +balancer RotateLB +noCMAForZC)
+	$(call run, +p4 ./simpleZeroCopy 32 +balancer GreedyLB +noCMAForZC)
 
 clean:
 	rm -f *.def.h *.decl.h *.o *~ *.exe cifiles charmrun simpleZeroCopy

--- a/examples/charm++/zerocopy/entry_method_post_api/reg/nodegroupTest/Makefile
+++ b/examples/charm++/zerocopy/entry_method_post_api/reg/nodegroupTest/Makefile
@@ -19,6 +19,7 @@ ifeq ($(CMK_MULTICORE),1)
 	echo "Skipping nodegroupTest test on MULTICORE builds as it has to be run on even number of logical nodes"
 else
 	$(call run, +p4 ./nodegroupTest)
+	$(call run, +p4 ./nodegroupTest +noCMAForZC)
 endif
 
 clean:

--- a/examples/charm++/zerocopy/entry_method_post_api/reg/simpleZeroCopy/Makefile
+++ b/examples/charm++/zerocopy/entry_method_post_api/reg/simpleZeroCopy/Makefile
@@ -16,6 +16,8 @@ simpleZeroCopy.o : simpleZeroCopy.C cifiles
 test: all
 	$(call run, +p4 ./simpleZeroCopy 32 +balancer RotateLB)
 	$(call run, +p4 ./simpleZeroCopy 32 +balancer GreedyLB)
+	$(call run, +p4 ./simpleZeroCopy 32 +balancer RotateLB +noCMAForZC)
+	$(call run, +p4 ./simpleZeroCopy 32 +balancer GreedyLB +noCMAForZC)
 
 clean:
 	rm -f *.def.h *.decl.h *.o *~ *.exe cifiles charmrun simpleZeroCopy

--- a/examples/charm++/zerocopy/entry_method_post_api/unreg/nodegroupTest/Makefile
+++ b/examples/charm++/zerocopy/entry_method_post_api/unreg/nodegroupTest/Makefile
@@ -19,6 +19,7 @@ ifeq ($(CMK_MULTICORE),1)
 	echo "Skipping nodegroupTest test on MULTICORE builds as it has to be run on even number of logical nodes"
 else
 	$(call run, +p4 ./nodegroupTest)
+	$(call run, +p4 ./nodegroupTest +noCMAForZC)
 endif
 
 clean:

--- a/examples/charm++/zerocopy/entry_method_post_api/unreg/simpleZeroCopy/Makefile
+++ b/examples/charm++/zerocopy/entry_method_post_api/unreg/simpleZeroCopy/Makefile
@@ -16,6 +16,8 @@ simpleZeroCopy.o : simpleZeroCopy.C cifiles
 test: all
 	$(call run, +p4 ./simpleZeroCopy 32 +balancer RotateLB)
 	$(call run, +p4 ./simpleZeroCopy 32 +balancer GreedyLB)
+	$(call run, +p4 ./simpleZeroCopy 32 +balancer RotateLB +noCMAForZC)
+	$(call run, +p4 ./simpleZeroCopy 32 +balancer GreedyLB +noCMAForZC)
 
 clean:
 	rm -f *.def.h *.decl.h *.o *~ *.exe cifiles charmrun simpleZeroCopy

--- a/examples/charm++/zerocopy/large_readonly/Makefile
+++ b/examples/charm++/zerocopy/large_readonly/Makefile
@@ -19,6 +19,8 @@ test: all
 	$(call run, +p1 ./readonly)
 	$(call run, +p4 ./readonly)
 	$(call run, +p6 ./readonly)
+	$(call run, +p4 ./readonly +noCMAForZC)
+	$(call run, +p6 ./readonly +noCMAForZC)
 
 clean:
 	rm -f *.decl.h *.def.h conv-host *.o readonly charmrun cifiles

--- a/src/ck-core/ckrdma.C
+++ b/src/ck-core/ckrdma.C
@@ -14,6 +14,7 @@
 
 // Integer used to store the ncpy ack handler idx
 static int ncpy_handler_idx;
+bool useCMAForZC;
 
 /*********************************** Zerocopy Direct API **********************************/
 // Get Methods
@@ -474,7 +475,7 @@ CkNcpyMode findTransferMode(int srcPe, int destPe) {
   if(CmiNodeOf(srcPe)==CmiNodeOf(destPe))
     return CkNcpyMode::MEMCPY;
 #if CMK_USE_CMA
-  else if(CmiDoesCMAWork() && CmiPeOnSamePhysicalNode(srcPe, destPe))
+  else if(useCMAForZC && CmiDoesCMAWork() && CmiPeOnSamePhysicalNode(srcPe, destPe))
     return CkNcpyMode::CMA;
 #endif
   else
@@ -485,7 +486,7 @@ CkNcpyMode findTransferModeWithNodes(int srcNode, int destNode) {
   if(srcNode==destNode)
     return CkNcpyMode::MEMCPY;
 #if CMK_USE_CMA
-  else if(CmiDoesCMAWork() && CmiPeOnSamePhysicalNode(CmiNodeFirst(srcNode), CmiNodeFirst(destNode)))
+  else if(useCMAForZC && CmiDoesCMAWork() && CmiPeOnSamePhysicalNode(CmiNodeFirst(srcNode), CmiNodeFirst(destNode)))
     return CkNcpyMode::CMA;
 #endif
   else

--- a/src/ck-core/init.C
+++ b/src/ck-core/init.C
@@ -237,6 +237,7 @@ void processRaiseEvacFile(char *raiseEvacFile);
 #endif
 
 extern bool useNodeBlkMapping;
+extern bool useCMAForZC;
 
 extern int quietMode;
 extern int quietModeRequested;
@@ -356,6 +357,11 @@ static inline void _parseCommandLineOpts(char **argv)
         if (CmiGetArgFlagDesc(argv,"+useNodeBlkMapping","Array elements are block-mapped in SMP-node level")) {
           useNodeBlkMapping = true;
         }
+
+  useCMAForZC = true;
+  if (CmiGetArgFlagDesc(argv, "+noCMAForZC", "When Cross Memory Attach (CMA) is supported, the program does not use CMA when using the Zerocopy API")) {
+    useCMAForZC = false;
+  }
 
 #if ! CMK_WITH_CONTROLPOINT
 	// Display a warning if charm++ wasn't compiled with control point support but user is expecting it

--- a/tests/charm++/zerocopy/dereg_and_nodereg/Makefile
+++ b/tests/charm++/zerocopy/dereg_and_nodereg/Makefile
@@ -20,6 +20,8 @@ test: all
 	$(call run, +p1 ./dereg_and_nodereg 10)
 	$(call run, +p4 ./dereg_and_nodereg 50)
 	$(call run, +p6 ./dereg_and_nodereg 100)
+	$(call run, +p4 ./dereg_and_nodereg 50 +noCMAForZC)
+	$(call run, +p6 ./dereg_and_nodereg 100 +noCMAForZC)
 
 clean:
 	rm -f *.decl.h *.def.h *.o

--- a/tests/charm++/zerocopy/direct_api/Makefile
+++ b/tests/charm++/zerocopy/direct_api/Makefile
@@ -19,6 +19,7 @@ direct_api.o: direct_api.C cifiles
 test: all
 	$(call run, +p1 ./direct_api 60)
 	$(call run, +p4 ./direct_api 100)
+	$(call run, +p4 ./direct_api 100 +noCMAForZC)
 
 clean:
 	rm -f *.decl.h *.def.h *.o

--- a/tests/charm++/zerocopy/largedata/Makefile
+++ b/tests/charm++/zerocopy/largedata/Makefile
@@ -27,6 +27,8 @@ $(NAME).o: $(NAME).C cifiles
 test: all
 	$(call run, ./pgm +p4 200000 10)
 	$(call run, ./pgm +p6 200000 10)
+	$(call run, ./pgm +p4 200000 10 +noCMAForZC)
+	$(call run, ./pgm +p6 200000 10 +noCMAForZC)
 
 test-bench: all
 	$(call run, ./pgm +p10)

--- a/tests/charm++/zerocopy/zc_post_modify_size/Makefile
+++ b/tests/charm++/zerocopy/zc_post_modify_size/Makefile
@@ -19,6 +19,7 @@ zc_post_modify_size.o: zc_post_modify_size.C cifiles
 test: all
 	$(call run, +p1 ./zc_post_modify_size)
 	$(call run, +p4 ./zc_post_modify_size)
+	$(call run, +p4 ./zc_post_modify_size +noCMAForZC)
 
 clean:
 	rm -f *.decl.h *.def.h *.o

--- a/tests/charm++/zerocopy/zerocopy_with_qd/Makefile
+++ b/tests/charm++/zerocopy/zerocopy_with_qd/Makefile
@@ -20,6 +20,8 @@ test: all
 	$(call run, +p1 ./zerocopy_with_qd 60)
 	$(call run, +p4 ./zerocopy_with_qd 100)
 	$(call run, +p6 ./zerocopy_with_qd 142)
+	$(call run, +p4 ./zerocopy_with_qd 100 +noCMAForZC)
+	$(call run, +p6 ./zerocopy_with_qd 142 +noCMAForZC)
 
 clean:
 	rm -f *.decl.h *.def.h *.o


### PR DESCRIPTION
This is useful to test the RDMA code path during autobuild on many machines that support CMA. Additionally, it can be used by users when RDMA performs better than CMA. 