### PR TITLE
Make it so CkArgMsg is now owned and freed by the RTS

### DIFF
--- a/examples/charm++/AMPI-interop/hello.C
+++ b/examples/charm++/AMPI-interop/hello.C
@@ -14,7 +14,6 @@ public:
     // Process command-line arguments
     nElements = 2;
     if (m->argc > 1) nElements=atoi(m->argv[1]);
-    delete m;
 
     // Init the AMPI chare group
     AmpiInteropInit();

--- a/examples/charm++/Molecular2D/Patch.C
+++ b/examples/charm++/Molecular2D/Patch.C
@@ -40,7 +40,6 @@ Main::Main(CkArgMsg* msg) {
   radius = DEFAULT_RADIUS;
   finalStepCount = DEFAULT_FINALSTEPCOUNT;
 
-  delete msg;
   mainProxy = thisProxy;
 
   // initializing the cell 2D array

--- a/examples/charm++/NQueen/main.C
+++ b/examples/charm++/NQueen/main.C
@@ -23,7 +23,6 @@ Main::Main(CkArgMsg* msg)
         numQueens = atoi(msg->argv[1]);
         grainsize = atoi(msg->argv[2]);   
     }
-    delete msg;
 
     CkPrintf(" Usage: nqueen numQueen grainsize (%d, g=%d, np=%d)\n", numQueens, grainsize, CkNumPes());
 

--- a/examples/charm++/PICS/ping/ping.C
+++ b/examples/charm++/PICS/ping/ping.C
@@ -54,7 +54,6 @@ public:
     CkPrintf("ping with payload: %d workload:%d maxIter: %d\n", payload, workLoad, maxIter);
     mainProxy = thishandle;
     arr1 = CProxy_Ping1::ckNew(2);
-    delete m;
     thisProxy.prepare();
   };
 

--- a/examples/charm++/PUP/pupDisk/pupDisk.C
+++ b/examples/charm++/PUP/pupDisk/pupDisk.C
@@ -33,7 +33,6 @@ main::main(CkArgMsg *m)
     maxFiles=atoi(m->argv[3]);
   if(m->argc>4)
     skipToRead=(m->argv[4][0]=='r');
-  delete m;
   if(numElements/maxFiles<=0)
     CkAbort("This works better with more elements than files");
   //rejigger their choices, possibly reducing the number of files below max

--- a/examples/charm++/TRAM/aggregateRandomAccessArray/randomAccess.C
+++ b/examples/charm++/TRAM/aggregateRandomAccessArray/randomAccess.C
@@ -41,8 +41,6 @@ public:
     updater_array = CProxy_Updater::ckNew(CkNumPes() * numElementsPerPe);
     int dims[2] = {CkNumNodes(), CkNumPes() / CkNumNodes()};
     CkPrintf("Aggregation topology: %d %d\n", dims[0], dims[1]);
-
-    delete args;
   }
 
   void start() {

--- a/examples/charm++/TRAM/aggregateRandomAccessGroup/randomAccess.C
+++ b/examples/charm++/TRAM/aggregateRandomAccessGroup/randomAccess.C
@@ -40,8 +40,6 @@ public:
     updater_group   = CProxy_Updater::ckNew();
     int dims[2] = {CkNumNodes(), CkNumPes() / CkNumNodes()};
     CkPrintf("Aggregation topology: %d %d\n", dims[0], dims[1]);
-
-    delete args;
   }
 
   void start() {

--- a/examples/charm++/TRAM/randomAccessArray/randomAccess.C
+++ b/examples/charm++/TRAM/randomAccessArray/randomAccess.C
@@ -51,8 +51,6 @@ public:
     aggregator =
       CProxy_ArrayMeshStreamer<dtype, CkArrayIndex1D, Updater, SimpleMeshRouter>
       ::ckNew(numMsgsBuffered, 2, dims, updater_array, 1);
-
-    delete args;
   }
 
   void start() {

--- a/examples/charm++/TRAM/randomAccessGroup/randomAccess.C
+++ b/examples/charm++/TRAM/randomAccessGroup/randomAccess.C
@@ -48,8 +48,6 @@ public:
     aggregator =
       CProxy_GroupMeshStreamer<dtype, Updater, SimpleMeshRouter>
       ::ckNew(numMsgsBuffered, 2, dims, updater_group, 1);
-
-    delete args;
   }
 
   void start() {

--- a/examples/charm++/allToAll/allToAll.C
+++ b/examples/charm++/allToAll/allToAll.C
@@ -35,8 +35,6 @@ struct Main : public CBase_Main {
             max_iter = atoi(m->argv[3]);
         }
         
-        delete m;
-
         iter = 0;
 		mainProxy = thisProxy;
 		// Construct an array of allToAll chares to do the calculation

--- a/examples/charm++/array/pgm.C
+++ b/examples/charm++/array/pgm.C
@@ -8,8 +8,6 @@ struct Main : CBase_Main {
   Main(CkArgMsg* msg)
     : numRecv(0)
   {
-    delete msg;
-
     mainProxy = thisProxy;
 
     const int X = 3;

--- a/examples/charm++/array_map/array_map.C
+++ b/examples/charm++/array_map/array_map.C
@@ -71,8 +71,6 @@ public:
 class Main : public CBase_Main {
 public:
   Main(CkArgMsg* msg) {
-    delete msg;
-
     // Sums for testing mapping
     int sum1, sum2;
     // Create a new map object

--- a/examples/charm++/ckcallback/reftest.C
+++ b/examples/charm++/ckcallback/reftest.C
@@ -9,7 +9,6 @@ public:
   size_t order { 0 };
 
   Main(CkArgMsg* msg) {
-    delete msg;
     magic_number = 29;
     max_iter = 1000;
     thisProxy.caller();

--- a/examples/charm++/ckloop/dotProd/dotProd.C
+++ b/examples/charm++/ckloop/dotProd/dotProd.C
@@ -74,7 +74,6 @@ public:
     chunkSize = msg->argc > 4 ?  atoi(msg->argv[4]) : DEFAULT_CHUNK_SIZE;
     opNum = msg->argc > 5 ?  atoi(msg->argv[5]) : DEFAULT_OP_NUM;
     iter = msg->argc > 6 ?  atoi(msg->argv[6]) : DEFAULT_NUM_ITERS;
-    delete msg;
     CkPrintf("Running dot product code with %d iterations.\n", iter);
 #ifdef OMP_HYBRID
     omp_set_num_threads(omp_get_max_threads());

--- a/examples/charm++/ckloop/fft-trans/fft1d.C
+++ b/examples/charm++/ckloop/fft-trans/fft1d.C
@@ -45,7 +45,6 @@ struct Main : public CBase_Main {
       numTasks = atol(m->argv[3]); //the number of tasks that 1D partition is splitted into
     else
       numTasks = CmiMyNodeSize();  //default to 1/core
-    delete m;
     
     mainProxy = thisProxy;
 

--- a/examples/charm++/cksequence/cksequence_test.C
+++ b/examples/charm++/cksequence/cksequence_test.C
@@ -46,7 +46,6 @@ class Main: public CBase_Main {
       }
       CkPrintf("Test passed!!\n");
 
-      delete m;
       CkExit();
     };
 

--- a/examples/charm++/completion/comp.C
+++ b/examples/charm++/completion/comp.C
@@ -7,7 +7,6 @@ struct Main : public CBase_Main {
 
   Main(CkArgMsg* msg)
     : num(10) {
-    delete msg;
     detector = CProxy_CompletionDetector::ckNew();
     detector.start_detection(num,
                              CkCallback(CkIndex_Main::startTest(), thisProxy),

--- a/examples/charm++/cuda/busywait/busywait.C
+++ b/examples/charm++/cuda/busywait/busywait.C
@@ -159,7 +159,6 @@ class Main : public CBase_Main {
       CkPrintf("Higher priority for GPU methods and callbacks: %s\n", (gpu_prio) ? "ON" : "OFF");
       CkPrintf("GPU handler PEs: %d\n", gpu_pes);
       CkPrintf("Sync mode: %s\n\n", (sync_mode) ? "ON" : "OFF");
-      delete m;
 
       // calculate kernel clock count
       int cuda_device = 0;

--- a/examples/charm++/cuda/hello/hello.C
+++ b/examples/charm++/cuda/hello/hello.C
@@ -28,7 +28,6 @@ class Main : public CBase_Main {
           CkExit();
       }
     }
-    delete m;
 
     // print configuration
     CkPrintf("\n[CUDA hello example]\n");

--- a/examples/charm++/cuda/matmul/matmul.C
+++ b/examples/charm++/cuda/matmul/matmul.C
@@ -63,7 +63,6 @@ class Main : public CBase_Main {
           CkExit();
       }
     }
-    delete m;
 
     // print configuration
     CkPrintf("\n[CUDA matmul example]\n");

--- a/examples/charm++/cuda/mempool/mempool.C
+++ b/examples/charm++/cuda/mempool/mempool.C
@@ -50,7 +50,6 @@ class Main : public CBase_Main {
           CkExit();
       }
     }
-    delete m;
 
     // print configuration
     CkPrintf("\n[CUDA mempool example]\n");

--- a/examples/charm++/cuda/qdtest/qdtest.C
+++ b/examples/charm++/cuda/qdtest/qdtest.C
@@ -55,7 +55,6 @@ public:
           CkExit();
       }
     }
-    delete m;
 
     // Calculate kernel clock count
     int cuda_device = 0;

--- a/examples/charm++/cuda/stencil2d/stencil2d.C
+++ b/examples/charm++/cuda/stencil2d/stencil2d.C
@@ -195,7 +195,6 @@ class Main : public CBase_Main {
     CkPrintf("Higher priority for GPU methods and callbacks: %s\n",
              (gpu_prio) ? "ON" : "OFF");
     CkPrintf("GPU handler PEs: %d\n\n", gpu_pes);
-    delete m;
 
     // Create 2D chare array
 #if USE_CUSTOM_MAP

--- a/examples/charm++/cuda/vecadd/vecadd.C
+++ b/examples/charm++/cuda/vecadd/vecadd.C
@@ -56,7 +56,6 @@ class Main : public CBase_Main {
           CkExit();
       }
     }
-    delete m;
 
     // print configuration
     CkPrintf("\n[CUDA vecadd example]\n");

--- a/examples/charm++/hello/1darray/hello.C
+++ b/examples/charm++/hello/1darray/hello.C
@@ -14,7 +14,6 @@ public:
     //Process command-line arguments
     nElements=5;
     if(m->argc >1 ) nElements=atoi(m->argv[1]);
-    delete m;
 
     //Start the computation
     CkPrintf("Running Hello on %d processors for %d elements\n",

--- a/examples/charm++/hello/1darraymsg/hello.C
+++ b/examples/charm++/hello/1darraymsg/hello.C
@@ -28,7 +28,6 @@ public:
     if(m->argc >1 ) nElements=atoi(m->argv[1]);
     if(m->argc >2 ) msgSize =atoi(m->argv[2]);
     if(m->argc >3 ) maxIter=atoi(m->argv[3]);
-    delete m;
 
     //Start the computation
     CkPrintf("Running Hello on %d processors for %d elements\n",

--- a/examples/charm++/hello/3darray/hello.C
+++ b/examples/charm++/hello/3darray/hello.C
@@ -13,7 +13,6 @@ public:
     //Process command-line arguments
     nElements=5;
     if(m->argc >1 ) nElements=atoi(m->argv[1]);
-    delete m;
 
     //Start the computation
     CkPrintf("Running Hello on %d processors for %d elements\n",

--- a/examples/charm++/hello/3dmultiarrays/hello.C
+++ b/examples/charm++/hello/3dmultiarrays/hello.C
@@ -15,7 +15,6 @@ public:
     //Process command-line arguments
     nElements=5;
     if(m->argc >1 ) nElements=atoi(m->argv[1]);
-    delete m;
 
     //Start the computation
     CkPrintf("Running Hello on %d processors for %d elements\n",

--- a/examples/charm++/hello/4darray/hello.C
+++ b/examples/charm++/hello/4darray/hello.C
@@ -48,7 +48,6 @@ public:
 	numZ = atoi(m->argv[4]);
       }
     }
-    delete m;
 
     //Start the computation
     CkPrintf("Running Hello on %d processors for [%d][%d][%d][%d] elements\n",

--- a/examples/charm++/hello/darray/hello.C
+++ b/examples/charm++/hello/darray/hello.C
@@ -13,7 +13,6 @@ public:
     //Process command-line arguments
     nElements=5;
     if(m->argc >1 ) nElements=atoi(m->argv[1]);
-    delete m;
 
     //Start the computation
     CkPrintf("Running Hello on %d processors for %d elements\n",

--- a/examples/charm++/hello/dgroup/hello.C
+++ b/examples/charm++/hello/dgroup/hello.C
@@ -9,9 +9,6 @@ class Main : public CBase_Main
 public:
   Main(CkArgMsg* m)
   {
-    //Process command-line arguments
-    delete m;
-
     //Start the computation
     CkPrintf("Running Hello on %d processors\n",
 	     CkNumPes());

--- a/examples/charm++/hello/dllarray/hello.C
+++ b/examples/charm++/hello/dllarray/hello.C
@@ -14,7 +14,6 @@ public:
     //Process command-line arguments
     nElements=5;
     if(m->argc >1 ) nElements=atoi(m->argv[1]);
-    delete m;
 
     //Start the computation
     CkPrintf("Running Hello on %d processors for %d elements\n",

--- a/examples/charm++/hello/fancyarray/hello.C
+++ b/examples/charm++/hello/fancyarray/hello.C
@@ -55,7 +55,6 @@ public:
     //Process command-line arguments
     nElements = 5;
     if (m->argc >1 ) nElements=atoi(m->argv[1]);
-    delete m;
 
     //Start the computation
     CkPrintf("Running Hello on %d processors for %d elements\n",

--- a/examples/charm++/hello/group/hello.C
+++ b/examples/charm++/hello/group/hello.C
@@ -9,9 +9,6 @@ class Main : public CBase_Main
 public:
   Main(CkArgMsg* m)
   {
-    //Process command-line arguments
-    delete m;
-
     //Start the computation
     CkPrintf("Running Hello on %d processors\n",
 	     CkNumPes());

--- a/examples/charm++/hello/hello.C
+++ b/examples/charm++/hello/hello.C
@@ -14,7 +14,6 @@
 main::main(CkArgMsg *m)
 {
   CkPrintf("Hello World \n");
-  delete m;
   CkExit();
 }
 

--- a/examples/charm++/hello/local/hello.C
+++ b/examples/charm++/hello/local/hello.C
@@ -16,7 +16,6 @@ public:
     //Process command-line arguments
     nElements=5;
     if(m->argc >1 ) nElements=atoi(m->argv[1]);
-    delete m;
 
     //Start the computation
     CkPrintf("Running Hello on %d processors for %d elements\n",

--- a/examples/charm++/hello/nodegroup/hello.C
+++ b/examples/charm++/hello/nodegroup/hello.C
@@ -9,9 +9,6 @@ class Main : public CBase_Main
 public:
   Main(CkArgMsg* m)
   {
-    //Process command-line arguments
-    delete m;
-
     //Start the computation
     CkPrintf("Running Hello on %d nodes\n",
 	     CkNumNodes());

--- a/examples/charm++/hello/sdag/hello.C
+++ b/examples/charm++/hello/sdag/hello.C
@@ -18,7 +18,6 @@ public:
   int counter;
   Main(CkArgMsg* m)
   {
-    delete m;
     counter=0;
     nElements=5;
 

--- a/examples/charm++/hello/stl_array/hello.C
+++ b/examples/charm++/hello/stl_array/hello.C
@@ -23,7 +23,6 @@ public:
     //Process command-line arguments
     nElements=5;
     if(m->argc >1 ) nElements=atoi(m->argv[1]);
-    delete m;
 
     //Start the computation
     CkPrintf("Running Hello on %d processors for %d elements\n",

--- a/examples/charm++/hello/xarraySection/hello.C
+++ b/examples/charm++/hello/xarraySection/hello.C
@@ -28,7 +28,6 @@ public:
     if (m->argc > 4) maxIter     = atoi(m->argv[4]);
     if (m->argc > 5)
     { CkPrintf("Syntax: %s [numElements numArrays sectionSize maxIter]",m->argv[0]); CkExit(1); }
-    delete m;
 
     CkPrintf("Running a cross-array section demo.\n");
     CkPrintf("\tnum PEs = %d\n\tnum arrays = %d\n\tnum elements = %d\n\tsection size = %d\n\tnum iterations = %d\n",

--- a/examples/charm++/leanmd/Main.C
+++ b/examples/charm++/leanmd/Main.C
@@ -59,7 +59,6 @@ Main::Main(CkArgMsg* m) {
         cellArray(x, y, z).createComputes();
 
   thisProxy.run();
-  delete m;
 }
 
 //constructor for chare object migration

--- a/examples/charm++/load_balancing/hello/hello.C
+++ b/examples/charm++/load_balancing/hello/hello.C
@@ -6,8 +6,6 @@
 class Main : public CBase_Main {
   public:
     Main(CkArgMsg* m) {
-      delete m;
-
       // 2 chares per PE
       int n = 2 * CkNumPes();
 

--- a/examples/charm++/load_balancing/kNeighbor/kNeighbor.C
+++ b/examples/charm++/load_balancing/kNeighbor/kNeighbor.C
@@ -67,7 +67,6 @@ class Main: public CBase_Main {
 
       if (m->argc!=4 && m->argc!=5) {
 	CkPrintf("Usage: %s <#elements> <#iterations> <msg size> [ldb freq]\n", m->argv[0]);
-	delete m;
 	CkExit(1);
       }
 

--- a/examples/charm++/lvServer/lvServer.C
+++ b/examples/charm++/lvServer/lvServer.C
@@ -34,8 +34,6 @@ public:
 
   Main(CkArgMsg* m)
   {
-	delete m;
-	
 	CkPrintf("lvServer with %d slices on %d Processors\n", nChares, CkNumPes());
 	mainProxy=thishandle;
 	

--- a/examples/charm++/manyToMany/manyToMany.C
+++ b/examples/charm++/manyToMany/manyToMany.C
@@ -30,8 +30,6 @@ struct Main : public CBase_Main {
             numChares = atoi(m->argv[2]);
         }
         
-        delete m;
-
         iter = 0;
 		mainProxy = thisProxy;
 		// Construct an array of manyToMany chares to do the calculation

--- a/examples/charm++/mpi-coexist/libs/hi/hi.C
+++ b/examples/charm++/mpi-coexist/libs/hi/hi.C
@@ -10,7 +10,6 @@ class MainHi : public CBase_MainHi
 public:
   MainHi(CkArgMsg *m) {
     mainHi = thisProxy;
-    delete m;
     thisProxy.StartHi(10);
   }
 

--- a/examples/charm++/openmp/simpleLoopBench/hello.C
+++ b/examples/charm++/openmp/simpleLoopBench/hello.C
@@ -72,7 +72,6 @@ Main::Main(CkArgMsg* m) {
     CkPrintf("Usage: -t(#iterations) -c(#chunks) -a(#test instances) -m(running mode, 1 for use Charm threads; 2 for use pthreads )  -p(#threads)\n");
     CkExit(1);
   }
-  delete m;
 
   omp_set_num_threads(numChunks);
 

--- a/examples/charm++/piArray/pgm.C
+++ b/examples/charm++/piArray/pgm.C
@@ -14,7 +14,6 @@ main::main(CkArgMsg * m)
 
   ns = atoi(m->argv[1]);
   nc = atoi(m->argv[2]);
-  delete m;
 
   starttime = CkWallTimer();
 

--- a/examples/charm++/prio/pgm.C
+++ b/examples/charm++/prio/pgm.C
@@ -10,8 +10,6 @@ struct Main : CBase_Main {
   Main(CkArgMsg* m)
     : numToSend(40)
   {
-    delete m;
-
     mainProxy = thisProxy;
 
     CProxy_Chare1 c1 = CProxy_Chare1::ckNew();

--- a/examples/charm++/reductions/typed_reduction/TypedReduction.C
+++ b/examples/charm++/reductions/typed_reduction/TypedReduction.C
@@ -28,7 +28,6 @@ Driver::Driver(CkArgMsg* args) {
     if (args->argc > 1) array_size = strtol(args->argv[1], NULL, 10);
     w = CProxy_Worker::ckNew(array_size);
     w.untyped_reduce();
-    delete args;
 }
 
 void Driver::untyped_done(CkReductionMsg* m) {

--- a/examples/charm++/ring/ring.C
+++ b/examples/charm++/ring/ring.C
@@ -80,7 +80,6 @@ main::main(CkArgMsg* m)
   for (int i=0;i<msg1->listsize;i++) 
     msg1->list1[i]=i;
   CProxy_Btest::ckNew(msg1);
-  delete m;
 }
 
 // Keeps track of the number of rings that terminated. An alternative 

--- a/examples/charm++/rings/rings.C
+++ b/examples/charm++/rings/rings.C
@@ -37,7 +37,6 @@ main::main(CkArgMsg *m) {
   }
 
   mainhandle = thishandle;
-  delete m;
 }
 
 void main::ringDone(NotifyDone *m) {

--- a/examples/charm++/shared_runtimes/openmp-offload/vecadd/vecadd.C
+++ b/examples/charm++/shared_runtimes/openmp-offload/vecadd/vecadd.C
@@ -30,8 +30,6 @@ public:
       }
     }
 
-    delete m;
-
     CkPrintf("\n[OpenMP offloading + Charm++ Vector Addition]\n");
     CkPrintf("Vector size: %lu doubles\n", n);
 

--- a/examples/charm++/speeds/speed.C
+++ b/examples/charm++/speeds/speed.C
@@ -117,7 +117,6 @@ main::main(CkArgMsg* m)
   CkGroupID gid = CProxy_test::ckNew();
   CProxy_test grp(gid);
   grp.measure(nchunks);
-  delete m;
 }
 
 #include "speed.def.h"

--- a/examples/charm++/state_space_searchengine/3SAT/main.C
+++ b/examples/charm++/state_space_searchengine/3SAT/main.C
@@ -13,7 +13,6 @@ public:
         {
             initial_grainsize = atoi(msg->argv[2]);
         }
-        delete msg;
 
         CkPrintf("\nInstance file:%s\ngrainsize:t%d\nprocessor number:%d\n", msg->argv[1], initial_grainsize, CkNumPes()); 
         strcpy(inputfile, msg->argv[1]);

--- a/examples/charm++/state_space_searchengine/BalancedTree/main.C
+++ b/examples/charm++/state_space_searchengine/BalancedTree/main.C
@@ -19,11 +19,9 @@ public:
             branchfactor = atoi(msg->argv[2]);
             depth = atoi(msg->argv[3]);
             target = atoi(msg->argv[4]);            
-            delete msg;
         }else
         {
             CkPrintf("Check input parameter\n");
-            delete msg;
             CkExit();
         }
 

--- a/examples/charm++/state_space_searchengine/Hamiltonian_SE/main.C
+++ b/examples/charm++/state_space_searchengine/Hamiltonian_SE/main.C
@@ -93,7 +93,6 @@ public:
             CkPrintf("exec inputfile grainsize\n");
             CkExit();
         }
-        delete msg;
         
         readinput(inputfile);
         searchEngineProxy.start();

--- a/examples/charm++/state_space_searchengine/NQueens/main.C
+++ b/examples/charm++/state_space_searchengine/NQueens/main.C
@@ -15,7 +15,6 @@ public:
             numQueens = atoi(msg->argv[1]);
             initial_grainsize = atoi(msg->argv[2]);
         }
-        delete msg;
 
         searchEngineProxy.start();
     }

--- a/examples/charm++/state_space_searchengine/TSP_SE/main.C
+++ b/examples/charm++/state_space_searchengine/TSP_SE/main.C
@@ -177,7 +177,6 @@ public:
         if(m->argc<2)
         {
             CkPrintf("Usage: tsp type(0-random graph, 1 inputfile, 2 inputfile) (Size of Problem) initialgrain\n");
-            delete m;
             CkExit(1);
         }
         int type = atoi(m->argv[1]);
@@ -199,7 +198,6 @@ public:
 
         CkPrintf("start\n");
         searchEngineProxy.start();
-        delete m;
     }
 
 };

--- a/examples/charm++/state_space_searchengine/UnbalancedTreeSearch_SE/main.C
+++ b/examples/charm++/state_space_searchengine/UnbalancedTreeSearch_SE/main.C
@@ -12,7 +12,6 @@ public:
     {
         uts_parseParams(msg->argc, msg->argv);                                                              
         initial_grainsize = atoi(msg->argv[1]);                 
-        delete msg;
         uts_printParams();                                                                                
         searchEngineProxy.start();
     }

--- a/examples/charm++/sync_square/sync_square.C
+++ b/examples/charm++/sync_square/sync_square.C
@@ -4,7 +4,6 @@
 Driver::Driver(CkArgMsg* args) {
     int value = 10;
     if (args->argc > 1) value = strtol(args->argv[1], NULL, 10);
-    delete args;
     s = CProxy_Squarer::ckNew();
     sarr = CProxy_SquarerArr::ckNew(2);
     sgrp = CProxy_SquarerGrp::ckNew();

--- a/examples/charm++/user-driven-interop/hello_user.cpp
+++ b/examples/charm++/user-driven-interop/hello_user.cpp
@@ -26,7 +26,6 @@ class Main : public CBase_Main {
     Main(CkArgMsg *msg) {
       // Call the init function using the message argc and argv
       init_hello(msg->argc, msg->argv);
-      delete msg;
     }
 };
 #endif

--- a/examples/charm++/zerocopy/direct_api/misc/zcpy_immediate/zcpy_immediate.C
+++ b/examples/charm++/zerocopy/direct_api/misc/zcpy_immediate/zcpy_immediate.C
@@ -17,7 +17,6 @@ public:
       CkExit(1);
     }
     numElements = atoi(m->argv[1]);
-    delete m;
     if(numElements % 2 != 0){
       CkPrintf("Argument <numelements> should be even");
       CkExit(1);

--- a/examples/charm++/zerocopy/direct_api/prereg/get_put_pingpong/get_put_pingpong.C
+++ b/examples/charm++/zerocopy/direct_api/prereg/get_put_pingpong/get_put_pingpong.C
@@ -20,7 +20,6 @@ public:
     }
     int size = atoi(m->argv[1]);
     mainProxy = thisProxy;
-    delete m;
     arr1 = CProxy_Ping1::ckNew(size, 2);
     count = 0;
     arr1[0].start();

--- a/examples/charm++/zerocopy/direct_api/prereg/simple_get/simple_get.C
+++ b/examples/charm++/zerocopy/direct_api/prereg/simple_get/simple_get.C
@@ -20,7 +20,6 @@ public:
     }
     int size = atoi(m->argv[1]);
     mainProxy = thisProxy;
-    delete m;
     arr1 = CProxy_Ping1::ckNew(size, 2);
     count = 0;
     arr1[0].start();

--- a/examples/charm++/zerocopy/direct_api/prereg/simple_put/simple_put.C
+++ b/examples/charm++/zerocopy/direct_api/prereg/simple_put/simple_put.C
@@ -20,7 +20,6 @@ public:
     }
     int size = atoi(m->argv[1]);
     mainProxy = thisProxy;
-    delete m;
     arr1 = CProxy_Ping1::ckNew(size, 2);
     count = 0;
     arr1[1].start();

--- a/examples/charm++/zerocopy/direct_api/reg/get_put_pingpong/get_put_pingpong.C
+++ b/examples/charm++/zerocopy/direct_api/reg/get_put_pingpong/get_put_pingpong.C
@@ -20,7 +20,6 @@ public:
     }
     int size = atoi(m->argv[1]);
     mainProxy = thisProxy;
-    delete m;
     arr1 = CProxy_Ping1::ckNew(size, 2);
     count = 0;
     arr1[0].start();

--- a/examples/charm++/zerocopy/direct_api/reg/simple_get/simple_get.C
+++ b/examples/charm++/zerocopy/direct_api/reg/simple_get/simple_get.C
@@ -20,7 +20,6 @@ public:
     }
     int size = atoi(m->argv[1]);
     mainProxy = thisProxy;
-    delete m;
     arr1 = CProxy_Ping1::ckNew(size, 2);
     count = 0;
     arr1[0].start();

--- a/examples/charm++/zerocopy/direct_api/reg/simple_put/simple_put.C
+++ b/examples/charm++/zerocopy/direct_api/reg/simple_put/simple_put.C
@@ -20,7 +20,6 @@ public:
     }
     int size = atoi(m->argv[1]);
     mainProxy = thisProxy;
-    delete m;
     arr1 = CProxy_Ping1::ckNew(size, 2);
     count = 0;
     arr1[1].start();

--- a/examples/charm++/zerocopy/direct_api/unreg/simple_get/simple_get.C
+++ b/examples/charm++/zerocopy/direct_api/unreg/simple_get/simple_get.C
@@ -22,7 +22,6 @@ public:
     }
     int size = atoi(m->argv[1]);
     mainProxy = thisProxy;
-    delete m;
     arr1 = CProxy_Ping1::ckNew(size, 2);
     count = 0;
     arr1[0].start();

--- a/examples/charm++/zerocopy/direct_api/unreg/simple_put/simple_put.C
+++ b/examples/charm++/zerocopy/direct_api/unreg/simple_put/simple_put.C
@@ -20,7 +20,6 @@ public:
     }
     int size = atoi(m->argv[1]);
     mainProxy = thisProxy;
-    delete m;
     arr1 = CProxy_Ping1::ckNew(size, 2);
     count = 0;
     arr1[1].start();

--- a/examples/charm++/zerocopy/entry_method_api/misc/simpleVec/simpleZCVec.C
+++ b/examples/charm++/zerocopy/entry_method_api/misc/simpleVec/simpleZCVec.C
@@ -15,7 +15,6 @@ class Main : public CBase_Main{
         CkExit(1);
       }
       numElements = atoi(m->argv[1]);
-      delete m;
       if(numElements%2 != 0){
         ckout<<"Argument <numelements> should be even"<<endl;
         CkExit(1);

--- a/examples/charm++/zerocopy/entry_method_api/prereg/simpleZeroCopy/simpleZeroCopy.C
+++ b/examples/charm++/zerocopy/entry_method_api/prereg/simpleZeroCopy/simpleZeroCopy.C
@@ -18,7 +18,6 @@ class Main : public CBase_Main{
         CkExit(1);
       }
       numElements = atoi(m->argv[1]);
-      delete m;
       if(numElements%2 != 0){
         ckout<<"Argument <numelements> should be even"<<endl;
         CkExit(1);

--- a/examples/charm++/zerocopy/entry_method_api/reg/simpleZeroCopy/simpleZeroCopy.C
+++ b/examples/charm++/zerocopy/entry_method_api/reg/simpleZeroCopy/simpleZeroCopy.C
@@ -18,7 +18,6 @@ class Main : public CBase_Main{
         CkExit(1);
       }
       numElements = atoi(m->argv[1]);
-      delete m;
       if(numElements%2 != 0){
         ckout<<"Argument <numelements> should be even"<<endl;
         CkExit(1);

--- a/examples/charm++/zerocopy/entry_method_api/unreg/simpleZeroCopy/simpleZeroCopy.C
+++ b/examples/charm++/zerocopy/entry_method_api/unreg/simpleZeroCopy/simpleZeroCopy.C
@@ -18,7 +18,6 @@ class Main : public CBase_Main{
         CkExit(1);
       }
       numElements = atoi(m->argv[1]);
-      delete m;
       if(numElements%2 != 0){
         ckout<<"Argument <numelements> should be even"<<endl;
         CkExit(1);

--- a/examples/charm++/zerocopy/entry_method_bcast_api/prereg/simpleBcast/simpleBcast.C
+++ b/examples/charm++/zerocopy/entry_method_bcast_api/prereg/simpleBcast/simpleBcast.C
@@ -30,7 +30,6 @@ class Main : public CBase_Main{
     } else {
       size = CkNumPes() * 10; // default with 10 chare array elements per pe
     }
-    delete m;
 
     counter = 0;
     mainProxy = thisProxy;

--- a/examples/charm++/zerocopy/entry_method_bcast_api/reg/simpleBcast/simpleBcast.C
+++ b/examples/charm++/zerocopy/entry_method_bcast_api/reg/simpleBcast/simpleBcast.C
@@ -31,8 +31,6 @@ class Main : public CBase_Main{
       size = CkNumPes() * 10; // default with 10 chare array elements per pe
     }
 
-    delete m;
-
     counter = 0;
     mainProxy = thisProxy;
 

--- a/examples/charm++/zerocopy/entry_method_bcast_api/unreg/simpleBcast/simpleBcast.C
+++ b/examples/charm++/zerocopy/entry_method_bcast_api/unreg/simpleBcast/simpleBcast.C
@@ -30,7 +30,6 @@ class Main : public CBase_Main{
     } else {
       size = CkNumPes() * 10; // default with 10 chare array elements per pe
     }
-    delete m;
 
     counter = 0;
     mainProxy = thisProxy;

--- a/examples/charm++/zerocopy/entry_method_bcast_post_api/prereg/simpleBcastPost/simpleBcastPost.C
+++ b/examples/charm++/zerocopy/entry_method_bcast_post_api/prereg/simpleBcastPost/simpleBcastPost.C
@@ -32,8 +32,6 @@ class Main : public CBase_Main{
       size = CkNumPes() * 3; // default with 10 chare array elements per pe
     }
 
-    delete m;
-
     counter = 0;
     mainProxy = thisProxy;
 

--- a/examples/charm++/zerocopy/entry_method_bcast_post_api/reg/simpleBcastPost/simpleBcastPost.C
+++ b/examples/charm++/zerocopy/entry_method_bcast_post_api/reg/simpleBcastPost/simpleBcastPost.C
@@ -32,8 +32,6 @@ class Main : public CBase_Main{
       size = CkNumPes() * 3; // default with 10 chare array elements per pe
     }
 
-    delete m;
-
     counter = 0;
     mainProxy = thisProxy;
 

--- a/examples/charm++/zerocopy/entry_method_bcast_post_api/unreg/simpleBcastPost/simpleBcastPost.C
+++ b/examples/charm++/zerocopy/entry_method_bcast_post_api/unreg/simpleBcastPost/simpleBcastPost.C
@@ -32,8 +32,6 @@ class Main : public CBase_Main{
       size = CkNumPes() * 3; // default with 10 chare array elements per pe
     }
 
-    delete m;
-
     counter = 0;
     mainProxy = thisProxy;
 

--- a/examples/charm++/zerocopy/entry_method_post_api/prereg/nodegroupTest/nodegroupTest.C
+++ b/examples/charm++/zerocopy/entry_method_post_api/prereg/nodegroupTest/nodegroupTest.C
@@ -14,7 +14,6 @@ class Main : public CBase_Main{
       }
       numElements = CkNumNodes();
       mProxy = thisProxy;
-      delete m;
 
       CProxy_zerocopyObject zerocopyObj = CProxy_zerocopyObject::ckNew();
       zerocopyObj.testZeroCopy();

--- a/examples/charm++/zerocopy/entry_method_post_api/prereg/simpleZeroCopy/simpleZeroCopy.C
+++ b/examples/charm++/zerocopy/entry_method_post_api/prereg/simpleZeroCopy/simpleZeroCopy.C
@@ -18,7 +18,6 @@ class Main : public CBase_Main{
         CkExit(1);
       }
       numElements = atoi(m->argv[1]);
-      delete m;
       if(numElements%2 != 0){
         ckout<<"Argument <numelements> should be even"<<endl;
         CkExit(1);

--- a/examples/charm++/zerocopy/entry_method_post_api/reg/multiplePostedBuffers/multiplePostedBuffers.C
+++ b/examples/charm++/zerocopy/entry_method_post_api/reg/multiplePostedBuffers/multiplePostedBuffers.C
@@ -18,7 +18,6 @@ class Main : public CBase_Main{
         CkExit(1);
       }
       numElements = atoi(m->argv[1]);
-      delete m;
       if(numElements%2 != 0){
         ckout<<"Argument <numelements> should be even"<<endl;
         CkExit(1);

--- a/examples/charm++/zerocopy/entry_method_post_api/reg/nodegroupTest/nodegroupTest.C
+++ b/examples/charm++/zerocopy/entry_method_post_api/reg/nodegroupTest/nodegroupTest.C
@@ -12,7 +12,6 @@ class Main : public CBase_Main{
         ckout<<"Run it on even number of processes"<<endl;
         CkExit(1);
       }
-      delete m;
 
       numElements = CkNumNodes();
       mProxy = thisProxy;

--- a/examples/charm++/zerocopy/entry_method_post_api/reg/simpleZeroCopy/simpleZeroCopy.C
+++ b/examples/charm++/zerocopy/entry_method_post_api/reg/simpleZeroCopy/simpleZeroCopy.C
@@ -18,7 +18,6 @@ class Main : public CBase_Main{
         CkExit(1);
       }
       numElements = atoi(m->argv[1]);
-      delete m;
       if(numElements%2 != 0){
         ckout<<"Argument <numelements> should be even"<<endl;
         CkExit(1);

--- a/examples/charm++/zerocopy/entry_method_post_api/unreg/nodegroupTest/nodegroupTest.C
+++ b/examples/charm++/zerocopy/entry_method_post_api/unreg/nodegroupTest/nodegroupTest.C
@@ -12,7 +12,6 @@ class Main : public CBase_Main{
         ckout<<"Run it on even number of processes"<<endl;
         CkExit(1);
       }
-      delete m;
 
       numElements = CkNumNodes();
       mProxy = thisProxy;

--- a/examples/charm++/zerocopy/entry_method_post_api/unreg/simpleZeroCopy/simpleZeroCopy.C
+++ b/examples/charm++/zerocopy/entry_method_post_api/unreg/simpleZeroCopy/simpleZeroCopy.C
@@ -18,7 +18,6 @@ class Main : public CBase_Main{
         CkExit(1);
       }
       numElements = atoi(m->argv[1]);
-      delete m;
       if(numElements%2 != 0){
         ckout<<"Argument <numelements> should be even"<<endl;
         CkExit(1);

--- a/examples/collide/collidecharm/hello.C
+++ b/examples/collide/collidecharm/hello.C
@@ -35,7 +35,6 @@ public:
   {
     nElements=5;
     if(m->argc > 1) nElements = atoi(m->argv[1]);
-    delete m;
     CkPrintf("Running Hello on %d processors for %d elements\n",
 	     CkNumPes(),nElements);
     mid = thishandle;

--- a/examples/multiphaseSharedArrays/histogram/histogram.C
+++ b/examples/multiphaseSharedArrays/histogram/histogram.C
@@ -24,7 +24,6 @@ public:
     {
         // Usage: histogram [number_of_worker_threads]
         if (m->argc > 1) WORKERS=atoi(m->argv[1]);
-        delete m;
 
         // Actually build the shared arrays: a 2d array to hold arbitrary
         // data, and a 1d histogram array.

--- a/examples/multiphaseSharedArrays/matmul/t2d.C
+++ b/examples/multiphaseSharedArrays/matmul/t2d.C
@@ -64,7 +64,6 @@ public:
         if(m->argc >5 ) COLS2=atoi(m->argv[5]);
         if(m->argc >6 ) DECOMPOSITION=atoi(m->argv[6]); // 1D, 2D, 3D
         if(m->argc >7 ) detailedTimings= ((atoi(m->argv[7])!=0)?true:false);
-        delete m;
         reallyDone = 0;
 
         MSA2DRowMjr arr1(ROWS1, COLS1, NUM_WORKERS, bytes);        // row major

--- a/examples/multiphaseSharedArrays/matmul/test.C
+++ b/examples/multiphaseSharedArrays/matmul/test.C
@@ -59,7 +59,6 @@ protected:
 public:
     Test(CkArgMsg* m) : doneCnt(0)
     {
-        delete m;
         mainFn();
 
         // now create a distributed array

--- a/examples/multiphaseSharedArrays/moldyn/moldyn.C
+++ b/examples/multiphaseSharedArrays/moldyn/moldyn.C
@@ -57,7 +57,6 @@ public:
         if(m->argc >2 ) NUM_ATOMS=atoi(m->argv[2]);
         if(m->argc >3 ) CACHE_SIZE_BYTES=atoi(m->argv[3]);
         if(m->argc >4 ) detailedTimings= ((atoi(m->argv[4])!=0)?true:false) ; // 1D, 2D, 3D
-        delete m;
         reallyDone = 0;
 
         XyzMSA coords(NUM_ATOMS, NUM_WORKERS, CACHE_SIZE_BYTES);

--- a/examples/multiphaseSharedArrays/simpleTestVarsize/t3.C
+++ b/examples/multiphaseSharedArrays/simpleTestVarsize/t3.C
@@ -207,7 +207,6 @@ public:
         // Usage: t3 [number_of_worker_threads [max_bytes]]
         if(m->argc >1 ) NUM_WORKERS=atoi(m->argv[1]);
         if(m->argc >2 ) bytes=atoi(m->argv[1]);
-        delete m;
         reallyDone = 0;
 
         // Actually build the shared array.

--- a/examples/multiphaseSharedArrays/simpletest/t3.C
+++ b/examples/multiphaseSharedArrays/simpletest/t3.C
@@ -35,7 +35,6 @@ public:
         // Usage: t3 [number_of_worker_threads [max_bytes]]
         if(m->argc >1 ) NUM_WORKERS=atoi(m->argv[1]);
         if(m->argc >2 ) bytes=atoi(m->argv[1]);
-        delete m;
         reallyDone = 0;
 
         // Actually build the shared array.

--- a/src/ck-core/ckcallback.C
+++ b/src/ck-core/ckcallback.C
@@ -27,7 +27,7 @@ class ckcallback_main : public CBase_ckcallback_main {
 public:
 	ckcallback_main(CkArgMsg *m) {
 		_ckcallbackgroup=CProxy_ckcallback_group::ckNew();
-		delete m;
+		//delete m;
 	}
 };
 

--- a/src/ck-core/ckcheckpoint.C
+++ b/src/ck-core/ckcheckpoint.C
@@ -862,7 +862,7 @@ class CkCheckpointInit : public Chare {
 public:
   CkCheckpointInit(CkArgMsg *msg) {
     _sysChkptMgr = CProxy_CkCheckpointMgr::ckNew();
-    delete msg;
+    //delete msg;
   }
   CkCheckpointInit(CkMigrateMessage *m) {delete m;}
 };

--- a/src/ck-core/ckfutures.C
+++ b/src/ck-core/ckfutures.C
@@ -254,7 +254,7 @@ class  FutureMain : public Chare {
   public:
     FutureMain(CkArgMsg *m) {
       _fbocID = CProxy_FutureBOC::ckNew(new FutureInitMsg);
-      delete m;
+      //delete m;
     }
     FutureMain(CkMigrateMessage *m) {}
 };

--- a/src/ck-core/cklocation.C
+++ b/src/ck-core/cklocation.C
@@ -1352,7 +1352,7 @@ public:
 		//_defaultArrayMapID = CProxy_HilbertArrayMap::ckNew();
 		_defaultArrayMapID = CProxy_DefaultArrayMap::ckNew();
 		_fastArrayMapID = CProxy_FastArrayMap::ckNew();
-		delete msg;
+		//delete msg;
 	}
 
 	CkMapsInit(CkMigrateMessage *m) {}

--- a/src/ck-core/ckmemcheckpoint.C
+++ b/src/ck-core/ckmemcheckpoint.C
@@ -1586,7 +1586,7 @@ extern int quietModeRequested;
 class CkMemCheckPTInit: public Chare {
 public:
   CkMemCheckPTInit(CkArgMsg *m) {
-    delete m;
+    //delete m;
 #if CMK_MEM_CHECKPOINT
     if (arg_where == CkCheckPoint_inDISK) {
       if (!quietModeRequested) CkPrintf("Charm++> Double-disk Checkpointing. \n");

--- a/src/ck-core/ckmessage.h
+++ b/src/ck-core/ckmessage.h
@@ -35,6 +35,10 @@ class CkArgMsg : public CkMessage {
 public:
   int argc;
   char **argv;
+
+  ~CkArgMsg() {
+    CkAbort("CkArgMsg deleted! These are owned and freed by the RTS.\n");
+  }
 };
 
 #endif

--- a/src/ck-core/init.C
+++ b/src/ck-core/init.C
@@ -1776,6 +1776,8 @@ void _initCharm(int unused_argc, char **argv)
 
 		CmiCheckAffinity(); // check for thread oversubscription
 
+		CkArgMsg *msg = (CkArgMsg *)CkAllocMsg(0, sizeof(CkArgMsg), 0, GroupDepNum{});
+		msg->argv = argv;
 		for(i=0;i<nMains;i++)  /* Create all mainchares */
 		{
 			size_t size = _chareTable[_mainTable[i]->chareIdx]->size;
@@ -1784,13 +1786,12 @@ void _initCharm(int unused_argc, char **argv)
 			_mainTable[i]->setObj(obj);
 			CkpvAccess(_currentChare) = obj;
 			CkpvAccess(_currentChareType) = _mainTable[i]->chareIdx;
-			CkArgMsg *msg = (CkArgMsg *)CkAllocMsg(0, sizeof(CkArgMsg), 0, GroupDepNum{});
-			msg->argc = CmiGetArgc(argv);
-			msg->argv = argv;
       quietMode = 0;  // allow printing any mainchare user messages
+			msg->argc = CmiGetArgc(argv);
 			_entryTable[_mainTable[i]->entryIdx]->call(msg, obj);
       if (quietModeRequested) quietMode = 1;
 		}
+		CkFreeMsg(msg);
                 _mainDone = true;
 
 		_STATS_RECORD_CREATE_CHARE_N(nMains);

--- a/src/ck-core/waitqd.C
+++ b/src/ck-core/waitqd.C
@@ -12,7 +12,7 @@ waitqd_QDChare::waitqd_QDChare(CkArgMsg *m) {
   waitStarted = false;
   threadList = 0;
   _waitqd_qdhandle = thishandle;
-  delete m;
+  //delete m;
 }
 
 void waitqd_QDChare::waitQD(void) {

--- a/src/ck-ldb/LBDatabase.C
+++ b/src/ck-ldb/LBDatabase.C
@@ -152,7 +152,7 @@ LBDBInit::LBDBInit(CkArgMsg *m)
     CProxy_LBDatabase(_lbdb).ckLocalBranch()->StartLB();
   }
 #endif
-  delete m;
+  //delete m;
 }
 
 // called from init.C

--- a/src/ck-ldb/MetaBalancer.C
+++ b/src/ck-ldb/MetaBalancer.C
@@ -102,7 +102,7 @@ MetaLBInit::MetaLBInit(CkArgMsg *m) {
     _metalb = CProxy_MetaBalancer::ckNew();
   }
 #endif
-  delete m;
+  //delete m;
 }
 
 // called from init.C

--- a/src/libs/ck-libs/io/ckio.C
+++ b/src/libs/ck-libs/io/ckio.C
@@ -72,7 +72,7 @@ namespace Ck { namespace IO {
         Director(CkArgMsg *m)
           : filesOpened(0), opnum(0), sessionID(0)
         {
-          delete m;
+          //delete m;
           director = thisProxy;
           managers = CProxy_Manager::ckNew();
         }

--- a/src/libs/ck-libs/pythonCCS/PythonCCS.C
+++ b/src/libs/ck-libs/pythonCCS/PythonCCS.C
@@ -860,7 +860,6 @@ void PythonObject::pythonSleep(int handle) {
 
 PythonCCS::PythonCCS(CkArgMsg *arg) {
   pythonCcsProxy = thishandle;
-  delete arg;
 }
 
 CkReductionMsg *pythonCombinePrint(int nMsg, CkReductionMsg **msgs) {

--- a/src/libs/ck-libs/pythonCCS/charmdebug-python.C
+++ b/src/libs/ck-libs/pythonCCS/charmdebug-python.C
@@ -4,7 +4,6 @@
 class CpdPython : public CBase_CpdPython {
 public:
   CpdPython (CkArgMsg *msg) {
-    delete msg;
     //((CProxy_CpdPython)thishandle).registerPython("CpdPython");
     //CkCallback cb(CkIndex_CpdPython::pyRequest(0),thishandle);
     //CcsRegisterHandler("pycode", cb);

--- a/src/libs/ck-libs/tcharm/tcharmmain.C
+++ b/src/libs/ck-libs/tcharm/tcharmmain.C
@@ -30,8 +30,6 @@ public:
   }
   
   TCharmMain(CkArgMsg *msg) {
-    delete msg;
-    
     TCHARM_Set_exit(); // Exit when done running these threads.
     
     /*Call user-overridable Fortran setup.

--- a/tests/charm++/alignment/alignmentCheck.C
+++ b/tests/charm++/alignment/alignmentCheck.C
@@ -84,8 +84,6 @@ class TestDriver : public CBase_TestDriver {
 public:
 
   TestDriver(CkArgMsg *m) {
-    delete m;
-
     CProxy_Destination destinationChare =
       CProxy_Destination::ckNew(CkNumPes() - 1);
 

--- a/tests/charm++/chkpt/hello.C
+++ b/tests/charm++/chkpt/hello.C
@@ -19,7 +19,6 @@ public:
     step=0;	
     a=123;b[0]=456;b[1]=789;
     nElements=8;
-    delete m;
     
     chkpPENum = CkNumPes();
     chkpNodeNum = CkNumNodes();

--- a/tests/charm++/delegation/1darray/hello.C
+++ b/tests/charm++/delegation/1darray/hello.C
@@ -16,7 +16,6 @@ public:
     //Process command-line arguments
     nElements=5;
     if(m->argc >1 ) nElements=atoi(m->argv[1]);
-    delete m;
 
     //Start the computation
     CkPrintf("Running Hello on %d processors for %d elements\n",

--- a/tests/charm++/delegation/multicast/hello.C
+++ b/tests/charm++/delegation/multicast/hello.C
@@ -44,7 +44,6 @@ public:
       CkExit(1);
     }
     nElements = atoi(m->argv[1]);
-    delete m;
     CkPrintf("Running Hello on %d processors for %d elements\n",
 	     CkNumPes(),nElements);
     mid = thishandle;

--- a/tests/charm++/delegation/pipelined-section-reduction/hello.C
+++ b/tests/charm++/delegation/pipelined-section-reduction/hello.C
@@ -49,7 +49,6 @@ public:
     NumReductions = atoi(m->argv[4]);
     SectionSize = atoi(m->argv[5]);
 
-    delete m;
     CkPrintf("Running Hello on %d processors for %d elements\n",
 	     CkNumPes(),NumElements);
     mid = thishandle;

--- a/tests/charm++/io/iotest.C
+++ b/tests/charm++/io/iotest.C
@@ -17,7 +17,6 @@ public:
       thisProxy.run(4*i);
 
     CkPrintf("Main ran\n");
-    delete m;
   }
 
   void iterDone() {

--- a/tests/charm++/jacobi3d-gausssiedel/main.C
+++ b/tests/charm++/jacobi3d-gausssiedel/main.C
@@ -112,7 +112,6 @@ public:
         iterations = 0;
         mainProxy = thisProxy;
         processCommandlines(m->argc, m->argv);
-        delete m;
 #if USE_TOPOMAP
         CProxy_JacobiMap map = CProxy_JacobiMap::ckNew(num_chare_x, num_chare_y, num_chare_z);
         CkPrintf("Topology Mapping is being done ... \n");

--- a/tests/charm++/load_balancing/meta_lb_test/period_selection.C
+++ b/tests/charm++/load_balancing/meta_lb_test/period_selection.C
@@ -30,7 +30,6 @@ private:
   int migrations;
 public:
   Main(CkArgMsg* msg) : iteration(0), migrations(0) {
-    delete msg;
     // Test currently requires an equal number of objects on every PE
     // TODO: Make a test that works with some empty PEs
     arrayProxy = CProxy_TestArray::ckNew(CkNumPes() * OBJS_PER_PE);

--- a/tests/charm++/megatest/groupring.h
+++ b/tests/charm++/megatest/groupring.h
@@ -17,7 +17,6 @@ class groupring_message : public CMessage_groupring_message {
 class groupring_main : public CBase_groupring_main {
   public:
     groupring_main(CkArgMsg *m) {
-      delete m;
     }
     groupring_main(CkMigrateMessage *m) {}
 };

--- a/tests/charm++/megatest/megatest.C
+++ b/tests/charm++/megatest/megatest.C
@@ -183,7 +183,6 @@ main::main(CkArgMsg *msg)
   int argc = msg->argc;
   char **argv = msg->argv;
   int numtests, i;
-  delete msg;
   mainhandle = thishandle;
   if (nTests<=0)
     CkAbort("Megatest: No tests registered-- is MEGATEST_REGISTER_TEST malfunctioning?");
@@ -203,6 +202,7 @@ main::main(CkArgMsg *msg)
   num_tests_to_skip = argc;
   tests_to_skip = argv;
   CProxy_main(thishandle).start();
+  CmiPrintf("At end of ctor\n");
 }
 
 void main::start()

--- a/tests/charm++/megatest/nodering.h
+++ b/tests/charm++/megatest/nodering.h
@@ -18,7 +18,6 @@ class nodering_message : public CMessage_nodering_message {
 class nodering_main : public CBase_nodering_main {
   public:
     nodering_main(CkArgMsg *m) {
-      delete m;
       nodering_thisgroup = CProxy_nodering_group::ckNew();
     }
     nodering_main(CkMigrateMessage *m) {}

--- a/tests/charm++/method_templates/pgm.C
+++ b/tests/charm++/method_templates/pgm.C
@@ -41,7 +41,6 @@ class pgm : public CBase_pgm
             // Create the library chare array
             arrProxy = CProxy_libArray::ckNew(nDatumsPerChare, nElements);
             thisProxy.startTest();
-            delete m;
         }
         
         void startTest() {

--- a/tests/charm++/partitions/hello.C
+++ b/tests/charm++/partitions/hello.C
@@ -20,7 +20,6 @@ public:
     else if(m->argc > 1){
         nElements=atoi(m->argv[1]);
     }
-    delete m;
 
     //Check correctness of partitions semantics
     assert(CkNumPes() == expectedNumPes);

--- a/tests/charm++/provisioning/launch.C
+++ b/tests/charm++/provisioning/launch.C
@@ -6,8 +6,6 @@ class Main : public CBase_Main
 public:
   Main(CkArgMsg* m)
   {
-    delete m;
-
     CkPrintf("Successfully launched %d PEs, %d processes, %d hosts\n",
              CkNumPes(), CkNumNodes(), CmiNumPhysicalNodes());
 

--- a/tests/charm++/reductionTesting/reductionTesting1D/Main.C
+++ b/tests/charm++/reductionTesting/reductionTesting1D/Main.C
@@ -21,7 +21,6 @@ Main::Main(CkArgMsg *m)
 	}
 	arrayDimension = atoi(m->argv[1]);
 	vectorSize = atoi(m->argv[2]);
-	delete m;
 	mainProxy = thisProxy;
 	mainhandle = thishandle;
 	testProxy1D = CProxy_Test1D::ckNew(arrayDimension);

--- a/tests/charm++/reductionTesting/reductionTesting2D/Main.C
+++ b/tests/charm++/reductionTesting/reductionTesting2D/Main.C
@@ -24,7 +24,6 @@ Main::Main(CkArgMsg *m)
 	arrayDimensionY = atoi(m->argv[2]);
 	vectorSize = atoi(m->argv[3]);
 
-	delete m;
 	mainProxy = thisProxy;
 	mainhandle = thishandle;
 	testProxy2D = CProxy_Test2D::ckNew(arrayDimensionX, arrayDimensionY);

--- a/tests/charm++/reductionTesting/reductionTesting3D/Main.C
+++ b/tests/charm++/reductionTesting/reductionTesting3D/Main.C
@@ -26,7 +26,6 @@ Main::Main(CkArgMsg *m)
 	arrayDimensionZ = atoi(m->argv[3]);
 	vectorSize = atoi(m->argv[4]);
 
-	delete m;
 	mainProxy = thisProxy;
 	mainhandle = thishandle;
 	testProxy3D = CProxy_Test3D::ckNew(arrayDimensionX, arrayDimensionY, arrayDimensionZ);

--- a/tests/charm++/sdag/sdag_tests.C
+++ b/tests/charm++/sdag/sdag_tests.C
@@ -16,7 +16,6 @@
 class Main : public CBase_Main {
 public:
   Main(CkArgMsg* m) {
-    delete m;
     mainProxy = thisProxy;
     basicTestProxy = CProxy_BasicTest::ckNew(CkNumPes() - 1);
     refnumTestProxy = CProxy_RefnumTest::ckNew(REFNUM_ELEMS, REFNUM_ELEMS);

--- a/tests/charm++/simplearrayhello/hello.C
+++ b/tests/charm++/simplearrayhello/hello.C
@@ -15,7 +15,6 @@ public:
     //Process command-line arguments
     nElements=5;
     if(m->argc >1 ) nElements=atoi(m->argv[1]);
-    delete m;
 
     //Start the computation
     CkPrintf("Running Hello on %d processors for %d elements\n",

--- a/tests/charm++/within_node_bcast/within_node_bcast.C
+++ b/tests/charm++/within_node_bcast/within_node_bcast.C
@@ -22,8 +22,6 @@ private:
   int test_num;
 public:
   Main(CkArgMsg* msg) {
-    delete msg;
-
     ngProxy = CProxy_TestNodeGroup::ckNew();
     gProxy = CProxy_TestGroup::ckNew();
 

--- a/tests/charm++/zerocopy/bcast_nonzero_root/bcast_nonzero_root.C
+++ b/tests/charm++/zerocopy/bcast_nonzero_root/bcast_nonzero_root.C
@@ -16,8 +16,6 @@ class main : public CBase_main {
   int testIndex;
   public:
     main(CkArgMsg *m) {
-      delete m;
-
       // Create a chare array
       arrProxy = CProxy_arr::ckNew(CkNumPes() * NUM_ELEMENTS_PER_PE);
 

--- a/tests/charm++/zerocopy/dereg_and_nodereg/dereg_and_nodereg.C
+++ b/tests/charm++/zerocopy/dereg_and_nodereg/dereg_and_nodereg.C
@@ -22,7 +22,6 @@ class Main : public CBase_Main {
       if(numElements % 2 != 0) {
         CkAbort("<array size> argument is not even\n");
       }
-      delete m;
 
       testIndex = 0;
 

--- a/tests/charm++/zerocopy/direct_api/direct_api.C
+++ b/tests/charm++/zerocopy/direct_api/direct_api.C
@@ -20,7 +20,6 @@ class Main : public CBase_Main {
       if(numElements % 2 != 0) {
         CkAbort("<array size> argument is not even\n");
       }
-      delete m;
 
       mProxy = thisProxy;
 

--- a/tests/charm++/zerocopy/largedata/largedata.C
+++ b/tests/charm++/zerocopy/largedata/largedata.C
@@ -35,7 +35,6 @@ public:
       CmiAbort("Incorrect arguments\n");
     }
     CkPrintf("Large data transfer with payload: %zd iterations: %d\n", payload, iterations);
-    delete m;
 
     // Initialize
     niter = 0;

--- a/tests/charm++/zerocopy/zc_post_modify_size/zc_post_modify_size.C
+++ b/tests/charm++/zerocopy/zc_post_modify_size/zc_post_modify_size.C
@@ -16,8 +16,6 @@ void verifyValuesWithIndex(int *arr, int size, int startIndex);
 class main : public CBase_main {
   public:
     main(CkArgMsg *m) {
-      delete m;
-
       // Create a chare array
       arrProxy = CProxy_arr::ckNew(CkNumPes() * NUM_ELEMENTS_PER_PE);
 

--- a/tests/charm++/zerocopy/zerocopy_with_qd/zerocopy_with_qd.C
+++ b/tests/charm++/zerocopy/zerocopy_with_qd/zerocopy_with_qd.C
@@ -27,7 +27,6 @@ class Main : public CBase_Main {
       if(numElements % 2 != 0) {
         CkAbort("<array size> argument is not even\n");
       }
-      delete m;
 
       arr_size = 2000000;
       vec_size = 2000000;

--- a/tests/util/headerpad.C
+++ b/tests/util/headerpad.C
@@ -4,7 +4,6 @@
 #include "headerpad.h"
 /*readonly*/ CProxy_main mainProxy;
 main::main(CkArgMsg *m) {
-    delete m;
     mainProxy=thishandle;
     CmiPrintf("Info: converse header: %d envelope: %d\n", CmiReservedHeaderSize, sizeof(envelope));
     // make a message with 1 payload


### PR DESCRIPTION
This makes it consistent with the mainchares migration constructor, which also
uses the CkArgMsg, but the message is freed by the RTS. Other changes to make
the rest of the migration constructors follow this pattern will follow.