### PR TITLE
AMPI: fix bug in zero copy buffer deregistration

### DIFF
--- a/src/libs/ck-libs/ampi/ampi.C
+++ b/src/libs/ck-libs/ampi/ampi.C
@@ -2888,7 +2888,7 @@ void ampi::inorderRdma(char* buf, int size, CMK_REFNUM_TYPE seq, int tag, int sr
 }
 
 // Callback signaling that the send buffer is now safe to re-use
-void ampi::completedSend(MPI_Request reqIdx) noexcept
+void ampi::completedSend(MPI_Request reqIdx, CkNcpyBuffer *srcInfo/*=nullptr*/) noexcept
 {
   MSG_ORDER_DEBUG(
      CkPrintf("[%d] VP %d in completedSend, reqIdx = %d\n",
@@ -2897,7 +2897,7 @@ void ampi::completedSend(MPI_Request reqIdx) noexcept
 
   AmpiRequestList& reqList = getReqs();
   AmpiRequest& sreq = (*reqList[reqIdx]);
-  sreq.deregisterMem();
+  sreq.deregisterMem(srcInfo);
   sreq.complete = true;
 
   handleBlockedReq(&sreq);
@@ -2909,11 +2909,12 @@ void ampi::completedRdmaSend(CkDataMsg *msg) noexcept
 {
   // refnum is the index into reqList for this SendReq
   int reqIdx = CkGetRefNum(msg);
-  completedSend(reqIdx);
+  CkNcpyBuffer *srcInfo = (CkNcpyBuffer *)(msg->data);
+  completedSend(reqIdx, srcInfo);
   // [nokeep] entry method, so do not delete msg
 }
 
-void ampi::completedRecv(MPI_Request reqIdx) noexcept
+void ampi::completedRecv(MPI_Request reqIdx, CkNcpyBuffer *targetInfo/*=nullptr*/) noexcept
 {
   MSG_ORDER_DEBUG(
     CkPrintf("[%d] VP %d in completedRecv, reqIdx = %d\n", CkMyPe(), parent->thisIndex, reqIdx);
@@ -2926,7 +2927,7 @@ void ampi::completedRecv(MPI_Request reqIdx) noexcept
     // deserialize message from intermediate/system buffer into non-contiguous user buffer
     processRdmaMsg(ireq.systemBuf, ireq.systemBufLen, ireq.buf, ireq.count, ireq.type);
   }
-  ireq.deregisterMem();
+  ireq.deregisterMem(targetInfo);
   ireq.complete = true;
 
   handleBlockedReq(&ireq);
@@ -2937,7 +2938,8 @@ void ampi::completedRdmaRecv(CkDataMsg *msg) noexcept
 {
   // refnum is the index into reqList for this IReq
   int reqIdx = CkGetRefNum(msg);
-  completedRecv(reqIdx);
+  CkNcpyBuffer *targetInfo = (CkNcpyBuffer *)(msg->data);
+  completedRecv(reqIdx, targetInfo);
   // [nokeep] entry method, so do not delete msg
 }
 
@@ -3025,9 +3027,10 @@ AmpiMsg* ampi::makeNcpyMsg(int t, int sRank, const void* buf, int count,
   CkCallback sendCB(CkIndex_ampi::completedRdmaSend(NULL), thisProxy[thisIndex], true /*inline*/);
   sendCB.setRefnum(ssendReq);
   SsendReq& req = *((SsendReq*)(getReqs()[ssendReq]));
+  CkNcpyBuffer srcInfo;
 
   if (ddt->isContig()) {
-    req.srcInfo = new CkNcpyBuffer(buf, len, sendCB);
+    srcInfo = CkNcpyBuffer(buf, len, sendCB);
   }
   else {
     // NOTE: if DDT could provide us with a list of pointers to contiguous chunks
@@ -3035,7 +3038,7 @@ AmpiMsg* ampi::makeNcpyMsg(int t, int sRank, const void* buf, int count,
     //       now we just copy into a contiguous system buffer and then send that.
     char* sbuf = new char[len];
     ddt->serialize((char*)buf, sbuf, count, len, PACK);
-    req.srcInfo = new CkNcpyBuffer(sbuf, len, sendCB);
+    srcInfo = CkNcpyBuffer(sbuf, len, sendCB);
     req.setSystemBuf(sbuf); // completedSend will need to free this
     // NOTE: We could set 'req.complete = true' here, but then we'd
     //       have to make sure req.systemBuf gets freed by someone else
@@ -3045,7 +3048,7 @@ AmpiMsg* ampi::makeNcpyMsg(int t, int sRank, const void* buf, int count,
   AmpiMsgType msgType = NCPY_MSG;
   PUP::sizer pupSizer;
   pupSizer | msgType;
-  pupSizer | (*req.srcInfo);
+  pupSizer | srcInfo;
   int srcInfoLen = pupSizer.size();
 
   AmpiMsg *msg = CkpvAccess(msgPool).newAmpiMsg(seq, ssendReq, t, sRank, srcInfoLen);
@@ -3053,7 +3056,7 @@ AmpiMsg* ampi::makeNcpyMsg(int t, int sRank, const void* buf, int count,
 
   PUP::toMem pupPacker(msg->getData());
   pupPacker | msgType;
-  pupPacker | (*req.srcInfo);
+  pupPacker | srcInfo;
   return msg;
 }
 
@@ -3320,21 +3323,22 @@ void ampi::requestPut(MPI_Request reqIdx, CkNcpyBuffer targetInfo) noexcept {
   CkDDT_DataType* sddt = getDDT()->getType(req.type);
   CkCallback sendCB(CkIndex_ampi::completedRdmaSend(NULL), thisProxy[thisIndex], true /*inline*/);
   sendCB.setRefnum(reqIdx);
+  CkNcpyBuffer srcInfo;
 
   if (sddt->isContig()) {
-    req.srcInfo = new CkNcpyBuffer(req.buf, req.count, sendCB);
+    srcInfo = CkNcpyBuffer(req.buf, req.count, sendCB);
   }
   else {
     int len = sddt->getSize(req.count);
     char* sbuf = new char[len];
     sddt->serialize((char*)req.buf, sbuf, req.count, len, PACK);
-    req.srcInfo = new CkNcpyBuffer(sbuf, len, sendCB);
+    srcInfo = CkNcpyBuffer(sbuf, len, sendCB);
     req.setSystemBuf(sbuf); // completedSend will need to free this
     // NOTE: We could set 'req.statusIreq = true' here, but then we'd
     // have to make sure systemBuf gets freed by someone in case the
     // user tries to free 'req' before the put() actually completes...
   }
-  req.srcInfo->put(targetInfo);
+  srcInfo.put(targetInfo);
 }
 
 bool ampi::processSsendMsg(AmpiMsg* msg, void* buf, MPI_Datatype type,
@@ -3410,9 +3414,10 @@ bool ampi::processSsendNcpyShmMsg(AmpiMsg* msg, void* buf, MPI_Datatype type,
     CkCallback recvCB(CkIndex_ampi::completedRdmaRecv(NULL), thisProxy[thisIndex], true /*inline*/);
     recvCB.setRefnum(req);
     IReq& ireq = *((IReq*)(parent->ampiReqs[req]));
+    CkNcpyBuffer targetInfo;
 
     if (rddt->isContig()) {
-      ireq.targetInfo = new CkNcpyBuffer(buf, len, recvCB);
+      targetInfo = CkNcpyBuffer(buf, len, recvCB);
     }
     else {
       // Allocate a contiguous intermediate buffer for the put(),
@@ -3420,9 +3425,9 @@ bool ampi::processSsendNcpyShmMsg(AmpiMsg* msg, void* buf, MPI_Datatype type,
       int slen = srcInfo.getLength();
       char* sbuf = new char[slen];
       ireq.setSystemBuf(sbuf, slen); // completedRecv will need to free this
-      ireq.targetInfo = new CkNcpyBuffer(sbuf, slen, recvCB);
+      targetInfo = CkNcpyBuffer(sbuf, slen, recvCB);
     }
-    thisProxy[srcInfo.getIdx()].requestPut(srcInfo.getSreqIdx(), *ireq.targetInfo);
+    thisProxy[srcInfo.getIdx()].requestPut(srcInfo.getSreqIdx(), targetInfo);
     return false;
   }
 }
@@ -3440,16 +3445,17 @@ bool ampi::processSsendNcpyMsg(AmpiMsg* msg, void* buf, MPI_Datatype type, int c
   int len = ddt->getSize(count);
   IReq& ireq = *((IReq*)(parent->ampiReqs[req]));
   ireq.length = len;
+  CkNcpyBuffer targetInfo;
 
   if (ddt->isContig()) {
-    ireq.targetInfo = new CkNcpyBuffer(buf, len, recvCB);
+    targetInfo = CkNcpyBuffer(buf, len, recvCB);
   }
   else {
     char* sbuf = new char[len];
     ireq.setSystemBuf(sbuf);
-    ireq.targetInfo = new CkNcpyBuffer(sbuf, len, recvCB);
+    targetInfo = CkNcpyBuffer(sbuf, len, recvCB);
   }
-  ireq.targetInfo->get(srcInfo);
+  targetInfo.get(srcInfo);
   return ireq.complete; // did the get() complete inline (i.e. src is in same process as target)?
 }
 

--- a/src/libs/ck-libs/ampi/ampiimpl.h
+++ b/src/libs/ck-libs/ampi/ampiimpl.h
@@ -1173,7 +1173,7 @@ class AmpiRequest {
   virtual bool isPersistent() const noexcept { return false; }
 
   /// Deregister memory from a get/put
-  virtual void deregisterMem() { }
+  virtual void deregisterMem(CkNcpyBuffer* info) { }
 
   /// Set an intermediate/system buffer that a message will be serialized thru
   virtual void setSystemBuf(void* buf_, int len=0) { }
@@ -1261,7 +1261,6 @@ class IReq final : public AmpiRequest {
   bool cancelled   = false; // track if request is cancelled
   bool persistent  = false; // Is this a persistent recv request?
   int length       = 0; // recv'ed length in bytes
-  CkNcpyBuffer* targetInfo = nullptr;
   char* systemBuf  = nullptr; // non-NULL for non-contiguous recv datatypes
   int systemBufLen = 0; // length in bytes of systemBuf
 
@@ -1297,7 +1296,7 @@ class IReq final : public AmpiRequest {
     systemBuf = (char*)buf_;
     systemBufLen = len;
   }
-  void deregisterMem() noexcept override {
+  void deregisterMem(CkNcpyBuffer *targetInfo) noexcept override {
     if (targetInfo) {
       targetInfo->deregisterMem();
       delete targetInfo;
@@ -1313,14 +1312,6 @@ class IReq final : public AmpiRequest {
     p|length;
     p|systemBufLen;
     p((char *)&systemBuf, sizeof(char *));
-    bool hasTargetInfo = (targetInfo != NULL);
-    p|hasTargetInfo;
-    if (hasTargetInfo) {
-      if (p.isUnpacking()) {
-        targetInfo = new CkNcpyBuffer();
-      }
-      p|*targetInfo;
-    }
   }
   void print() const noexcept override;
 };
@@ -1465,7 +1456,6 @@ class SsendReq final : public AmpiRequest {
   bool persistent = false; // is this a persistent Ssend request?
  public:
   int destRank = MPI_PROC_NULL;
-  CkNcpyBuffer* srcInfo = nullptr;
 
  public:
   SsendReq(MPI_Datatype type_, MPI_Comm comm_, CkDDT* ddt_, AmpiReqSts sts_=AMPI_REQ_PENDING) noexcept
@@ -1509,7 +1499,7 @@ class SsendReq final : public AmpiRequest {
   AmpiReqType getType() const noexcept override { return AMPI_SSEND_REQ; }
   bool isUnmatched() const noexcept override { return false; }
   bool isPooledType() const noexcept override { return true; }
-  void deregisterMem() noexcept override {
+  void deregisterMem(CkNcpyBuffer *srcInfo) noexcept override {
     if (srcInfo) {
       srcInfo->deregisterMem();
       delete srcInfo;
@@ -1527,12 +1517,6 @@ class SsendReq final : public AmpiRequest {
     p|persistent;
     p|destRank;
     p|systemBuf;
-    bool hasSrcInfo = (srcInfo != NULL);
-    p|hasSrcInfo;
-    if (hasSrcInfo) {
-      if (p.isUnpacking()) srcInfo = new CkNcpyBuffer();
-      p|*srcInfo;
-    }
   }
   void print() const noexcept override;
 };
@@ -2653,8 +2637,8 @@ class ampi final : public CBase_ampi {
                                                   int t, MPI_Comm comm, MPI_Status* sts) noexcept;
   MPI_Request postReq(AmpiRequest* newreq) noexcept;
   inline void waitOnBlockingSend(MPI_Request* req, AmpiSendType sendType) noexcept;
-  inline void completedSend(MPI_Request req) noexcept;
-  inline void completedRecv(MPI_Request req) noexcept;
+  inline void completedSend(MPI_Request req, CkNcpyBuffer *srcInfo=nullptr) noexcept;
+  inline void completedRecv(MPI_Request req, CkNcpyBuffer *targetInfo=nullptr) noexcept;
 
   inline CMK_REFNUM_TYPE getSeqNo(int destRank, MPI_Comm destcomm, int tag) noexcept;
   AmpiMsg *makeBcastMsg(const void *buf,int count,MPI_Datatype type,int root,MPI_Comm destcomm) noexcept;

--- a/src/libs/ck-libs/ampi/ampiimpl.h
+++ b/src/libs/ck-libs/ampi/ampiimpl.h
@@ -1299,7 +1299,7 @@ class IReq final : public AmpiRequest {
   void deregisterMem(CkNcpyBuffer *targetInfo) noexcept override {
     if (targetInfo) {
       targetInfo->deregisterMem();
-      delete targetInfo;
+      // targetInfo is owned by the CkDataMsg and so is freed with it
     }
     if (systemBuf) {
       delete [] systemBuf;
@@ -1502,7 +1502,7 @@ class SsendReq final : public AmpiRequest {
   void deregisterMem(CkNcpyBuffer *srcInfo) noexcept override {
     if (srcInfo) {
       srcInfo->deregisterMem();
-      delete srcInfo;
+      // srcInfo is owned by the CkDataMsg and so is freed with it
     }
     if (systemBuf) {
       delete [] (char*)buf;


### PR DESCRIPTION
AMPI previously kept around the original CkNcpyBuffer objects
used in all zero copy operations. Instead, one should get a
CkNcpyBuffer object back from zero copy completion callbacks
via the CkDataMsg::data field.