### PR TITLE
bugfix : CldEnqueueGroup for cldbs none and test

### DIFF
--- a/src/conv-ldb/cldb.none.C
+++ b/src/conv-ldb/cldb.none.C
@@ -27,6 +27,22 @@ void CldHandler(char *msg)
   CsdEnqueueGeneral(msg, queueing, priobits, prioptr);
 }
 
+void CldEnqueueGroup(CmiGroup grp, void *msg, int infofn)
+{
+  int len, queueing, priobits,i; unsigned int *prioptr;
+  CldInfoFn ifn = (CldInfoFn)CmiHandlerToFunction(infofn);
+  CldPackFn pfn;
+  ifn(msg, &pfn, &len, &queueing, &priobits, &prioptr);
+  if (pfn) {
+    pfn(&msg);
+    ifn(msg, &pfn, &len, &queueing, &priobits, &prioptr);
+  }
+  CldSwitchHandler((char *)msg, CpvAccess(CldHandlerIndex));
+  CmiSetInfo(msg,infofn);
+
+  CmiSyncMulticastAndFree(grp, len, msg);
+}
+
 void CldEnqueueWithinNode(void *msg, int infofn)
 {
   int len, queueing, priobits;

--- a/src/conv-ldb/cldb.test.C
+++ b/src/conv-ldb/cldb.test.C
@@ -30,6 +30,23 @@ void CldHandler(char *msg)
   CsdEnqueueGeneral(msg, queueing, priobits, prioptr);
 }
 
+void CldEnqueueGroup(CmiGroup grp, void *msg, int infofn)
+{
+  int len, queueing, priobits,i; unsigned int *prioptr;
+  CldInfoFn ifn = (CldInfoFn)CmiHandlerToFunction(infofn);
+  CldPackFn pfn;
+  ifn(msg, &pfn, &len, &queueing, &priobits, &prioptr);
+  if (pfn) {
+    pfn(&msg);
+    ifn(msg, &pfn, &len, &queueing, &priobits, &prioptr);
+  }
+  CldSwitchHandler((char *)msg, CpvAccess(CldHandlerIndex));
+  CmiSetInfo(msg,infofn);
+
+  CmiSyncMulticastAndFree(grp, len, msg);
+}
+
+
 void CldEnqueueWithinNode(void *msg, int infofn)
 {
   int len, queueing, priobits;


### PR DESCRIPTION
Old extensions (i.e., CldEnqueueGroup) to cldb.rand were not propagated to cldb.none or cldb.test. This replicates that so these can be selected via -balance and function correctly to govern singleton chare placement. Neither of these strategies is good as a balancer, but none provides a deterministic approach that assists various debugging scenarios.  cldb.test provided simply for completeness.