### PR TITLE
Enable CMK_IMMEDIATE_MSG on mpi-win64 platforms

### DIFF
--- a/src/arch/mpi-win64/conv-mach.h
+++ b/src/arch/mpi-win64/conv-mach.h
@@ -40,7 +40,7 @@
 #define CMK_LBDB_ON					   1
 
 #undef  CMK_IMMEDIATE_MSG
-#define CMK_IMMEDIATE_MSG				   0
+#define CMK_IMMEDIATE_MSG				   1
 
 /*
 #define CMK_PCQUEUE_LOCK                                   1


### PR DESCRIPTION
This fixes the mpi-win-smp ZC QD test, which was hanging because
the QD counter from the comm thread was not being accounted for in the
QD detection process.

I tested autobuild style 'make test' with this patch and all tests seem to be running fine. 