### PR TITLE
bugfix #1999: record/replay may hang in SMP

### DIFF
--- a/src/ck-core/envelope.h
+++ b/src/ck-core/envelope.h
@@ -290,7 +290,7 @@ public:
     void* getGroupDepPtr(void) const {
       return (void *)((char *)this + totalsize - getGroupDepSize());
     }
-    static envelope *alloc(const UChar type, const UInt size=0, const UShort prio=0, const GroupDepNum groupDepNumRequest=GroupDepNum{})
+    static envelope *alloc(const UChar type, const UInt size=0, const UShort prio=0, const GroupDepNum groupDepNumRequest=GroupDepNum{}, const bool incEvent=true)
     {
 #if CMK_LOCKLESS_QUEUE
       CkAssert(type>=NewChareMsg && type<LAST_CK_ENVELOPE_TYPE);
@@ -313,7 +313,10 @@ public:
 #if CMK_REPLAYSYSTEM
       //for record-replay
       memset(env, 0, sizeof(envelope));
-      env->setEvent(++CkpvAccess(envelopeEventID));
+      if(incEvent)
+	env->setEvent(++CkpvAccess(envelopeEventID));
+      else
+	env->setEvent(CkpvAccess(envelopeEventID));
 #endif
       env->setMsgtype(type);
       env->totalsize = tsize;
@@ -474,6 +477,12 @@ inline void *EnvToUsr(const envelope *const env) {
 inline envelope *_allocEnv(const int msgtype, const int size=0, const int prio=0, const GroupDepNum groupDepNum=GroupDepNum{}) {
   return envelope::alloc(msgtype,size,prio,groupDepNum);
 }
+
+#if CMK_REPLAYSYSTEM
+inline envelope *_allocEnvNoIncEvent(const int msgtype, const int size=0, const int prio=0, const GroupDepNum groupDepNum=GroupDepNum{}) {
+  return envelope::alloc(msgtype,size,prio,groupDepNum,false);
+}
+#endif
 
 inline void *_allocMsg(const int msgtype, const int size, const int prio=0, const GroupDepNum groupDepNum=GroupDepNum{}) {
   return EnvToUsr(envelope::alloc(msgtype,size,prio,groupDepNum));

--- a/src/ck-core/init.C
+++ b/src/ck-core/init.C
@@ -818,7 +818,11 @@ static void _sendTriggers(void)
   {
     CksvAccess(_triggersSent) = true;
     num = CmiMyNodeSize();
+#if CMK_REPLAYSYSTEM
     envelope *env = _allocEnvNoIncEvent(RODataMsg); // Notice that the type here is irrelevant
+#else    
+    envelope *env = _allocEnv(RODataMsg); // Notice that the type here is irrelevant
+#endif    
     env->setSrcPe(CkMyPe());
     CmiSetHandler(env, _triggerHandlerIdx);
     first = CmiNodeFirst(CmiMyNode());

--- a/src/ck-core/init.C
+++ b/src/ck-core/init.C
@@ -818,7 +818,7 @@ static void _sendTriggers(void)
   {
     CksvAccess(_triggersSent) = true;
     num = CmiMyNodeSize();
-    envelope *env = _allocEnv(RODataMsg); // Notice that the type here is irrelevant
+    envelope *env = _allocEnvNoIncEvent(RODataMsg); // Notice that the type here is irrelevant
     env->setSrcPe(CkMyPe());
     CmiSetHandler(env, _triggerHandlerIdx);
     first = CmiNodeFirst(CmiMyNode());

--- a/tests/charm++/Makefile
+++ b/tests/charm++/Makefile
@@ -1,17 +1,11 @@
 DIRS = \
-  megatest \
   alignment \
   simplearrayhello \
   provisioning \
-  load_balancing \
-  chkpt \
   delegation \
   queue \
-  sdag \
-  ckAllocSysMsgTest \
   method_templates \
   demand_creation \
-  startupTest \
   topology \
   io \
   sparse \
@@ -20,7 +14,6 @@ DIRS = \
   charmxi_parsing \
   jacobi3d \
   jacobi3d-sdag \
-  zerocopy \
   within_node_bcast \
 
 # skip sdag, megatest and commtest

--- a/tests/charm++/Makefile
+++ b/tests/charm++/Makefile
@@ -1,11 +1,17 @@
 DIRS = \
+  megatest \
   alignment \
   simplearrayhello \
   provisioning \
+  load_balancing \
+  chkpt \
   delegation \
   queue \
+  sdag \
+  ckAllocSysMsgTest \
   method_templates \
   demand_creation \
+  startupTest \
   topology \
   io \
   sparse \
@@ -14,6 +20,7 @@ DIRS = \
   charmxi_parsing \
   jacobi3d \
   jacobi3d-sdag \
+  zerocopy \
   within_node_bcast \
 
 # skip sdag, megatest and commtest


### PR DESCRIPTION
envelopeEventID is the ckpv that monotonically increases
with each envelope (and therefore message).  However, in SMP
the envelope allocated and enqueued in the initDone process
is invisible to the record/replay process and can occur
on any PE in the node.  That creates a non-deterministic
race condition in the PE:envelopeEventID tuple space.

This workaround simply avoids incrementing the envelopeEventID
on the PE that triggers doneInit. This allows otherwise
deterministic SMP applications to record/replay with proper
fidelity.