### PR TITLE
AMPI: debug API arguments

### DIFF
--- a/src/libs/ck-libs/ampi/ampi.C
+++ b/src/libs/ck-libs/ampi/ampi.C
@@ -4240,7 +4240,7 @@ int testRequestNoFree(ampiParent* pptr, MPI_Request *reqIdx, int *flag, MPI_Stat
 
 AMPI_API_IMPL(int, MPI_Is_thread_main, int *flag)
 {
-  AMPI_API_INIT("AMPI_Is_thread_main");
+  AMPI_API_INIT("AMPI_Is_thread_main", flag);
   if (isAmpiThread()) {
     *flag = 1;
   } else {
@@ -4251,7 +4251,7 @@ AMPI_API_IMPL(int, MPI_Is_thread_main, int *flag)
 
 AMPI_API_IMPL(int, MPI_Query_thread, int *provided)
 {
-  AMPI_API("AMPI_Query_thread");
+  AMPI_API("AMPI_Query_thread", provided);
   *provided = CkpvAccess(ampiThreadLevel);
   return MPI_SUCCESS;
 }
@@ -4259,7 +4259,7 @@ AMPI_API_IMPL(int, MPI_Query_thread, int *provided)
 AMPI_API_IMPL(int, MPI_Init_thread, int *p_argc, char*** p_argv, int required, int *provided)
 {
   if (nodeinit_has_been_called) {
-    AMPI_API_INIT("AMPI_Init_thread");
+    AMPI_API_INIT("AMPI_Init_thread", p_argc, p_argv, required, provided);
 
 #if AMPI_ERROR_CHECKING
     if (required < MPI_THREAD_SINGLE || required > MPI_THREAD_MULTIPLE) {
@@ -4288,7 +4288,7 @@ AMPI_API_IMPL(int, MPI_Init_thread, int *p_argc, char*** p_argv, int required, i
 AMPI_API_IMPL(int, MPI_Init, int *p_argc, char*** p_argv)
 {
   if (nodeinit_has_been_called) {
-    AMPI_API_INIT("AMPI_Init");
+    AMPI_API_INIT("AMPI_Init", p_argc, p_argv);
     char **argv;
     if (p_argv) argv=*p_argv;
     else argv=CkGetArgv();
@@ -4306,7 +4306,7 @@ AMPI_API_IMPL(int, MPI_Init, int *p_argc, char*** p_argv)
 AMPI_API_IMPL(int, MPI_Initialized, int *isInit)
 {
   if (nodeinit_has_been_called) {
-    AMPI_API_INIT("AMPI_Initialized");     /* in case charm init not called */
+    AMPI_API_INIT("AMPI_Initialized", isInit);     /* in case charm init not called */
     *isInit=CtvAccess(ampiInitDone);
   }
   else {
@@ -4317,14 +4317,14 @@ AMPI_API_IMPL(int, MPI_Initialized, int *isInit)
 
 AMPI_API_IMPL(int, MPI_Finalized, int *isFinalized)
 {
-  AMPI_API_INIT("AMPI_Finalized");     /* in case charm init not called */
+  AMPI_API_INIT("AMPI_Finalized", isFinalized);     /* in case charm init not called */
   *isFinalized=(CtvAccess(ampiFinalized)) ? 1 : 0;
   return MPI_SUCCESS;
 }
 
 AMPI_API_IMPL(int, MPI_Comm_rank, MPI_Comm comm, int *rank)
 {
-  AMPI_API("AMPI_Comm_rank");
+  AMPI_API("AMPI_Comm_rank", comm, rank);
 
 #if AMPI_ERROR_CHECKING
   int ret = checkCommunicator("AMPI_Comm_rank", comm);
@@ -4352,7 +4352,7 @@ AMPI_API_IMPL(int, MPI_Comm_rank, MPI_Comm comm, int *rank)
 
 AMPI_API_IMPL(int, MPI_Comm_size, MPI_Comm comm, int *size)
 {
-  AMPI_API("AMPI_Comm_size");
+  AMPI_API("AMPI_Comm_size", comm, size);
 
 #if AMPI_ERROR_CHECKING
   int ret = checkCommunicator("AMPI_Comm_size", comm);
@@ -4381,7 +4381,7 @@ AMPI_API_IMPL(int, MPI_Comm_size, MPI_Comm comm, int *size)
 
 AMPI_API_IMPL(int, MPI_Comm_compare, MPI_Comm comm1, MPI_Comm comm2, int *result)
 {
-  AMPI_API("AMPI_Comm_compare");
+  AMPI_API("AMPI_Comm_compare", comm1, comm2, result);
 
 #if AMPI_ERROR_CHECKING
   int ret;
@@ -4437,7 +4437,7 @@ void AMPI_Exit(int exitCode)
 {
   // If we are not actually running AMPI code (e.g., by compiling a serial
   // application with ampicc), exit cleanly when the application calls exit().
-  AMPI_API_INIT("AMPI_Exit");
+  AMPI_API_INIT("AMPI_Exit", exitCode);
   CkpvAccess(msgPool).clear();
 
   if (!atexit_called)
@@ -4455,7 +4455,7 @@ AMPI_API_IMPL(int, MPI_Finalize, void)
   { // This brace is necessary here to make sure the object created on the stack
     // by the AMPI_API call gets destroyed before the call to AMPI_Exit(), since
     // AMPI_Exit() never returns.
-  AMPI_API("AMPI_Finalize");
+  AMPI_API("AMPI_Finalize", "");
 
   ampiParent* parent = getAmpiParent();
   int ret;
@@ -4498,7 +4498,7 @@ MPI_Request ampi::postReq(AmpiRequest* newreq) noexcept
 AMPI_API_IMPL(int, MPI_Send, const void *buf, int count, MPI_Datatype type,
                              int dest, int tag, MPI_Comm comm)
 {
-  AMPI_API("AMPI_Send");
+  AMPI_API("AMPI_Send", buf, count, type, dest, tag, comm);
 
   handle_MPI_BOTTOM((void*&)buf, type);
 
@@ -4524,7 +4524,7 @@ AMPI_API_IMPL(int, MPI_Send, const void *buf, int count, MPI_Datatype type,
 AMPI_API_IMPL(int, MPI_Bsend, const void *buf, int count, MPI_Datatype datatype,
                               int dest, int tag, MPI_Comm comm)
 {
-  AMPI_API("AMPI_Bsend");
+  AMPI_API("AMPI_Bsend", buf, count, datatype, dest, tag, comm);
   // FIXME: we don't actually use the buffer set in MPI_Buffer_attach
   //        for buffering of messages sent via MPI_Bsend
   return MPI_Send(buf, count, datatype, dest, tag, comm);
@@ -4532,7 +4532,7 @@ AMPI_API_IMPL(int, MPI_Bsend, const void *buf, int count, MPI_Datatype datatype,
 
 AMPI_API_IMPL(int, MPI_Buffer_attach, void *buffer, int size)
 {
-  AMPI_API("AMPI_Buffer_attach");
+  AMPI_API("AMPI_Buffer_attach", buffer, size);
 #if AMPI_ERROR_CHECKING
   if (size < 0) {
     return ampiErrhandler("AMPI_Buffer_attach", MPI_ERR_ARG);
@@ -4547,7 +4547,7 @@ AMPI_API_IMPL(int, MPI_Buffer_attach, void *buffer, int size)
 
 AMPI_API_IMPL(int, MPI_Buffer_detach, void *buffer, int *size)
 {
-  AMPI_API("AMPI_Buffer_detach");
+  AMPI_API("AMPI_Buffer_detach", buffer, size);
   getAmpiParent()->detachBuffer(buffer, size);
   return MPI_SUCCESS;
 }
@@ -4556,14 +4556,14 @@ AMPI_API_IMPL(int, MPI_Rsend, const void *buf, int count, MPI_Datatype datatype,
                               int dest, int tag, MPI_Comm comm)
 {
   /* FIXME: MPI_Rsend can be posted only after recv */
-  AMPI_API("AMPI_Rsend");
+  AMPI_API("AMPI_Rsend", buf, count, datatype, dest, tag, comm);
   return MPI_Send(buf, count, datatype, dest, tag, comm);
 }
 
 AMPI_API_IMPL(int, MPI_Ssend, const void *buf, int count, MPI_Datatype type,
                               int dest, int tag, MPI_Comm comm)
 {
-  AMPI_API("AMPI_Ssend");
+  AMPI_API("AMPI_Ssend", buf, count, type, dest, tag, comm);
 
   handle_MPI_BOTTOM((void*&)buf, type);
 
@@ -4588,7 +4588,7 @@ AMPI_API_IMPL(int, MPI_Ssend, const void *buf, int count, MPI_Datatype type,
 AMPI_API_IMPL(int, MPI_Issend, const void *buf, int count, MPI_Datatype type, int dest,
                                int tag, MPI_Comm comm, MPI_Request *request)
 {
-  AMPI_API("AMPI_Issend");
+  AMPI_API("AMPI_Issend", buf, count, type, dest, tag, comm, request);
 
   handle_MPI_BOTTOM((void*&)buf, type);
 
@@ -4624,7 +4624,8 @@ AMPI_API_IMPL(int, MPI_Issend, const void *buf, int count, MPI_Datatype type, in
 AMPI_API_IMPL(int, MPI_Recv, void *buf, int count, MPI_Datatype type, int src, int tag,
                              MPI_Comm comm, MPI_Status *status)
 {
-  AMPI_API("AMPI_Recv");
+  AMPI_API("AMPI_Recv", buf, count, type, src, tag,
+                              comm, status);
 
   handle_MPI_BOTTOM(buf, type);
 
@@ -4661,7 +4662,7 @@ AMPI_API_IMPL(int, MPI_Recv, void *buf, int count, MPI_Datatype type, int src, i
 
 AMPI_API_IMPL(int, MPI_Probe, int src, int tag, MPI_Comm comm, MPI_Status *status)
 {
-  AMPI_API("AMPI_Probe");
+  AMPI_API("AMPI_Probe", src, tag, comm, status);
 
 #if AMPI_ERROR_CHECKING
   int ret = errorCheck("AMPI_Probe", comm, 1, 0, 0, 0, 0, tag, 1, src, 1, 0, 0);
@@ -4676,7 +4677,7 @@ AMPI_API_IMPL(int, MPI_Probe, int src, int tag, MPI_Comm comm, MPI_Status *statu
 
 AMPI_API_IMPL(int, MPI_Iprobe, int src, int tag, MPI_Comm comm, int *flag, MPI_Status *status)
 {
-  AMPI_API("AMPI_Iprobe");
+  AMPI_API("AMPI_Iprobe", src, tag, comm, flag, status);
 
 #if AMPI_ERROR_CHECKING
   int ret = errorCheck("AMPI_Iprobe", comm, 1, 0, 0, 0, 0, tag, 1, src, 1, 0, 0);
@@ -4692,7 +4693,7 @@ AMPI_API_IMPL(int, MPI_Iprobe, int src, int tag, MPI_Comm comm, int *flag, MPI_S
 AMPI_API_IMPL(int, MPI_Improbe, int source, int tag, MPI_Comm comm, int *flag,
                                 MPI_Message *message, MPI_Status *status)
 {
-  AMPI_API("AMPI_Improbe");
+  AMPI_API("AMPI_Improbe", source, tag, comm, flag, message, status);
 
 #if AMPI_ERROR_CHECKING
   int ret = errorCheck("AMPI_Improbe", comm, 1, 0, 0, 0, 0, tag, 1, source, 1, 0, 0);
@@ -4709,7 +4710,7 @@ AMPI_API_IMPL(int, MPI_Improbe, int source, int tag, MPI_Comm comm, int *flag,
 AMPI_API_IMPL(int, MPI_Imrecv, void* buf, int count, MPI_Datatype datatype, MPI_Message *message,
                                MPI_Request *request)
 {
-  AMPI_API("AMPI_Imrecv");
+  AMPI_API("AMPI_Imrecv", buf, count, datatype, message, request);
 
 #if AMPI_ERROR_CHECKING
   if (*message == MPI_MESSAGE_NULL) {
@@ -4757,7 +4758,7 @@ AMPI_API_IMPL(int, MPI_Imrecv, void* buf, int count, MPI_Datatype datatype, MPI_
 AMPI_API_IMPL(int, MPI_Mprobe, int source, int tag, MPI_Comm comm, MPI_Message *message,
                                MPI_Status *status)
 {
-  AMPI_API("AMPI_Mprobe");
+  AMPI_API("AMPI_Mprobe", source, tag, comm, message, status);
 
 #if AMPI_ERROR_CHECKING
   int ret = errorCheck("AMPI_Mprobe", comm, 1, 0, 0, 0, 0, tag, 1, source, 1, 0, 0);
@@ -4774,7 +4775,7 @@ AMPI_API_IMPL(int, MPI_Mprobe, int source, int tag, MPI_Comm comm, MPI_Message *
 AMPI_API_IMPL(int, MPI_Mrecv, void* buf, int count, MPI_Datatype datatype, MPI_Message *message,
                               MPI_Status *status)
 {
-  AMPI_API("AMPI_Mrecv");
+  AMPI_API("AMPI_Mrecv", buf, count, datatype, message, status);
 
 #if AMPI_ERROR_CHECKING
   if (*message == MPI_MESSAGE_NULL) {
@@ -4873,7 +4874,7 @@ AMPI_API_IMPL(int, MPI_Sendrecv, const void *sbuf, int scount, MPI_Datatype styp
                                  int stag, void *rbuf, int rcount, MPI_Datatype rtype,
                                  int src, int rtag, MPI_Comm comm, MPI_Status *sts)
 {
-  AMPI_API("AMPI_Sendrecv");
+  AMPI_API("AMPI_Sendrecv", sbuf, scount, stype, dest, stag, rbuf, rcount, rtype, src, rtag, comm, sts);
 
   handle_MPI_BOTTOM((void*&)sbuf, stype, rbuf, rtype);
 
@@ -4926,7 +4927,7 @@ AMPI_API_IMPL(int, MPI_Sendrecv_replace, void* buf, int count, MPI_Datatype data
                                          int dest, int sendtag, int source, int recvtag,
                                          MPI_Comm comm, MPI_Status *status)
 {
-  AMPI_API("AMPI_Sendrecv_replace");
+  AMPI_API("AMPI_Sendrecv_replace", buf, count, datatype, dest, sendtag, source, recvtag, comm, status);
 
   handle_MPI_BOTTOM(buf, datatype);
 
@@ -4993,7 +4994,7 @@ void ampi::barrierResult() noexcept
 
 AMPI_API_IMPL(int, MPI_Barrier, MPI_Comm comm)
 {
-  AMPI_API("AMPI_Barrier");
+  AMPI_API("AMPI_Barrier", comm);
 
 #if AMPI_ERROR_CHECKING
   int ret = checkCommunicator("AMPI_Barrier", comm);
@@ -5033,7 +5034,7 @@ void ampi::ibarrierResult() noexcept
 
 AMPI_API_IMPL(int, MPI_Ibarrier, MPI_Comm comm, MPI_Request *request)
 {
-  AMPI_API("AMPI_Ibarrier");
+  AMPI_API("AMPI_Ibarrier", comm, request);
 
 #if AMPI_ERROR_CHECKING
   int ret = checkCommunicator("AMPI_Ibarrier", comm);
@@ -5066,7 +5067,7 @@ AMPI_API_IMPL(int, MPI_Ibarrier, MPI_Comm comm, MPI_Request *request)
 
 AMPI_API_IMPL(int, MPI_Bcast, void *buf, int count, MPI_Datatype type, int root, MPI_Comm comm)
 {
-  AMPI_API("AMPI_Bcast");
+  AMPI_API("AMPI_Bcast", buf, count, type, root, comm);
 
   handle_MPI_BOTTOM(buf, type);
 
@@ -5116,7 +5117,7 @@ AMPI_API_IMPL(int, MPI_Bcast, void *buf, int count, MPI_Datatype type, int root,
 AMPI_API_IMPL(int, MPI_Ibcast, void *buf, int count, MPI_Datatype type, int root,
                                MPI_Comm comm, MPI_Request *request)
 {
-  AMPI_API("AMPI_Ibcast");
+  AMPI_API("AMPI_Ibcast", buf, count, type, root, comm, request);
 
   handle_MPI_BOTTOM(buf, type);
 
@@ -5396,7 +5397,7 @@ static void handle_MPI_IN_PLACE_alltoallw(void* &sendbuf, void* recvbuf, int* &s
 AMPI_API_IMPL(int, MPI_Reduce, const void *inbuf, void *outbuf, int count, MPI_Datatype type,
                                MPI_Op op, int root, MPI_Comm comm)
 {
-  AMPI_API("AMPI_Reduce");
+  AMPI_API("AMPI_Reduce", inbuf, outbuf, count, type, op, root, comm);
 
   handle_MPI_BOTTOM((void*&)inbuf, type, outbuf, type);
   handle_MPI_IN_PLACE((void*&)inbuf, outbuf);
@@ -5469,7 +5470,7 @@ AMPI_API_IMPL(int, MPI_Reduce, const void *inbuf, void *outbuf, int count, MPI_D
 AMPI_API_IMPL(int, MPI_Allreduce, const void *inbuf, void *outbuf, int count, MPI_Datatype type,
                                   MPI_Op op, MPI_Comm comm)
 {
-  AMPI_API("AMPI_Allreduce");
+  AMPI_API("AMPI_Allreduce", inbuf, outbuf, count, type, op, comm);
 
   handle_MPI_BOTTOM((void*&)inbuf, type, outbuf, type);
   handle_MPI_IN_PLACE((void*&)inbuf, outbuf);
@@ -5530,7 +5531,7 @@ AMPI_API_IMPL(int, MPI_Allreduce, const void *inbuf, void *outbuf, int count, MP
 AMPI_API_IMPL(int, MPI_Iallreduce, const void *inbuf, void *outbuf, int count, MPI_Datatype type,
                                    MPI_Op op, MPI_Comm comm, MPI_Request* request)
 {
-  AMPI_API("AMPI_Iallreduce");
+  AMPI_API("AMPI_Iallreduce", inbuf, outbuf, count, type, op, comm, request);
 
   handle_MPI_BOTTOM((void*&)inbuf, type, outbuf, type);
   handle_MPI_IN_PLACE((void*&)inbuf, outbuf);
@@ -5569,7 +5570,7 @@ AMPI_API_IMPL(int, MPI_Iallreduce, const void *inbuf, void *outbuf, int count, M
 AMPI_API_IMPL(int, MPI_Reduce_local, const void *inbuf, void *outbuf, int count,
                                      MPI_Datatype type, MPI_Op op)
 {
-  AMPI_API("AMPI_Reduce_local");
+  AMPI_API("AMPI_Reduce_local", inbuf, outbuf, count, type, op);
 
   handle_MPI_BOTTOM((void*&)inbuf, type, outbuf, type);
 
@@ -5590,7 +5591,7 @@ AMPI_API_IMPL(int, MPI_Reduce_local, const void *inbuf, void *outbuf, int count,
 AMPI_API_IMPL(int, MPI_Reduce_scatter_block, const void* sendbuf, void* recvbuf, int count,
                                              MPI_Datatype datatype, MPI_Op op, MPI_Comm comm)
 {
-  AMPI_API("AMPI_Reduce_scatter_block");
+  AMPI_API("AMPI_Reduce_scatter_block", sendbuf, recvbuf, count, datatype, op, comm);
 
   handle_MPI_BOTTOM((void*&)sendbuf, datatype, recvbuf, datatype);
   handle_MPI_IN_PLACE((void*&)sendbuf, recvbuf);
@@ -5623,7 +5624,7 @@ AMPI_API_IMPL(int, MPI_Ireduce_scatter_block, const void* sendbuf, void* recvbuf
                                               MPI_Datatype datatype, MPI_Op op, MPI_Comm comm,
                                               MPI_Request* request)
 {
-  AMPI_API("AMPI_Ireduce_scatter_block");
+  AMPI_API("AMPI_Ireduce_scatter_block", sendbuf, recvbuf, count, datatype, op, comm, request);
   // FIXME: implement non-blocking reduce_scatter_block
   int ret = MPI_Reduce_scatter_block(sendbuf, recvbuf, count, datatype, op, comm);
   *request = MPI_REQUEST_NULL;
@@ -5633,7 +5634,7 @@ AMPI_API_IMPL(int, MPI_Ireduce_scatter_block, const void* sendbuf, void* recvbuf
 AMPI_API_IMPL(int, MPI_Reduce_scatter, const void* sendbuf, void* recvbuf, const int *recvcounts,
                                        MPI_Datatype datatype, MPI_Op op, MPI_Comm comm)
 {
-  AMPI_API("AMPI_Reduce_scatter");
+  AMPI_API("AMPI_Reduce_scatter", sendbuf, recvbuf, recvcounts, datatype, op, comm);
 
   handle_MPI_BOTTOM((void*&)sendbuf, datatype, recvbuf, datatype);
   handle_MPI_IN_PLACE((void*&)sendbuf, recvbuf);
@@ -5673,7 +5674,7 @@ AMPI_API_IMPL(int, MPI_Reduce_scatter, const void* sendbuf, void* recvbuf, const
 AMPI_API_IMPL(int, MPI_Ireduce_scatter, const void* sendbuf, void* recvbuf, const int *recvcounts,
                                         MPI_Datatype datatype, MPI_Op op, MPI_Comm comm, MPI_Request* request)
 {
-  AMPI_API("AMPI_Ireduce_scatter");
+  AMPI_API("AMPI_Ireduce_scatter", sendbuf, recvbuf, recvcounts, datatype, op, comm, request);
   // FIXME: implement non-blocking reduce_scatter
   int ret = MPI_Reduce_scatter(sendbuf, recvbuf, recvcounts, datatype, op, comm);
   *request = MPI_REQUEST_NULL;
@@ -5683,7 +5684,7 @@ AMPI_API_IMPL(int, MPI_Ireduce_scatter, const void* sendbuf, void* recvbuf, cons
 AMPI_API_IMPL(int, MPI_Scan, const void* sendbuf, void* recvbuf, int count, MPI_Datatype datatype,
                              MPI_Op op, MPI_Comm comm)
 {
-  AMPI_API("AMPI_Scan");
+  AMPI_API("AMPI_Scan", sendbuf, recvbuf, count, datatype, op, comm);
 
   handle_MPI_BOTTOM((void*&)sendbuf, datatype, recvbuf, datatype);
   handle_MPI_IN_PLACE((void*&)sendbuf,recvbuf);
@@ -5733,7 +5734,7 @@ AMPI_API_IMPL(int, MPI_Scan, const void* sendbuf, void* recvbuf, int count, MPI_
 AMPI_API_IMPL(int, MPI_Iscan, const void* sendbuf, void* recvbuf, int count, MPI_Datatype datatype,
                               MPI_Op op, MPI_Comm comm, MPI_Request* request)
 {
-  AMPI_API("AMPI_Iscan");
+  AMPI_API("AMPI_Iscan", sendbuf, recvbuf, count, datatype, op, comm, request);
   // FIXME: implement non-blocking scan
   int ret = MPI_Scan(sendbuf, recvbuf, count, datatype, op, comm);
   *request = MPI_REQUEST_NULL;
@@ -5743,7 +5744,7 @@ AMPI_API_IMPL(int, MPI_Iscan, const void* sendbuf, void* recvbuf, int count, MPI
 AMPI_API_IMPL(int, MPI_Exscan, const void* sendbuf, void* recvbuf, int count, MPI_Datatype datatype,
                                MPI_Op op, MPI_Comm comm)
 {
-  AMPI_API("AMPI_Exscan");
+  AMPI_API("AMPI_Exscan", sendbuf, recvbuf, count, datatype, op, comm);
 
   handle_MPI_BOTTOM((void*&)sendbuf, datatype, recvbuf, datatype);
   handle_MPI_IN_PLACE((void*&)sendbuf,recvbuf);
@@ -5804,7 +5805,7 @@ AMPI_API_IMPL(int, MPI_Exscan, const void* sendbuf, void* recvbuf, int count, MP
 AMPI_API_IMPL(int, MPI_Iexscan, const void* sendbuf, void* recvbuf, int count, MPI_Datatype datatype,
                                 MPI_Op op, MPI_Comm comm, MPI_Request* request)
 {
-  AMPI_API("AMPI_Iexscan");
+  AMPI_API("AMPI_Iexscan", sendbuf, recvbuf, count, datatype, op, comm, request);
   // FIXME: implement non-blocking exscan
   int ret = MPI_Exscan(sendbuf, recvbuf, count, datatype, op, comm);
   *request = MPI_REQUEST_NULL;
@@ -5813,14 +5814,14 @@ AMPI_API_IMPL(int, MPI_Iexscan, const void* sendbuf, void* recvbuf, int count, M
 
 AMPI_API_IMPL(int, MPI_Op_create, MPI_User_function *function, int commute, MPI_Op *op)
 {
-  AMPI_API("AMPI_Op_create");
+  AMPI_API("AMPI_Op_create", function, commute, op);
   *op = getAmpiParent()->createOp(function, commute);
   return MPI_SUCCESS;
 }
 
 AMPI_API_IMPL(int, MPI_Op_free, MPI_Op *op)
 {
-  AMPI_API("AMPI_Op_free");
+  AMPI_API("AMPI_Op_free", op);
   getAmpiParent()->freeOp(*op);
   *op = MPI_OP_NULL;
   return MPI_SUCCESS;
@@ -5828,7 +5829,7 @@ AMPI_API_IMPL(int, MPI_Op_free, MPI_Op *op)
 
 AMPI_API_IMPL(int, MPI_Op_commutative, MPI_Op op, int *commute)
 {
-  AMPI_API("AMPI_Op_commutative");
+  AMPI_API("AMPI_Op_commutative", op, commute);
   if (op == MPI_OP_NULL)
     return ampiErrhandler("AMPI_Op_commutative", MPI_ERR_OP);
   *commute = (int)getAmpiParent()->opIsCommutative(op);
@@ -5867,7 +5868,7 @@ AMPI_API_IMPL(double, MPI_Wtick, void)
 
 AMPI_API_IMPL(int, MPI_Start, MPI_Request *request)
 {
-  AMPI_API("AMPI_Start");
+  AMPI_API("AMPI_Start", request);
   checkRequest(*request);
   AmpiRequestList& reqs = getReqs();
 #if AMPI_ERROR_CHECKING
@@ -5880,7 +5881,7 @@ AMPI_API_IMPL(int, MPI_Start, MPI_Request *request)
 
 AMPI_API_IMPL(int, MPI_Startall, int count, MPI_Request *requests)
 {
-  AMPI_API("AMPI_Startall");
+  AMPI_API("AMPI_Startall", count, requests);
   checkRequests(count,requests);
   AmpiRequestList& reqs = getReqs();
   for(int i=0;i<count;i++){
@@ -6133,7 +6134,7 @@ CMI_WARN_UNUSED_RESULT ampiParent* GReq::wait(ampiParent* parent, MPI_Status *st
 
 AMPI_API_IMPL(int, MPI_Wait, MPI_Request *request, MPI_Status *sts)
 {
-  AMPI_API("AMPI_Wait");
+  AMPI_API("AMPI_Wait", request, sts);
   ampiParent* unused = getAmpiParent()->wait(request, sts);
   return MPI_SUCCESS;
 }
@@ -6295,7 +6296,7 @@ CMI_WARN_UNUSED_RESULT ampiParent* ampiParent::waitall(int count, MPI_Request re
 
 AMPI_API_IMPL(int, MPI_Waitall, int count, MPI_Request request[], MPI_Status sts[])
 {
-  AMPI_API("AMPI_Waitall");
+  AMPI_API("AMPI_Waitall", count, request, sts);
   checkRequests(count, request);
   ampiParent* unused = getAmpiParent()->waitall(count, request, sts);
   return MPI_SUCCESS;
@@ -6303,7 +6304,7 @@ AMPI_API_IMPL(int, MPI_Waitall, int count, MPI_Request request[], MPI_Status sts
 
 AMPI_API_IMPL(int, MPI_Waitany, int count, MPI_Request *request, int *idx, MPI_Status *sts)
 {
-  AMPI_API("AMPI_Waitany");
+  AMPI_API("AMPI_Waitany", count, request, idx, sts);
 
   checkRequests(count, request);
   if (count == 0) {
@@ -6372,7 +6373,7 @@ AMPI_API_IMPL(int, MPI_Waitany, int count, MPI_Request *request, int *idx, MPI_S
 AMPI_API_IMPL(int, MPI_Waitsome, int incount, MPI_Request *array_of_requests, int *outcount,
                                  int *array_of_indices, MPI_Status *array_of_statuses)
 {
-  AMPI_API("AMPI_Waitsome");
+  AMPI_API("AMPI_Waitsome", incount, array_of_requests, outcount, array_of_indices, array_of_statuses);
 
   checkRequests(incount, array_of_requests);
   if (incount == 0) {
@@ -6596,7 +6597,7 @@ void GathervReq::receive(ampi *ptr, CkReductionMsg *msg) noexcept
 
 AMPI_API_IMPL(int, MPI_Request_get_status, MPI_Request request, int *flag, MPI_Status *sts)
 {
-  AMPI_API("AMPI_Request_get_status");
+  AMPI_API("AMPI_Request_get_status", request, flag, sts);
   ampiParent* pptr = getAmpiParent();
   testRequestNoFree(pptr, &request, flag, sts);
   if(*flag != 1)
@@ -6606,7 +6607,7 @@ AMPI_API_IMPL(int, MPI_Request_get_status, MPI_Request request, int *flag, MPI_S
 
 AMPI_API_IMPL(int, MPI_Test, MPI_Request *request, int *flag, MPI_Status *sts)
 {
-  AMPI_API("AMPI_Test");
+  AMPI_API("AMPI_Test", request, flag, sts);
   ampiParent* pptr = getAmpiParent();
   testRequest(pptr, request, flag, sts);
   if(*flag != 1)
@@ -6616,7 +6617,7 @@ AMPI_API_IMPL(int, MPI_Test, MPI_Request *request, int *flag, MPI_Status *sts)
 
 AMPI_API_IMPL(int, MPI_Testany, int count, MPI_Request *request, int *index, int *flag, MPI_Status *sts)
 {
-  AMPI_API("AMPI_Testany");
+  AMPI_API("AMPI_Testany", count, request, index, flag, sts);
 
   checkRequests(count, request);
 
@@ -6657,7 +6658,7 @@ AMPI_API_IMPL(int, MPI_Testany, int count, MPI_Request *request, int *index, int
 
 AMPI_API_IMPL(int, MPI_Testall, int count, MPI_Request *request, int *flag, MPI_Status *sts)
 {
-  AMPI_API("AMPI_Testall");
+  AMPI_API("AMPI_Testall", count, request, flag, sts);
 
   checkRequests(count, request);
   if (count == 0) {
@@ -6700,7 +6701,7 @@ AMPI_API_IMPL(int, MPI_Testall, int count, MPI_Request *request, int *flag, MPI_
 AMPI_API_IMPL(int, MPI_Testsome, int incount, MPI_Request *array_of_requests, int *outcount,
                                  int *array_of_indices, MPI_Status *array_of_statuses)
 {
-  AMPI_API("AMPI_Testsome");
+  AMPI_API("AMPI_Testsome", incount, array_of_requests, outcount, array_of_indices, array_of_statuses);
 
   checkRequests(incount, array_of_requests);
   if (incount == 0) {
@@ -6740,7 +6741,7 @@ AMPI_API_IMPL(int, MPI_Testsome, int incount, MPI_Request *array_of_requests, in
 
 AMPI_API_IMPL(int, MPI_Request_free, MPI_Request *request)
 {
-  AMPI_API("AMPI_Request_free");
+  AMPI_API("AMPI_Request_free", request);
   if(*request==MPI_REQUEST_NULL) return MPI_SUCCESS;
   checkRequest(*request);
   ampiParent* pptr = getAmpiParent();
@@ -6753,7 +6754,7 @@ AMPI_API_IMPL(int, MPI_Request_free, MPI_Request *request)
 AMPI_API_IMPL(int, MPI_Grequest_start, MPI_Grequest_query_function *query_fn, MPI_Grequest_free_function *free_fn,
                                        MPI_Grequest_cancel_function *cancel_fn, void *extra_state, MPI_Request *request)
 {
-  AMPI_API("AMPI_Grequest_start");
+  AMPI_API("AMPI_Grequest_start", query_fn, free_fn, cancel_fn, extra_state, request);
 
   ampi* ptr = getAmpiInstance(MPI_COMM_SELF); // All GReq's are posted to MPI_COMM_SELF
   GReq *newreq = new GReq(query_fn, free_fn, cancel_fn, extra_state);
@@ -6764,7 +6765,7 @@ AMPI_API_IMPL(int, MPI_Grequest_start, MPI_Grequest_query_function *query_fn, MP
 
 AMPI_API_IMPL(int, MPI_Grequest_complete, MPI_Request request)
 {
-  AMPI_API("AMPI_Grequest_complete");
+  AMPI_API("AMPI_Grequest_complete", request);
 
 #if AMPI_ERROR_CHECKING
   if (request == MPI_REQUEST_NULL) {
@@ -6784,7 +6785,7 @@ AMPI_API_IMPL(int, MPI_Grequest_complete, MPI_Request request)
 
 AMPI_API_IMPL(int, MPI_Cancel, MPI_Request *request)
 {
-  AMPI_API("AMPI_Cancel");
+  AMPI_API("AMPI_Cancel", request);
   if(*request == MPI_REQUEST_NULL) return MPI_SUCCESS;
   checkRequest(*request);
   AmpiRequestList& reqs = getReqs();
@@ -6800,7 +6801,7 @@ AMPI_API_IMPL(int, MPI_Cancel, MPI_Request *request)
 
 AMPI_API_IMPL(int, MPI_Test_cancelled, const MPI_Status* status, int* flag)
 {
-  AMPI_API("AMPI_Test_cancelled");
+  AMPI_API("AMPI_Test_cancelled", status, flag);
   // NOTE : current implementation requires AMPI_{Wait,Test}{any,some,all}
   // to be invoked before AMPI_Test_cancelled
   *flag = status->MPI_CANCEL;
@@ -6809,14 +6810,14 @@ AMPI_API_IMPL(int, MPI_Test_cancelled, const MPI_Status* status, int* flag)
 
 AMPI_API_IMPL(int, MPI_Status_set_cancelled, MPI_Status *status, int flag)
 {
-  AMPI_API("AMPI_Status_set_cancelled");
+  AMPI_API("AMPI_Status_set_cancelled", status, flag);
   status->MPI_CANCEL = flag;
   return MPI_SUCCESS;
 }
 
 AMPI_API_IMPL(int, MPI_Status_c2f, const MPI_Status *c_status, MPI_Fint *f_status)
 {
-  AMPI_API("AMPI_Status_c2f");
+  AMPI_API("AMPI_Status_c2f", c_status, f_status);
   if (c_status == MPI_STATUS_IGNORE || c_status == MPI_STATUSES_IGNORE) {
     return MPI_ERR_OTHER;
   }
@@ -6827,7 +6828,7 @@ AMPI_API_IMPL(int, MPI_Status_c2f, const MPI_Status *c_status, MPI_Fint *f_statu
 
 AMPI_API_IMPL(int, MPI_Status_f2c, const MPI_Fint *f_status, MPI_Status *c_status)
 {
-  AMPI_API("AMPI_Status_f2c");
+  AMPI_API("AMPI_Status_f2c", f_status, c_status);
   // FIXME: Currently, AMPI does not have MPI_F_STATUS_IGNORE or MPI_F_STATUSES_IGNORE
   /* if (f_status == MPI_F_STATUS_IGNORE || c_status == MPI_F_STATUSES_IGNORE) {
     return MPI_ERR_OTHER;
@@ -6840,7 +6841,7 @@ AMPI_API_IMPL(int, MPI_Status_f2c, const MPI_Fint *f_status, MPI_Status *c_statu
 AMPI_API_IMPL(int, MPI_Recv_init, void *buf, int count, MPI_Datatype type, int src,
                                   int tag, MPI_Comm comm, MPI_Request *req)
 {
-  AMPI_API("AMPI_Recv_init");
+  AMPI_API("AMPI_Recv_init", buf, count, type, src, tag, comm, req);
 
   handle_MPI_BOTTOM(buf, type);
 
@@ -6861,7 +6862,7 @@ AMPI_API_IMPL(int, MPI_Recv_init, void *buf, int count, MPI_Datatype type, int s
 AMPI_API_IMPL(int, MPI_Send_init, const void *buf, int count, MPI_Datatype type, int dest,
                                   int tag, MPI_Comm comm, MPI_Request *req)
 {
-  AMPI_API("AMPI_Send_init");
+  AMPI_API("AMPI_Send_init", buf, count, type, dest, tag, comm, req);
 
   handle_MPI_BOTTOM((void*&)buf, type);
 
@@ -6882,21 +6883,21 @@ AMPI_API_IMPL(int, MPI_Send_init, const void *buf, int count, MPI_Datatype type,
 AMPI_API_IMPL(int, MPI_Rsend_init, const void *buf, int count, MPI_Datatype type, int dest,
                                    int tag, MPI_Comm comm, MPI_Request *req)
 {
-  AMPI_API("AMPI_Rsend_init");
+  AMPI_API("AMPI_Rsend_init", buf, count, type, dest, tag, comm, req);
   return MPI_Send_init(buf, count, type, dest, tag, comm, req);
 }
 
 AMPI_API_IMPL(int, MPI_Bsend_init, const void *buf, int count, MPI_Datatype type, int dest,
                                    int tag, MPI_Comm comm, MPI_Request *req)
 {
-  AMPI_API("AMPI_Bsend_init");
+  AMPI_API("AMPI_Bsend_init", buf, count, type, dest, tag, comm, req);
   return MPI_Send_init(buf, count, type, dest, tag, comm, req);
 }
 
 AMPI_API_IMPL(int, MPI_Ssend_init, const void *buf, int count, MPI_Datatype type, int dest,
                                    int tag, MPI_Comm comm, MPI_Request *req)
 {
-  AMPI_API("AMPI_Ssend_init");
+  AMPI_API("AMPI_Ssend_init", buf, count, type, dest, tag, comm, req);
 
   handle_MPI_BOTTOM((void*&)buf, type);
 
@@ -6917,7 +6918,7 @@ AMPI_API_IMPL(int, MPI_Ssend_init, const void *buf, int count, MPI_Datatype type
 
 AMPI_API_IMPL(int, MPI_Type_contiguous, int count, MPI_Datatype oldtype, MPI_Datatype *newtype)
 {
-  AMPI_API("AMPI_Type_contiguous");
+  AMPI_API("AMPI_Type_contiguous", count, oldtype, newtype);
 
 #if AMPI_ERROR_CHECKING
   int ret = checkData("MPI_Type_contiguous", oldtype);
@@ -6932,7 +6933,7 @@ AMPI_API_IMPL(int, MPI_Type_contiguous, int count, MPI_Datatype oldtype, MPI_Dat
 AMPI_API_IMPL(int, MPI_Type_vector, int count, int blocklength, int stride,
                                     MPI_Datatype oldtype, MPI_Datatype* newtype)
 {
-  AMPI_API("AMPI_Type_vector");
+  AMPI_API("AMPI_Type_vector", count, blocklength, stride, oldtype, newtype);
 
 #if AMPI_ERROR_CHECKING
   int ret = checkData("AMPI_Type_vector", oldtype);
@@ -6947,7 +6948,7 @@ AMPI_API_IMPL(int, MPI_Type_vector, int count, int blocklength, int stride,
 AMPI_API_IMPL(int, MPI_Type_create_hvector, int count, int blocklength, MPI_Aint stride,
                                             MPI_Datatype oldtype, MPI_Datatype* newtype)
 {
-  AMPI_API("AMPI_Type_create_hvector");
+  AMPI_API("AMPI_Type_create_hvector", count, blocklength, stride, oldtype, newtype);
 
 #if AMPI_ERROR_CHECKING
   int ret = checkData("AMPI_Type_create_hvector", oldtype);
@@ -6962,7 +6963,7 @@ AMPI_API_IMPL(int, MPI_Type_create_hvector, int count, int blocklength, MPI_Aint
 AMPI_API_IMPL(int, MPI_Type_hvector, int count, int blocklength, MPI_Aint stride,
                                      MPI_Datatype oldtype, MPI_Datatype* newtype)
 {
-  AMPI_API("AMPI_Type_hvector");
+  AMPI_API("AMPI_Type_hvector", count, blocklength, stride, oldtype, newtype);
 
 #if AMPI_ERROR_CHECKING
   int ret = checkData("AMPI_Type_hvector", oldtype);
@@ -6976,7 +6977,7 @@ AMPI_API_IMPL(int, MPI_Type_hvector, int count, int blocklength, MPI_Aint stride
 AMPI_API_IMPL(int, MPI_Type_indexed, int count, const int* arrBlength, const int* arrDisp,
                                      MPI_Datatype oldtype, MPI_Datatype* newtype)
 {
-  AMPI_API("AMPI_Type_indexed");
+  AMPI_API("AMPI_Type_indexed", count, arrBlength, arrDisp, oldtype, newtype);
 
 #if AMPI_ERROR_CHECKING
   int ret = checkData("AMPI_Type_indexed", oldtype);
@@ -6995,7 +6996,7 @@ AMPI_API_IMPL(int, MPI_Type_indexed, int count, const int* arrBlength, const int
 AMPI_API_IMPL(int, MPI_Type_create_hindexed, int count, const int* arrBlength, const MPI_Aint* arrDisp,
                                              MPI_Datatype oldtype, MPI_Datatype* newtype)
 {
-  AMPI_API("AMPI_Type_create_hindexed");
+  AMPI_API("AMPI_Type_create_hindexed", count, arrBlength, arrDisp, oldtype, newtype);
 
 #if AMPI_ERROR_CHECKING
   int ret = checkData("AMPI_Type_create_hindexed", oldtype);
@@ -7010,7 +7011,7 @@ AMPI_API_IMPL(int, MPI_Type_create_hindexed, int count, const int* arrBlength, c
 AMPI_API_IMPL(int, MPI_Type_hindexed, int count, int* arrBlength, MPI_Aint* arrDisp,
                                       MPI_Datatype oldtype, MPI_Datatype* newtype)
 {
-  AMPI_API("AMPI_Type_hindexed");
+  AMPI_API("AMPI_Type_hindexed", count, arrBlength, arrDisp, oldtype, newtype);
 
 #if AMPI_ERROR_CHECKING
   int ret = checkData("AMPI_Type_hindexed", oldtype);
@@ -7024,7 +7025,7 @@ AMPI_API_IMPL(int, MPI_Type_hindexed, int count, int* arrBlength, MPI_Aint* arrD
 AMPI_API_IMPL(int, MPI_Type_create_indexed_block, int count, int Blength, const int *arr,
                                                   MPI_Datatype oldtype, MPI_Datatype *newtype)
 {
-  AMPI_API("AMPI_Type_create_indexed_block");
+  AMPI_API("AMPI_Type_create_indexed_block", count, Blength, arr, oldtype, newtype);
 
 #if AMPI_ERROR_CHECKING
   int ret = checkData("AMPI_Type_create_indexed_block", oldtype);
@@ -7039,7 +7040,7 @@ AMPI_API_IMPL(int, MPI_Type_create_indexed_block, int count, int Blength, const 
 AMPI_API_IMPL(int, MPI_Type_create_hindexed_block, int count, int Blength, const MPI_Aint *arr,
                                                    MPI_Datatype oldtype, MPI_Datatype *newtype)
 {
-  AMPI_API("AMPI_Type_create_hindexed_block");
+  AMPI_API("AMPI_Type_create_hindexed_block", count, Blength, arr, oldtype, newtype);
 
 #if AMPI_ERROR_CHECKING
   int ret = checkData("AMPI_Type_create_hindexed_block", oldtype);
@@ -7054,7 +7055,7 @@ AMPI_API_IMPL(int, MPI_Type_create_hindexed_block, int count, int Blength, const
 AMPI_API_IMPL(int, MPI_Type_create_struct, int count, const int* arrBlength, const MPI_Aint* arrDisp,
                                            const MPI_Datatype* oldtype, MPI_Datatype*  newtype)
 {
-  AMPI_API("AMPI_Type_create_struct");
+  AMPI_API("AMPI_Type_create_struct", count, arrBlength, arrDisp, oldtype, newtype);
   getDDT()->newStruct(count, arrBlength, arrDisp, oldtype, newtype);
   return MPI_SUCCESS;
 }
@@ -7062,13 +7063,13 @@ AMPI_API_IMPL(int, MPI_Type_create_struct, int count, const int* arrBlength, con
 AMPI_API_IMPL(int, MPI_Type_struct, int count, int* arrBlength, MPI_Aint* arrDisp,
                                     MPI_Datatype* oldtype, MPI_Datatype* newtype)
 {
-  AMPI_API("AMPI_Type_struct");
+  AMPI_API("AMPI_Type_struct", count, arrBlength, arrDisp, oldtype, newtype);
   return MPI_Type_create_struct(count, arrBlength, arrDisp, oldtype, newtype);
 }
 
 AMPI_API_IMPL(int, MPI_Type_commit, MPI_Datatype *datatype)
 {
-  AMPI_API("AMPI_Type_commit");
+  AMPI_API("AMPI_Type_commit", datatype);
 
 #if AMPI_ERROR_CHECKING
   int ret = checkData("MPI_Type_commit", *datatype);
@@ -7081,7 +7082,7 @@ AMPI_API_IMPL(int, MPI_Type_commit, MPI_Datatype *datatype)
 
 AMPI_API_IMPL(int, MPI_Type_free, MPI_Datatype *datatype)
 {
-  AMPI_API("AMPI_Type_free");
+  AMPI_API("AMPI_Type_free", datatype);
 
   int ret;
 
@@ -7110,7 +7111,7 @@ AMPI_API_IMPL(int, MPI_Type_free, MPI_Datatype *datatype)
 
 AMPI_API_IMPL(int, MPI_Type_get_extent, MPI_Datatype datatype, MPI_Aint *lb, MPI_Aint *extent)
 {
-  AMPI_API("AMPI_Type_get_extent");
+  AMPI_API("AMPI_Type_get_extent", datatype, lb, extent);
 
 #if AMPI_ERROR_CHECKING
   int ret = checkData("AMPI_Type_get_extent", datatype);
@@ -7125,7 +7126,7 @@ AMPI_API_IMPL(int, MPI_Type_get_extent, MPI_Datatype datatype, MPI_Aint *lb, MPI
 
 AMPI_API_IMPL(int, MPI_Type_get_extent_x, MPI_Datatype datatype, MPI_Count *lb, MPI_Count *extent)
 {
-  AMPI_API("AMPI_Type_get_extent_x");
+  AMPI_API("AMPI_Type_get_extent_x", datatype, lb, extent);
 
 #if AMPI_ERROR_CHECKING
   int ret = checkData("AMPI_Type_get_extent_x", datatype);
@@ -7140,7 +7141,7 @@ AMPI_API_IMPL(int, MPI_Type_get_extent_x, MPI_Datatype datatype, MPI_Count *lb, 
 
 AMPI_API_IMPL(int, MPI_Type_extent, MPI_Datatype datatype, MPI_Aint *extent)
 {
-  AMPI_API("AMPI_Type_extent");
+  AMPI_API("AMPI_Type_extent", datatype, extent);
 
 #if AMPI_ERROR_CHECKING
   int ret = checkData("AMPI_Type_extent", datatype);
@@ -7154,7 +7155,7 @@ AMPI_API_IMPL(int, MPI_Type_extent, MPI_Datatype datatype, MPI_Aint *extent)
 
 AMPI_API_IMPL(int, MPI_Type_get_true_extent, MPI_Datatype datatype, MPI_Aint *true_lb, MPI_Aint *true_extent)
 {
-  AMPI_API("AMPI_Type_get_true_extent");
+  AMPI_API("AMPI_Type_get_true_extent", datatype, true_lb, true_extent);
 
 #if AMPI_ERROR_CHECKING
   int ret = checkData("AMPI_Type_get_true_extent", datatype);
@@ -7169,7 +7170,7 @@ AMPI_API_IMPL(int, MPI_Type_get_true_extent, MPI_Datatype datatype, MPI_Aint *tr
 
 AMPI_API_IMPL(int, MPI_Type_get_true_extent_x, MPI_Datatype datatype, MPI_Count *true_lb, MPI_Count *true_extent)
 {
-  AMPI_API("AMPI_Type_get_true_extent_x");
+  AMPI_API("AMPI_Type_get_true_extent_x", datatype, true_lb, true_extent);
 
 #if AMPI_ERROR_CHECKING
   int ret = checkData("AMPI_Type_get_true_extent_x", datatype);
@@ -7184,7 +7185,7 @@ AMPI_API_IMPL(int, MPI_Type_get_true_extent_x, MPI_Datatype datatype, MPI_Count 
 
 AMPI_API_IMPL(int, MPI_Type_size, MPI_Datatype datatype, int *size)
 {
-  AMPI_API("AMPI_Type_size");
+  AMPI_API("AMPI_Type_size", datatype, size);
 
 #if AMPI_ERROR_CHECKING
   int ret = checkData("AMPI_Type_size", datatype);
@@ -7198,7 +7199,7 @@ AMPI_API_IMPL(int, MPI_Type_size, MPI_Datatype datatype, int *size)
 
 AMPI_API_IMPL(int, MPI_Type_size_x, MPI_Datatype datatype, MPI_Count *size)
 {
-  AMPI_API("AMPI_Type_size_x");
+  AMPI_API("AMPI_Type_size_x", datatype, size);
 
 #if AMPI_ERROR_CHECKING
   int ret = checkData("AMPI_Type_size_x", datatype);
@@ -7212,7 +7213,7 @@ AMPI_API_IMPL(int, MPI_Type_size_x, MPI_Datatype datatype, MPI_Count *size)
 
 AMPI_API_IMPL(int, MPI_Type_set_name, MPI_Datatype datatype, const char *name)
 {
-  AMPI_API("AMPI_Type_set_name");
+  AMPI_API("AMPI_Type_set_name", datatype, name);
 
 #if AMPI_ERROR_CHECKING
   int ret = checkData("MPI_Type_set_name", datatype);
@@ -7226,7 +7227,7 @@ AMPI_API_IMPL(int, MPI_Type_set_name, MPI_Datatype datatype, const char *name)
 
 AMPI_API_IMPL(int, MPI_Type_get_name, MPI_Datatype datatype, char *name, int *resultlen)
 {
-  AMPI_API("AMPI_Type_get_name");
+  AMPI_API("AMPI_Type_get_name", datatype, name, resultlen);
 
 #if AMPI_ERROR_CHECKING
   int ret = checkData("AMPI_Type_get_name", datatype);
@@ -7241,7 +7242,7 @@ AMPI_API_IMPL(int, MPI_Type_get_name, MPI_Datatype datatype, char *name, int *re
 AMPI_API_IMPL(int, MPI_Type_create_resized, MPI_Datatype oldtype, MPI_Aint lb,
                                             MPI_Aint extent, MPI_Datatype *newtype)
 {
-  AMPI_API("AMPI_Type_create_resized");
+  AMPI_API("AMPI_Type_create_resized", oldtype, lb, extent, newtype);
 
 #if AMPI_ERROR_CHECKING
   int ret = checkData("AMPI_Type_create_resized", oldtype);
@@ -7255,7 +7256,7 @@ AMPI_API_IMPL(int, MPI_Type_create_resized, MPI_Datatype oldtype, MPI_Aint lb,
 
 AMPI_API_IMPL(int, MPI_Type_dup, MPI_Datatype oldtype, MPI_Datatype *newtype)
 {
-  AMPI_API("AMPI_Type_dup");
+  AMPI_API("AMPI_Type_dup", oldtype, newtype);
 
 #if AMPI_ERROR_CHECKING
   int ret = checkData("AMPI_Type_dup", oldtype);
@@ -7274,7 +7275,7 @@ AMPI_API_IMPL(int, MPI_Type_dup, MPI_Datatype oldtype, MPI_Datatype *newtype)
 
 AMPI_API_IMPL(int, MPI_Type_match_size, int typeclass, int size, MPI_Datatype *rtype)
 {
-  AMPI_API("AMPI_Type_match_size");
+  AMPI_API("AMPI_Type_match_size", typeclass, size, rtype);
 
   switch(typeclass) {
     case MPI_TYPECLASS_INTEGER: switch(size) {
@@ -7303,7 +7304,7 @@ AMPI_API_IMPL(int, MPI_Type_match_size, int typeclass, int size, MPI_Datatype *r
 
 AMPI_API_IMPL(int, MPI_Type_set_attr, MPI_Datatype datatype, int keyval, void *attribute_val)
 {
-  AMPI_API("AMPI_Type_set_attr");
+  AMPI_API("AMPI_Type_set_attr", datatype, keyval, attribute_val);
 
 #if AMPI_ERROR_CHECKING
   int ret = checkData("AMPI_Type_set_attr", datatype);
@@ -7320,7 +7321,7 @@ AMPI_API_IMPL(int, MPI_Type_set_attr, MPI_Datatype datatype, int keyval, void *a
 AMPI_API_IMPL(int, MPI_Type_get_attr, MPI_Datatype datatype, int keyval,
                                       void *attribute_val, int *flag)
 {
-  AMPI_API("AMPI_Type_get_attr");
+  AMPI_API("AMPI_Type_get_attr", datatype, keyval, attribute_val, flag);
 
 #if AMPI_ERROR_CHECKING
   int ret = checkData("AMPI_Type_get_attr", datatype);
@@ -7336,7 +7337,7 @@ AMPI_API_IMPL(int, MPI_Type_get_attr, MPI_Datatype datatype, int keyval,
 
 AMPI_API_IMPL(int, MPI_Type_delete_attr, MPI_Datatype datatype, int keyval)
 {
-  AMPI_API("AMPI_Type_delete_attr");
+  AMPI_API("AMPI_Type_delete_attr", datatype, keyval);
 
 #if AMPI_ERROR_CHECKING
   int ret = checkData("AMPI_Type_delete_attr", datatype);
@@ -7354,13 +7355,13 @@ AMPI_API_IMPL(int, MPI_Type_create_keyval, MPI_Type_copy_attr_function *copy_fn,
                                            MPI_Type_delete_attr_function *delete_fn,
                                            int *keyval, void *extra_state)
 {
-  AMPI_API("AMPI_Type_create_keyval");
+  AMPI_API("AMPI_Type_create_keyval", copy_fn, delete_fn, keyval, extra_state);
   return MPI_Comm_create_keyval(copy_fn, delete_fn, keyval, extra_state);
 }
 
 AMPI_API_IMPL(int, MPI_Type_free_keyval, int *keyval)
 {
-  AMPI_API("AMPI_Type_free_keyval");
+  AMPI_API("AMPI_Type_free_keyval", keyval);
   return MPI_Comm_free_keyval(keyval);
 }
 
@@ -7521,7 +7522,7 @@ AMPI_API_IMPL(int, MPI_Type_create_darray, int size, int rank, int ndims,
           MPI_Datatype *newtype)
 {
   // FIXME: do error checking
-  AMPI_API("AMPI_Type_create_darray");
+  AMPI_API("AMPI_Type_create_darray", size, rank, ndims, array_of_gsizes, array_of_distribs, array_of_dargs, array_of_psizes, order, oldtype, newtype);
   MPI_Datatype type_old, type_new=MPI_DATATYPE_NULL, types[3];
   int procs, tmp_rank, i, tmp_size, blklens[3], *coords;
   MPI_Aint *st_offsets, orig_extent, disps[3];
@@ -7648,7 +7649,7 @@ AMPI_API_IMPL(int, MPI_Type_create_subarray, int ndims,
               MPI_Datatype *newtype)
 {
   // FIXME: do error checking
-  AMPI_API("AMPI_Type_create_subarray");
+  AMPI_API("AMPI_Type_create_subarray", ndims, array_of_sizes, array_of_subsizes, array_of_starts, order, oldtype, newtype);
   MPI_Aint extent, disps[3], size;
   int i, blklens[3];
   MPI_Datatype tmp1, tmp2, types[3];
@@ -7734,7 +7735,7 @@ AMPI_API_IMPL(int, MPI_Type_create_subarray, int ndims,
 AMPI_API_IMPL(int, MPI_Isend, const void *buf, int count, MPI_Datatype type, int dest,
                               int tag, MPI_Comm comm, MPI_Request *request)
 {
-  AMPI_API("AMPI_Isend");
+  AMPI_API("AMPI_Isend", buf, count, type, dest, tag, comm, request);
 
   handle_MPI_BOTTOM((void*&)buf, type);
 
@@ -7771,14 +7772,14 @@ AMPI_API_IMPL(int, MPI_Isend, const void *buf, int count, MPI_Datatype type, int
 AMPI_API_IMPL(int, MPI_Ibsend, const void *buf, int count, MPI_Datatype type, int dest,
                                int tag, MPI_Comm comm, MPI_Request *request)
 {
-  AMPI_API("AMPI_Ibsend");
+  AMPI_API("AMPI_Ibsend", buf, count, type, dest, tag, comm, request);
   return MPI_Isend(buf, count, type, dest, tag, comm, request);
 }
 
 AMPI_API_IMPL(int, MPI_Irsend, const void *buf, int count, MPI_Datatype type, int dest,
                                int tag, MPI_Comm comm, MPI_Request *request)
 {
-  AMPI_API("AMPI_Irsend");
+  AMPI_API("AMPI_Irsend", buf, count, type, dest, tag, comm, request);
   return MPI_Isend(buf, count, type, dest, tag, comm, request);
 }
 
@@ -7844,7 +7845,7 @@ void ampi::irecv(void *buf, int count, MPI_Datatype type, int src,
 AMPI_API_IMPL(int, MPI_Irecv, void *buf, int count, MPI_Datatype type, int src,
                               int tag, MPI_Comm comm, MPI_Request *request)
 {
-  AMPI_API("AMPI_Irecv");
+  AMPI_API("AMPI_Irecv", buf, count, type, src, tag, comm, request);
 
   handle_MPI_BOTTOM(buf, type);
 
@@ -7868,7 +7869,7 @@ AMPI_API_IMPL(int, MPI_Ireduce, const void *sendbuf, void *recvbuf, int count,
                                 MPI_Datatype type, MPI_Op op, int root,
                                 MPI_Comm comm, MPI_Request *request)
 {
-  AMPI_API("AMPI_Ireduce");
+  AMPI_API("AMPI_Ireduce", sendbuf, recvbuf, count, type, op, root, comm, request);
 
   handle_MPI_BOTTOM((void*&)sendbuf, type, recvbuf, type);
   handle_MPI_IN_PLACE((void*&)sendbuf, recvbuf);
@@ -7975,7 +7976,7 @@ AMPI_API_IMPL(int, MPI_Allgather, const void *sendbuf, int sendcount, MPI_Dataty
                                   void *recvbuf, int recvcount, MPI_Datatype recvtype,
                                   MPI_Comm comm)
 {
-  AMPI_API("AMPI_Allgather");
+  AMPI_API("AMPI_Allgather", sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, comm);
 
   ampi *ptr = getAmpiInstance(comm);
   int rank = ptr->getRank();
@@ -8019,7 +8020,7 @@ AMPI_API_IMPL(int, MPI_Iallgather, const void *sendbuf, int sendcount, MPI_Datat
                                    void *recvbuf, int recvcount, MPI_Datatype recvtype,
                                    MPI_Comm comm, MPI_Request* request)
 {
-  AMPI_API("AMPI_Iallgather");
+  AMPI_API("AMPI_Iallgather", sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, comm, request);
 
   ampi *ptr = getAmpiInstance(comm);
   int rank = ptr->getRank();
@@ -8067,7 +8068,7 @@ AMPI_API_IMPL(int, MPI_Allgatherv, const void *sendbuf, int sendcount, MPI_Datat
                                    void *recvbuf, const int *recvcounts, const int *displs,
                                    MPI_Datatype recvtype, MPI_Comm comm)
 {
-  AMPI_API("AMPI_Allgatherv");
+  AMPI_API("AMPI_Allgatherv", sendbuf, sendcount, sendtype, recvbuf, recvcounts, displs, recvtype, comm);
 
   ampi *ptr = getAmpiInstance(comm);
   int rank = ptr->getRank();
@@ -8111,7 +8112,7 @@ AMPI_API_IMPL(int, MPI_Iallgatherv, const void *sendbuf, int sendcount, MPI_Data
                                     void *recvbuf, const int *recvcounts, const int *displs,
                                     MPI_Datatype recvtype, MPI_Comm comm, MPI_Request *request)
 {
-  AMPI_API("AMPI_Iallgatherv");
+  AMPI_API("AMPI_Iallgatherv", sendbuf, sendcount, sendtype, recvbuf, recvcounts, displs, recvtype, comm, request);
 
   ampi *ptr = getAmpiInstance(comm);
   int rank = ptr->getRank();
@@ -8161,7 +8162,7 @@ AMPI_API_IMPL(int, MPI_Gather, const void *sendbuf, int sendcount, MPI_Datatype 
                                void *recvbuf, int recvcount, MPI_Datatype recvtype,
                                int root, MPI_Comm comm)
 {
-  AMPI_API("AMPI_Gather");
+  AMPI_API("AMPI_Gather", sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, root, comm);
 
   ampi *ptr = getAmpiInstance(comm);
   int rank = ptr->getRank();
@@ -8232,7 +8233,7 @@ AMPI_API_IMPL(int, MPI_Igather, const void *sendbuf, int sendcount, MPI_Datatype
                                 void *recvbuf, int recvcount, MPI_Datatype recvtype,
                                 int root, MPI_Comm comm, MPI_Request *request)
 {
-  AMPI_API("AMPI_Igather");
+  AMPI_API("AMPI_Igather", sendbuf, sendtype, sendtype, recvbuf, recvcount, recvtype, root, comm, request);
 
   ampi *ptr = getAmpiInstance(comm);
   int rank = ptr->getRank();
@@ -8305,7 +8306,7 @@ AMPI_API_IMPL(int, MPI_Gatherv, const void *sendbuf, int sendcount, MPI_Datatype
                                 void *recvbuf, const int *recvcounts, const int *displs,
                                 MPI_Datatype recvtype, int root, MPI_Comm comm)
 {
-  AMPI_API("AMPI_Gatherv");
+  AMPI_API("AMPI_Gatherv", sendbuf, sendtype, sendtype, recvbuf, recvcounts, displs, recvtype, root, comm);
 
   ampi *ptr = getAmpiInstance(comm);
   int rank = ptr->getRank();
@@ -8383,7 +8384,7 @@ AMPI_API_IMPL(int, MPI_Igatherv, const void *sendbuf, int sendcount, MPI_Datatyp
                                  void *recvbuf, const int *recvcounts, const int *displs,
                                  MPI_Datatype recvtype, int root, MPI_Comm comm, MPI_Request *request)
 {
-  AMPI_API("AMPI_Igatherv");
+  AMPI_API("AMPI_Igatherv", sendbuf, sendtype, sendtype, recvbuf, recvcounts, displs, recvtype, root, comm, request);
 
   ampi *ptr = getAmpiInstance(comm);
   int rank = ptr->getRank();
@@ -8466,7 +8467,7 @@ AMPI_API_IMPL(int, MPI_Scatter, const void *sendbuf, int sendcount, MPI_Datatype
                                 void *recvbuf, int recvcount, MPI_Datatype recvtype,
                                 int root, MPI_Comm comm)
 {
-  AMPI_API("AMPI_Scatter");
+  AMPI_API("AMPI_Scatter", sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, root, comm);
 
   handle_MPI_BOTTOM((void*&)sendbuf, sendtype, recvbuf, recvtype);
   handle_MPI_IN_PLACE((void*&)sendbuf,recvbuf);
@@ -8539,7 +8540,7 @@ AMPI_API_IMPL(int, MPI_Iscatter, const void *sendbuf, int sendcount, MPI_Datatyp
                                  void *recvbuf, int recvcount, MPI_Datatype recvtype,
                                  int root, MPI_Comm comm, MPI_Request *request)
 {
-  AMPI_API("AMPI_Iscatter");
+  AMPI_API("AMPI_Iscatter", sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, root, comm, request);
 
   handle_MPI_BOTTOM((void*&)sendbuf, sendtype, recvbuf, recvtype);
   handle_MPI_IN_PLACE((void*&)sendbuf,recvbuf);
@@ -8623,7 +8624,7 @@ AMPI_API_IMPL(int, MPI_Scatterv, const void *sendbuf, const int *sendcounts, con
                                  MPI_Datatype sendtype, void *recvbuf, int recvcount,
                                  MPI_Datatype recvtype, int root, MPI_Comm comm)
 {
-  AMPI_API("AMPI_Scatterv");
+  AMPI_API("AMPI_Scatterv", sendbuf, sendcounts, sendtype, recvbuf, recvcount, recvtype, root, comm);
 
   handle_MPI_BOTTOM((void*&)sendbuf, sendtype, recvbuf, recvtype);
   handle_MPI_IN_PLACE((void*&)sendbuf, recvbuf);
@@ -8697,7 +8698,7 @@ AMPI_API_IMPL(int, MPI_Iscatterv, const void *sendbuf, const int *sendcounts, co
                                   MPI_Datatype recvtype, int root, MPI_Comm comm,
                                   MPI_Request *request)
 {
-  AMPI_API("AMPI_Iscatterv");
+  AMPI_API("AMPI_Iscatterv", sendbuf, sendcounts, displs, sendtype, recvbuf, recvcount, recvtype, root, comm, request);
 
   handle_MPI_BOTTOM((void*&)sendbuf, sendtype, recvbuf, recvtype);
   handle_MPI_IN_PLACE((void*&)sendbuf,recvbuf);
@@ -8782,7 +8783,7 @@ AMPI_API_IMPL(int, MPI_Alltoall, const void *sendbuf, int sendcount, MPI_Datatyp
                                  void *recvbuf, int recvcount, MPI_Datatype recvtype,
                                  MPI_Comm comm)
 {
-  AMPI_API("AMPI_Alltoall");
+  AMPI_API("AMPI_Alltoall", sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, comm);
 
   handle_MPI_BOTTOM((void*&)sendbuf, sendtype, recvbuf, recvtype);
   handle_MPI_IN_PLACE_alltoall((void*&)sendbuf, recvbuf, sendcount, sendtype, recvcount, recvtype);
@@ -8904,7 +8905,7 @@ AMPI_API_IMPL(int, MPI_Ialltoall, const void *sendbuf, int sendcount, MPI_Dataty
                                   void *recvbuf, int recvcount, MPI_Datatype recvtype,
                                   MPI_Comm comm, MPI_Request *request)
 {
-  AMPI_API("AMPI_Ialltoall");
+  AMPI_API("AMPI_Ialltoall", sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, comm, request);
 
   handle_MPI_BOTTOM((void*&)sendbuf, sendtype, recvbuf, recvtype);
   handle_MPI_IN_PLACE_alltoall((void*&)sendbuf, recvbuf, sendcount, sendtype, recvcount, recvtype);
@@ -8961,7 +8962,7 @@ AMPI_API_IMPL(int, MPI_Alltoallv, const void *sendbuf, const int *sendcounts, co
                                   MPI_Datatype sendtype, void *recvbuf, const int *recvcounts,
                                   const int *rdispls, MPI_Datatype recvtype, MPI_Comm comm)
 {
-  AMPI_API("AMPI_Alltoallv");
+  AMPI_API("AMPI_Alltoallv", sendbuf, sendcounts, sdispls, sendtype, recvbuf, recvcounts, rdispls, recvtype, comm);
 
   handle_MPI_BOTTOM((void*&)sendbuf, sendtype, recvbuf, recvtype);
   handle_MPI_IN_PLACE_alltoallv((void*&)sendbuf, recvbuf, (int*&)sendcounts, sendtype,
@@ -9048,7 +9049,7 @@ AMPI_API_IMPL(int, MPI_Ialltoallv, void *sendbuf, int *sendcounts, int *sdispls,
                                    void *recvbuf, int *recvcounts, int *rdispls, MPI_Datatype recvtype,
                                    MPI_Comm comm, MPI_Request *request)
 {
-  AMPI_API("AMPI_Ialltoallv");
+  AMPI_API("AMPI_Ialltoallv", sendbuf, sendcounts, sdispls, sendtype, recvbuf, recvcounts, rdispls, recvtype, comm, request);
 
   handle_MPI_BOTTOM(sendbuf, sendtype, recvbuf, recvtype);
   handle_MPI_IN_PLACE_alltoallv((void*&)sendbuf, recvbuf, (int*&)sendcounts, sendtype,
@@ -9108,7 +9109,7 @@ AMPI_API_IMPL(int, MPI_Alltoallw, const void *sendbuf, const int *sendcounts, co
                                   const MPI_Datatype *sendtypes, void *recvbuf, const int *recvcounts,
                                   const int *rdispls, const MPI_Datatype *recvtypes, MPI_Comm comm)
 {
-  AMPI_API("AMPI_Alltoallw");
+  AMPI_API("AMPI_Alltoallw", sendbuf, sendcounts, sdispls, sendtypes, recvbuf, recvcounts, rdispls, recvtypes, comm);
 
   if (sendbuf == MPI_IN_PLACE) {
     handle_MPI_BOTTOM(recvbuf, recvtypes[0]);
@@ -9199,7 +9200,7 @@ AMPI_API_IMPL(int, MPI_Ialltoallw, const void *sendbuf, const int *sendcounts, c
                                    const int *rdispls, const MPI_Datatype *recvtypes, MPI_Comm comm,
                                    MPI_Request *request)
 {
-  AMPI_API("AMPI_Ialltoallw");
+  AMPI_API("AMPI_Ialltoallw", sendbuf, sendcounts, sdispls, sendtypes, recvbuf, recvcounts, rdispls, recvtypes, comm, request);
 
   if (sendbuf == MPI_IN_PLACE) {
     handle_MPI_BOTTOM(recvbuf, recvtypes[0]);
@@ -9261,7 +9262,7 @@ AMPI_API_IMPL(int, MPI_Neighbor_alltoall, const void* sendbuf, int sendcount, MP
                                           void* recvbuf, int recvcount, MPI_Datatype recvtype,
                                           MPI_Comm comm)
 {
-  AMPI_API("AMPI_Neighbor_alltoall");
+  AMPI_API("AMPI_Neighbor_alltoall", sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, comm);
 
   handle_MPI_BOTTOM((void*&)sendbuf, sendtype, recvbuf, recvtype);
 
@@ -9310,7 +9311,7 @@ AMPI_API_IMPL(int, MPI_Ineighbor_alltoall, const void* sendbuf, int sendcount, M
                                            void* recvbuf, int recvcount, MPI_Datatype recvtype,
                                            MPI_Comm comm, MPI_Request *request)
 {
-  AMPI_API("AMPI_Ineighbor_alltoall");
+  AMPI_API("AMPI_Ineighbor_alltoall", sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, comm, request);
 
   handle_MPI_BOTTOM((void*&)sendbuf, sendtype, recvbuf, recvtype);
 
@@ -9366,7 +9367,7 @@ AMPI_API_IMPL(int, MPI_Neighbor_alltoallv, const void* sendbuf, const int *sendc
                                            MPI_Datatype sendtype, void* recvbuf, const int *recvcounts,
                                            const int *rdispls, MPI_Datatype recvtype, MPI_Comm comm)
 {
-  AMPI_API("AMPI_Neighbor_alltoallv");
+  AMPI_API("AMPI_Neighbor_alltoallv", sendbuf, sendcounts, sdispls, sendtype, recvbuf, recvcounts, rdispls, recvtype, comm);
 
   handle_MPI_BOTTOM((void*&)sendbuf, sendtype, recvbuf, recvtype);
 
@@ -9416,7 +9417,7 @@ AMPI_API_IMPL(int, MPI_Ineighbor_alltoallv, const void* sendbuf, const int *send
                                             const int *rdispls, MPI_Datatype recvtype, MPI_Comm comm,
                                             MPI_Request *request)
 {
-  AMPI_API("AMPI_Ineighbor_alltoallv");
+  AMPI_API("AMPI_Ineighbor_alltoallv", sendbuf, sendcounts, sdispls, sendtype, recvbuf, recvcounts, rdispls, recvtype, comm, request);
 
   handle_MPI_BOTTOM((void*&)sendbuf, sendtype, recvbuf, recvtype);
 
@@ -9472,7 +9473,7 @@ AMPI_API_IMPL(int, MPI_Neighbor_alltoallw, const void* sendbuf, const int *sendc
                                            const MPI_Datatype *sendtypes, void* recvbuf, const int *recvcounts,
                                            const MPI_Aint *rdispls, const MPI_Datatype *recvtypes, MPI_Comm comm)
 {
-  AMPI_API("AMPI_Neighbor_alltoallw");
+  AMPI_API("AMPI_Neighbor_alltoallw", sendbuf, sendcounts, sdispls, sendtypes, recvbuf, recvcounts, rdispls, recvtypes, comm);
 
   handle_MPI_BOTTOM((void*&)sendbuf, sendtypes[0], recvbuf, recvtypes[0]);
 
@@ -9520,7 +9521,7 @@ AMPI_API_IMPL(int, MPI_Ineighbor_alltoallw, const void* sendbuf, const int *send
                                             const MPI_Aint *rdispls, const MPI_Datatype *recvtypes, MPI_Comm comm,
                                             MPI_Request *request)
 {
-  AMPI_API("AMPI_Ineighbor_alltoallw");
+  AMPI_API("AMPI_Ineighbor_alltoallw", sendbuf, sendcounts, sdispls, sendtypes, recvbuf, recvcounts, rdispls, recvtypes, comm, request);
 
   handle_MPI_BOTTOM((void*&)sendbuf, sendtypes[0], recvbuf, recvtypes[0]);
 
@@ -9574,7 +9575,7 @@ AMPI_API_IMPL(int, MPI_Neighbor_allgather, const void* sendbuf, int sendcount, M
                                            void* recvbuf, int recvcount, MPI_Datatype recvtype,
                                            MPI_Comm comm)
 {
-  AMPI_API("AMPI_Neighbor_allgather");
+  AMPI_API("AMPI_Neighbor_allgather", sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, comm);
 
   handle_MPI_BOTTOM((void*&)sendbuf, sendtype, recvbuf, recvtype);
 
@@ -9622,7 +9623,7 @@ AMPI_API_IMPL(int, MPI_Ineighbor_allgather, const void* sendbuf, int sendcount, 
                                             void* recvbuf, int recvcount, MPI_Datatype recvtype,
                                             MPI_Comm comm, MPI_Request *request)
 {
-  AMPI_API("AMPI_Ineighbor_allgather");
+  AMPI_API("AMPI_Ineighbor_allgather", sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, comm, request);
 
   handle_MPI_BOTTOM((void*&)sendbuf, sendtype, recvbuf, recvtype);
 
@@ -9677,7 +9678,7 @@ AMPI_API_IMPL(int, MPI_Neighbor_allgatherv, const void* sendbuf, int sendcount, 
                                             void* recvbuf, const int *recvcounts, const int *displs,
                                             MPI_Datatype recvtype, MPI_Comm comm)
 {
-  AMPI_API("AMPI_Neighbor_allgatherv");
+  AMPI_API("AMPI_Neighbor_allgatherv", sendbuf, sendcount, sendtype, recvbuf, recvcounts, displs, recvtype, comm);
 
   handle_MPI_BOTTOM((void*&)sendbuf, sendtype, recvbuf, recvtype);
 
@@ -9723,7 +9724,7 @@ AMPI_API_IMPL(int, MPI_Ineighbor_allgatherv, const void* sendbuf, int sendcount,
                                              void* recvbuf, const int* recvcounts, const int* displs,
                                              MPI_Datatype recvtype, MPI_Comm comm, MPI_Request *request)
 {
-  AMPI_API("AMPI_Ineighbor_allgatherv");
+  AMPI_API("AMPI_Ineighbor_allgatherv", sendbuf, sendcount, sendtype, recvbuf, recvcounts, displs, recvtype, comm, request);
 
   handle_MPI_BOTTOM((void*&)sendbuf, sendtype, recvbuf, recvtype);
 
@@ -9776,7 +9777,7 @@ AMPI_API_IMPL(int, MPI_Ineighbor_allgatherv, const void* sendbuf, int sendcount,
 
 AMPI_API_IMPL(int, MPI_Comm_dup, MPI_Comm comm, MPI_Comm *newcomm)
 {
-  AMPI_API("AMPI_Comm_dup");
+  AMPI_API("AMPI_Comm_dup", comm, newcomm);
 
   {
     ampi *ptr = getAmpiInstance(comm);
@@ -9806,7 +9807,7 @@ AMPI_API_IMPL(int, MPI_Comm_dup, MPI_Comm comm, MPI_Comm *newcomm)
 
 AMPI_API_IMPL(int, MPI_Comm_idup, MPI_Comm comm, MPI_Comm *newcomm, MPI_Request *request)
 {
-  AMPI_API("AMPI_Comm_idup");
+  AMPI_API("AMPI_Comm_idup", comm, newcomm, request);
   // FIXME: implement non-blocking comm_dup
   *request = MPI_REQUEST_NULL;
   return MPI_Comm_dup(comm, newcomm);
@@ -9814,7 +9815,7 @@ AMPI_API_IMPL(int, MPI_Comm_idup, MPI_Comm comm, MPI_Comm *newcomm, MPI_Request 
 
 AMPI_API_IMPL(int, MPI_Comm_dup_with_info, MPI_Comm comm, MPI_Info info, MPI_Comm *dest)
 {
-  AMPI_API("AMPI_Comm_dup_with_info");
+  AMPI_API("AMPI_Comm_dup_with_info", comm, info, dest);
   MPI_Comm_dup(comm, dest);
   MPI_Comm_set_info(*dest, info);
   return MPI_SUCCESS;
@@ -9822,7 +9823,7 @@ AMPI_API_IMPL(int, MPI_Comm_dup_with_info, MPI_Comm comm, MPI_Info info, MPI_Com
 
 AMPI_API_IMPL(int, MPI_Comm_idup_with_info, MPI_Comm comm, MPI_Info info, MPI_Comm *dest, MPI_Request *request)
 {
-  AMPI_API("AMPI_Comm_idup_with_info");
+  AMPI_API("AMPI_Comm_idup_with_info", comm, info, dest, request);
   // FIXME: implement non-blocking comm_dup_with_info
   *request = MPI_REQUEST_NULL;
   return MPI_Comm_dup_with_info(comm, info, dest);
@@ -9830,7 +9831,7 @@ AMPI_API_IMPL(int, MPI_Comm_idup_with_info, MPI_Comm comm, MPI_Info info, MPI_Co
 
 AMPI_API_IMPL(int, MPI_Comm_split, MPI_Comm src, int color, int key, MPI_Comm *dest)
 {
-  AMPI_API("AMPI_Comm_split");
+  AMPI_API("AMPI_Comm_split", src, color, key, dest);
   {
     ampiParent *pptr = getAmpiParent();
     ampi *ptr = pptr->comm2ampi(src);
@@ -9868,7 +9869,7 @@ AMPI_API_IMPL(int, MPI_Comm_split, MPI_Comm src, int color, int key, MPI_Comm *d
 AMPI_API_IMPL(int, MPI_Comm_split_type, MPI_Comm src, int split_type, int key,
                                         MPI_Info info, MPI_Comm *dest)
 {
-  AMPI_API("AMPI_Comm_split_type");
+  AMPI_API("AMPI_Comm_split_type", src, split_type, key, info, dest);
 
   if (src == MPI_COMM_SELF && split_type == MPI_UNDEFINED) {
     *dest = MPI_COMM_NULL;
@@ -9892,7 +9893,7 @@ AMPI_API_IMPL(int, MPI_Comm_split_type, MPI_Comm src, int split_type, int key,
 
 AMPI_API_IMPL(int, MPI_Comm_free, MPI_Comm *comm)
 {
-  AMPI_API("AMPI_Comm_free");
+  AMPI_API("AMPI_Comm_free", comm);
   int ret = MPI_SUCCESS;
   if (*comm != MPI_COMM_NULL) {
     if (*comm != MPI_COMM_WORLD && *comm != MPI_COMM_SELF) {
@@ -9908,21 +9909,21 @@ AMPI_API_IMPL(int, MPI_Comm_free, MPI_Comm *comm)
 
 AMPI_API_IMPL(int, MPI_Comm_test_inter, MPI_Comm comm, int *flag)
 {
-  AMPI_API("AMPI_Comm_test_inter");
+  AMPI_API("AMPI_Comm_test_inter", comm, flag);
   *flag = getAmpiParent()->isInter(comm);
   return MPI_SUCCESS;
 }
 
 AMPI_API_IMPL(int, MPI_Comm_remote_size, MPI_Comm comm, int *size)
 {
-  AMPI_API("AMPI_Comm_remote_size");
+  AMPI_API("AMPI_Comm_remote_size", comm, size);
   *size = getAmpiParent()->getRemoteSize(comm);
   return MPI_SUCCESS;
 }
 
 AMPI_API_IMPL(int, MPI_Comm_remote_group, MPI_Comm comm, MPI_Group *group)
 {
-  AMPI_API("AMPI_Comm_remote_group");
+  AMPI_API("AMPI_Comm_remote_group", comm, group);
   *group = getAmpiParent()->getRemoteGroup(comm);
   return MPI_SUCCESS;
 }
@@ -9930,7 +9931,7 @@ AMPI_API_IMPL(int, MPI_Comm_remote_group, MPI_Comm comm, MPI_Group *group)
 AMPI_API_IMPL(int, MPI_Intercomm_create, MPI_Comm localComm, int localLeader, MPI_Comm peerComm,
                                          int remoteLeader, int tag, MPI_Comm *newintercomm)
 {
-  AMPI_API("AMPI_Intercomm_create");
+  AMPI_API("AMPI_Intercomm_create", localComm, localLeader, peerComm, remoteLeader, newintercomm);
 
 #if AMPI_ERROR_CHECKING
   if (getAmpiParent()->isInter(localComm) || getAmpiParent()->isInter(peerComm))
@@ -9974,7 +9975,7 @@ AMPI_API_IMPL(int, MPI_Intercomm_create, MPI_Comm localComm, int localLeader, MP
 
 AMPI_API_IMPL(int, MPI_Intercomm_merge, MPI_Comm intercomm, int high, MPI_Comm *newintracomm)
 {
-  AMPI_API("AMPI_Intercomm_merge");
+  AMPI_API("AMPI_Intercomm_merge", intercomm, high, newintracomm);
 
 #if AMPI_ERROR_CHECKING
   if (!getAmpiParent()->isInter(intercomm))
@@ -10008,14 +10009,14 @@ AMPI_API_IMPL(int, MPI_Intercomm_merge, MPI_Comm intercomm, int high, MPI_Comm *
 
 AMPI_API_IMPL(int, MPI_Abort, MPI_Comm comm, int errorcode)
 {
-  AMPI_API_INIT("AMPI_Abort");
+  AMPI_API_INIT("AMPI_Abort", comm, errorcode);
   CkAbort("AMPI: Application called MPI_Abort()!\n");
   return errorcode;
 }
 
 AMPI_API_IMPL(int, MPI_Get_count, const MPI_Status *sts, MPI_Datatype dtype, int *count)
 {
-  AMPI_API("AMPI_Get_count");
+  AMPI_API("AMPI_Get_count", sts, dtype, count);
   CkDDT_DataType* dttype = getDDT()->getType(dtype);
   int itemsize = dttype->getSize() ;
   if (itemsize == 0) {
@@ -10032,7 +10033,7 @@ AMPI_API_IMPL(int, MPI_Get_count, const MPI_Status *sts, MPI_Datatype dtype, int
 
 AMPI_API_IMPL(int, MPI_Type_lb, MPI_Datatype dtype, MPI_Aint* displacement)
 {
-  AMPI_API("AMPI_Type_lb");
+  AMPI_API("AMPI_Type_lb", dtype, displacement);
 
 #if AMPI_ERROR_CHECKING
   int ret = checkData("AMPI_Type_lb", dtype);
@@ -10046,7 +10047,7 @@ AMPI_API_IMPL(int, MPI_Type_lb, MPI_Datatype dtype, MPI_Aint* displacement)
 
 AMPI_API_IMPL(int, MPI_Type_ub, MPI_Datatype dtype, MPI_Aint* displacement)
 {
-  AMPI_API("AMPI_Type_ub");
+  AMPI_API("AMPI_Type_ub", dtype, displacement);
 
 #if AMPI_ERROR_CHECKING
   int ret = checkData("AMPI_Type_ub", dtype);
@@ -10060,20 +10061,20 @@ AMPI_API_IMPL(int, MPI_Type_ub, MPI_Datatype dtype, MPI_Aint* displacement)
 
 AMPI_API_IMPL(int, MPI_Get_address, const void* location, MPI_Aint *address)
 {
-  AMPI_API("AMPI_Get_address");
+  AMPI_API("AMPI_Get_address", location, address);
   *address = (MPI_Aint)location;
   return MPI_SUCCESS;
 }
 
 AMPI_API_IMPL(int, MPI_Address, void* location, MPI_Aint *address)
 {
-  AMPI_API("AMPI_Address");
+  AMPI_API("AMPI_Address", location, address);
   return MPI_Get_address(location, address);
 }
 
 AMPI_API_IMPL(int, MPI_Status_set_elements, MPI_Status *sts, MPI_Datatype dtype, int count)
 {
-  AMPI_API("AMPI_Status_set_elements");
+  AMPI_API("AMPI_Status_set_elements", sts, dtype, count);
   if(sts == MPI_STATUS_IGNORE || sts == MPI_STATUSES_IGNORE)
     return MPI_SUCCESS;
 
@@ -10092,7 +10093,7 @@ AMPI_API_IMPL(int, MPI_Status_set_elements, MPI_Status *sts, MPI_Datatype dtype,
 
 AMPI_API_IMPL(int, MPI_Status_set_elements_x, MPI_Status *sts, MPI_Datatype dtype, MPI_Count count)
 {
-  AMPI_API("AMPI_Status_set_elements_x");
+  AMPI_API("AMPI_Status_set_elements_x", sts, dtype, count);
   if(sts == MPI_STATUS_IGNORE || sts == MPI_STATUSES_IGNORE)
     return MPI_SUCCESS;
 
@@ -10111,7 +10112,7 @@ AMPI_API_IMPL(int, MPI_Status_set_elements_x, MPI_Status *sts, MPI_Datatype dtyp
 
 AMPI_API_IMPL(int, MPI_Get_elements, const MPI_Status *sts, MPI_Datatype dtype, int *count)
 {
-  AMPI_API("AMPI_Get_elements");
+  AMPI_API("AMPI_Get_elements", sts, dtype, count);
 
 #if AMPI_ERROR_CHECKING
     int ret = checkData("AMPI_Type_create_keyval", dtype);
@@ -10125,7 +10126,7 @@ AMPI_API_IMPL(int, MPI_Get_elements, const MPI_Status *sts, MPI_Datatype dtype, 
 
 AMPI_API_IMPL(int, MPI_Get_elements_x, const MPI_Status *sts, MPI_Datatype dtype, MPI_Count *count)
 {
-  AMPI_API("AMPI_Get_elements_x");
+  AMPI_API("AMPI_Get_elements_x", sts, dtype, count);
   *count = getDDT()->getType(dtype)->getNumBasicElements(sts->MPI_LENGTH);
   return MPI_SUCCESS;
 }
@@ -10133,7 +10134,7 @@ AMPI_API_IMPL(int, MPI_Get_elements_x, const MPI_Status *sts, MPI_Datatype dtype
 AMPI_API_IMPL(int, MPI_Pack, const void *inbuf, int incount, MPI_Datatype dtype,
                              void *outbuf, int outsize, int *position, MPI_Comm comm)
 {
-  AMPI_API("AMPI_Pack");
+  AMPI_API("AMPI_Pack", inbuf, incount, dtype, outbuf, outsize, position, comm);
   CkDDT_DataType* dttype = getDDT()->getType(dtype) ;
   int itemsize = dttype->getSize();
   dttype->serialize((char*)inbuf, ((char*)outbuf)+(*position), incount, outsize, PACK);
@@ -10144,7 +10145,7 @@ AMPI_API_IMPL(int, MPI_Pack, const void *inbuf, int incount, MPI_Datatype dtype,
 AMPI_API_IMPL(int, MPI_Unpack, const void *inbuf, int insize, int *position, void *outbuf,
                                int outcount, MPI_Datatype dtype, MPI_Comm comm)
 {
-  AMPI_API("AMPI_Unpack");
+  AMPI_API("AMPI_Unpack", inbuf, insize, position, outbuf, outcount, dtype, comm);
   CkDDT_DataType* dttype = getDDT()->getType(dtype) ;
   int itemsize = dttype->getSize();
   dttype->serialize((char*)outbuf, ((char*)inbuf+(*position)), outcount, insize, UNPACK);
@@ -10154,7 +10155,7 @@ AMPI_API_IMPL(int, MPI_Unpack, const void *inbuf, int insize, int *position, voi
 
 AMPI_API_IMPL(int, MPI_Pack_size, int incount, MPI_Datatype datatype, MPI_Comm comm, int *sz)
 {
-  AMPI_API("AMPI_Pack_size");
+  AMPI_API("AMPI_Pack_size", incount, datatype, comm, sz);
   CkDDT_DataType* dttype = getDDT()->getType(datatype) ;
   *sz = incount*dttype->getSize() ;
   return MPI_SUCCESS;
@@ -10162,7 +10163,7 @@ AMPI_API_IMPL(int, MPI_Pack_size, int incount, MPI_Datatype datatype, MPI_Comm c
 
 AMPI_API_IMPL(int, MPI_Get_version, int *version, int *subversion)
 {
-  AMPI_API_INIT("AMPI_Get_version");
+  AMPI_API_INIT("AMPI_Get_version", version, subversion);
   *version = MPI_VERSION;
   *subversion = MPI_SUBVERSION;
   return MPI_SUCCESS;
@@ -10170,7 +10171,7 @@ AMPI_API_IMPL(int, MPI_Get_version, int *version, int *subversion)
 
 AMPI_API_IMPL(int, MPI_Get_library_version, char *version, int *resultlen)
 {
-  AMPI_API_INIT("AMPI_Get_library_version");
+  AMPI_API_INIT("AMPI_Get_library_version", version, resultlen);
   const char *ampiNameStr = "Adaptive MPI ";
   strncpy(version, ampiNameStr, MPI_MAX_LIBRARY_VERSION_STRING);
   strncat(version, CmiCommitID, MPI_MAX_LIBRARY_VERSION_STRING - strlen(version));
@@ -10180,7 +10181,7 @@ AMPI_API_IMPL(int, MPI_Get_library_version, char *version, int *resultlen)
 
 AMPI_API_IMPL(int, MPI_Get_processor_name, char *name, int *resultlen)
 {
-  AMPI_API_INIT("AMPI_Get_processor_name");
+  AMPI_API_INIT("AMPI_Get_processor_name", name, resultlen);
   ampiParent *ptr = getAmpiParent();
   sprintf(name,"AMPI_RANK[%d]_WTH[%d]",ptr->thisIndex,ptr->getMyPe());
   *resultlen = strlen(name);
@@ -10196,111 +10197,111 @@ void error_handler ( MPI_Comm *, int * );
 
 AMPI_API_IMPL(int, MPI_Comm_call_errhandler, MPI_Comm comm, int errorcode)
 {
-  AMPI_API("AMPI_Comm_call_errhandler");
+  AMPI_API("AMPI_Comm_call_errhandler", comm, errorcode);
   return MPI_SUCCESS;
 }
 
 AMPI_API_IMPL(int, MPI_Comm_create_errhandler, MPI_Comm_errhandler_fn *function, MPI_Errhandler *errhandler)
 {
-  AMPI_API("AMPI_Comm_create_errhandler");
+  AMPI_API("AMPI_Comm_create_errhandler", function, errhandler);
   return MPI_SUCCESS;
 }
 
 AMPI_API_IMPL(int, MPI_Comm_set_errhandler, MPI_Comm comm, MPI_Errhandler errhandler)
 {
-  AMPI_API("AMPI_Comm_set_errhandler");
+  AMPI_API("AMPI_Comm_set_errhandler", comm, errhandler);
   return MPI_SUCCESS;
 }
 
 AMPI_API_IMPL(int, MPI_Comm_get_errhandler, MPI_Comm comm, MPI_Errhandler *errhandler)
 {
-  AMPI_API("AMPI_Comm_get_errhandler");
+  AMPI_API("AMPI_Comm_get_errhandler", comm, errhandler);
   return MPI_SUCCESS;
 }
 
 AMPI_API_IMPL(int, MPI_Comm_free_errhandler, MPI_Errhandler *errhandler)
 {
-  AMPI_API("AMPI_Comm_free_errhandler");
+  AMPI_API("AMPI_Comm_free_errhandler", errhandler);
   *errhandler = MPI_ERRHANDLER_NULL;
   return MPI_SUCCESS;
 }
 
 AMPI_API_IMPL(int, MPI_File_call_errhandler, MPI_File file, int errorcode)
 {
-  AMPI_API("AMPI_File_call_errhandler");
+  AMPI_API("AMPI_File_call_errhandler", file, errorcode);
   return MPI_SUCCESS;
 }
 
 AMPI_API_IMPL(int, MPI_File_create_errhandler, MPI_File_errhandler_function *function, MPI_Errhandler *errhandler)
 {
-  AMPI_API("AMPI_File_create_errhandler");
+  AMPI_API("AMPI_File_create_errhandler", function, errhandler);
   return MPI_SUCCESS;
 }
 
 AMPI_API_IMPL(int, MPI_File_set_errhandler, MPI_File file, MPI_Errhandler errhandler)
 {
-  AMPI_API("AMPI_File_set_errhandler");
+  AMPI_API("AMPI_File_set_errhandler", file, errhandler);
   return MPI_SUCCESS;
 }
 
 AMPI_API_IMPL(int, MPI_File_get_errhandler, MPI_File file, MPI_Errhandler *errhandler)
 {
-  AMPI_API("AMPI_File_get_errhandler");
+  AMPI_API("AMPI_File_get_errhandler", file, errhandler);
   return MPI_SUCCESS;
 }
 
 AMPI_API_IMPL(int, MPI_Errhandler_create, MPI_Handler_function *function, MPI_Errhandler *errhandler)
 {
-  AMPI_API("AMPI_Errhandler_create");
+  AMPI_API("AMPI_Errhandler_create", function, errhandler);
   return MPI_Comm_create_errhandler(function, errhandler);
 }
 
 AMPI_API_IMPL(int, MPI_Errhandler_set, MPI_Comm comm, MPI_Errhandler errhandler)
 {
-  AMPI_API("AMPI_Errhandler_set");
+  AMPI_API("AMPI_Errhandler_set", comm, errhandler);
   return MPI_Comm_set_errhandler(comm, errhandler);
 }
 
 AMPI_API_IMPL(int, MPI_Errhandler_get, MPI_Comm comm, MPI_Errhandler *errhandler)
 {
-  AMPI_API("AMPI_Errhandler_get");
+  AMPI_API("AMPI_Errhandler_get", comm, errhandler);
   return MPI_Comm_get_errhandler(comm, errhandler);
 }
 
 AMPI_API_IMPL(int, MPI_Errhandler_free, MPI_Errhandler *errhandler)
 {
-  AMPI_API("AMPI_Errhandler_free");
+  AMPI_API("AMPI_Errhandler_free", errhandler);
   return MPI_Comm_free_errhandler(errhandler);
 }
 
 AMPI_API_IMPL(int, MPI_Add_error_code, int errorclass, int *errorcode)
 {
-  AMPI_API("AMPI_Add_error_code");
+  AMPI_API("AMPI_Add_error_code", errorclass, errorcode);
   return MPI_SUCCESS;
 }
 
 AMPI_API_IMPL(int, MPI_Add_error_class, int *errorclass)
 {
-  AMPI_API("AMPI_Add_error_class");
+  AMPI_API("AMPI_Add_error_class", errorclass);
   return MPI_SUCCESS;
 }
 
 AMPI_API_IMPL(int, MPI_Add_error_string, int errorcode, const char *errorstring)
 {
-  AMPI_API("AMPI_Add_error_string");
+  AMPI_API("AMPI_Add_error_string", errorcode, errorstring);
   return MPI_SUCCESS;
 }
 
 AMPI_API_IMPL(int, MPI_Error_class, int errorcode, int *errorclass)
 {
-  AMPI_API("AMPI_Error_class");
+  AMPI_API("AMPI_Error_class", errorcode, errorclass);
   *errorclass = errorcode;
   return MPI_SUCCESS;
 }
 
 AMPI_API_IMPL(int, MPI_Error_string, int errorcode, char *errorstring, int *resultlen)
 {
-  AMPI_API("AMPI_Error_string");
+  AMPI_API("AMPI_Error_string", errorcode, errorstring, resultlen);
   const char *r="";
   switch(errorcode) {
     case MPI_SUCCESS:
@@ -10423,14 +10424,14 @@ AMPI_API_IMPL(int, MPI_Error_string, int errorcode, char *errorstring, int *resu
 /* Group operations */
 AMPI_API_IMPL(int, MPI_Comm_group, MPI_Comm comm, MPI_Group *group)
 {
-  AMPI_API("AMPI_Comm_Group");
+  AMPI_API("AMPI_Comm_Group", comm, group);
   *group = getAmpiParent()->comm2group(comm);
   return MPI_SUCCESS;
 }
 
 AMPI_API_IMPL(int, MPI_Group_union, MPI_Group group1, MPI_Group group2, MPI_Group *newgroup)
 {
-  AMPI_API("AMPI_Group_union");
+  AMPI_API("AMPI_Group_union", group1, group2, newgroup);
   ampiParent *ptr = getAmpiParent();
   std::vector<int> vec1 = ptr->group2vec(group1);
   std::vector<int> vec2 = ptr->group2vec(group2);
@@ -10441,7 +10442,7 @@ AMPI_API_IMPL(int, MPI_Group_union, MPI_Group group1, MPI_Group group2, MPI_Grou
 
 AMPI_API_IMPL(int, MPI_Group_intersection, MPI_Group group1, MPI_Group group2, MPI_Group *newgroup)
 {
-  AMPI_API("AMPI_Group_intersection");
+  AMPI_API("AMPI_Group_intersection", group1, group2, newgroup);
   ampiParent *ptr = getAmpiParent();
   std::vector<int> vec1 = ptr->group2vec(group1);
   std::vector<int> vec2 = ptr->group2vec(group2);
@@ -10452,7 +10453,7 @@ AMPI_API_IMPL(int, MPI_Group_intersection, MPI_Group group1, MPI_Group group2, M
 
 AMPI_API_IMPL(int, MPI_Group_difference, MPI_Group group1, MPI_Group group2, MPI_Group *newgroup)
 {
-  AMPI_API("AMPI_Group_difference");
+  AMPI_API("AMPI_Group_difference", group1, group2, newgroup);
   ampiParent *ptr = getAmpiParent();
   std::vector<int> vec1 = ptr->group2vec(group1);
   std::vector<int> vec2 = ptr->group2vec(group2);
@@ -10463,14 +10464,14 @@ AMPI_API_IMPL(int, MPI_Group_difference, MPI_Group group1, MPI_Group group2, MPI
 
 AMPI_API_IMPL(int, MPI_Group_size, MPI_Group group, int *size)
 {
-  AMPI_API("AMPI_Group_size");
+  AMPI_API("AMPI_Group_size", group, size);
   *size = (getAmpiParent()->group2vec(group)).size();
   return MPI_SUCCESS;
 }
 
 AMPI_API_IMPL(int, MPI_Group_rank, MPI_Group group, int *rank)
 {
-  AMPI_API("AMPI_Group_rank");
+  AMPI_API("AMPI_Group_rank", group, rank);
   *rank = getAmpiParent()->getRank(group);
   return MPI_SUCCESS;
 }
@@ -10478,7 +10479,7 @@ AMPI_API_IMPL(int, MPI_Group_rank, MPI_Group group, int *rank)
 AMPI_API_IMPL(int, MPI_Group_translate_ranks, MPI_Group group1, int n, const int *ranks1,
                                               MPI_Group group2, int *ranks2)
 {
-  AMPI_API("AMPI_Group_translate_ranks");
+  AMPI_API("AMPI_Group_translate_ranks", group1, n, ranks1, group2, ranks2);
   ampiParent *ptr = getAmpiParent();
   std::vector<int> vec1 = ptr->group2vec(group1);
   std::vector<int> vec2 = ptr->group2vec(group2);
@@ -10486,9 +10487,9 @@ AMPI_API_IMPL(int, MPI_Group_translate_ranks, MPI_Group group1, int n, const int
   return MPI_SUCCESS;
 }
 
-AMPI_API_IMPL(int, MPI_Group_compare, MPI_Group group1,MPI_Group group2, int *result)
+AMPI_API_IMPL(int, MPI_Group_compare, MPI_Group group1, MPI_Group group2, int *result)
 {
-  AMPI_API("AMPI_Group_compare");
+  AMPI_API("AMPI_Group_compare", group1, group2, result);
   ampiParent *ptr = getAmpiParent();
   std::vector<int> vec1 = ptr->group2vec(group1);
   std::vector<int> vec2 = ptr->group2vec(group2);
@@ -10498,7 +10499,7 @@ AMPI_API_IMPL(int, MPI_Group_compare, MPI_Group group1,MPI_Group group2, int *re
 
 AMPI_API_IMPL(int, MPI_Group_incl, MPI_Group group, int n, const int *ranks, MPI_Group *newgroup)
 {
-  AMPI_API("AMPI_Group_incl");
+  AMPI_API("AMPI_Group_incl", group, n, ranks, newgroup);
   ampiParent *ptr = getAmpiParent();
   std::vector<int> vec = ptr->group2vec(group);
   std::vector<int> newvec = inclOp(n,ranks,vec);
@@ -10508,7 +10509,7 @@ AMPI_API_IMPL(int, MPI_Group_incl, MPI_Group group, int n, const int *ranks, MPI
 
 AMPI_API_IMPL(int, MPI_Group_excl, MPI_Group group, int n, const int *ranks, MPI_Group *newgroup)
 {
-  AMPI_API("AMPI_Group_excl");
+  AMPI_API("AMPI_Group_excl", group, n, ranks, newgroup);
   ampiParent *ptr = getAmpiParent();
   std::vector<int> vec = ptr->group2vec(group);
   std::vector<int> newvec = exclOp(n,ranks,vec);
@@ -10518,7 +10519,7 @@ AMPI_API_IMPL(int, MPI_Group_excl, MPI_Group group, int n, const int *ranks, MPI
 
 AMPI_API_IMPL(int, MPI_Group_range_incl, MPI_Group group, int n, int ranges[][3], MPI_Group *newgroup)
 {
-  AMPI_API("AMPI_Group_range_incl");
+  AMPI_API("AMPI_Group_range_incl", group, n, ranges, newgroup);
   int ret;
   ampiParent *ptr = getAmpiParent();
   std::vector<int> vec = ptr->group2vec(group);
@@ -10534,7 +10535,7 @@ AMPI_API_IMPL(int, MPI_Group_range_incl, MPI_Group group, int n, int ranges[][3]
 
 AMPI_API_IMPL(int, MPI_Group_range_excl, MPI_Group group, int n, int ranges[][3], MPI_Group *newgroup)
 {
-  AMPI_API("AMPI_Group_range_excl");
+  AMPI_API("AMPI_Group_range_excl", group, n, ranges, newgroup);
   int ret;
   ampiParent *ptr = getAmpiParent();
   std::vector<int> vec = ptr->group2vec(group);
@@ -10550,13 +10551,13 @@ AMPI_API_IMPL(int, MPI_Group_range_excl, MPI_Group group, int n, int ranges[][3]
 
 AMPI_API_IMPL(int, MPI_Group_free, MPI_Group *group)
 {
-  AMPI_API("AMPI_Group_free");
+  AMPI_API("AMPI_Group_free", group);
   return MPI_SUCCESS;
 }
 
 AMPI_API_IMPL(int, MPI_Comm_create, MPI_Comm comm, MPI_Group group, MPI_Comm* newcomm)
 {
-  AMPI_API("AMPI_Comm_create");
+  AMPI_API("AMPI_Comm_create", comm, group, newcomm);
   int rank_in_group, key, color, zero;
   MPI_Group group_of_comm;
 
@@ -10595,7 +10596,7 @@ AMPI_API_IMPL(int, MPI_Comm_create, MPI_Comm comm, MPI_Group group, MPI_Comm* ne
 
 AMPI_API_IMPL(int, MPI_Comm_create_group, MPI_Comm comm, MPI_Group group, int tag, MPI_Comm *newcomm)
 {
-  AMPI_API("AMPI_Comm_create_group");
+  AMPI_API("AMPI_Comm_create_group", comm, group, tag, newcomm);
 
   if (group == MPI_GROUP_NULL) {
     *newcomm = MPI_COMM_NULL;
@@ -10658,28 +10659,28 @@ AMPI_API_IMPL(int, MPI_Comm_create_group, MPI_Comm comm, MPI_Group group, int ta
 
 AMPI_API_IMPL(int, MPI_Comm_set_name, MPI_Comm comm, const char *comm_name)
 {
-  AMPI_API("AMPI_Comm_set_name");
+  AMPI_API("AMPI_Comm_set_name", comm, comm_name);
   getAmpiInstance(comm)->setCommName(comm_name);
   return MPI_SUCCESS;
 }
 
 AMPI_API_IMPL(int, MPI_Comm_get_name, MPI_Comm comm, char *comm_name, int *resultlen)
 {
-  AMPI_API("AMPI_Comm_get_name");
+  AMPI_API("AMPI_Comm_get_name", comm, comm_name, resultlen);
   getAmpiInstance(comm)->getCommName(comm_name, resultlen);
   return MPI_SUCCESS;
 }
 
 AMPI_API_IMPL(int, MPI_Comm_set_info, MPI_Comm comm, MPI_Info info)
 {
-  AMPI_API("AMPI_Comm_set_info");
+  AMPI_API("AMPI_Comm_set_info", comm, info);
   /* FIXME: no-op implementation */
   return MPI_SUCCESS;
 }
 
 AMPI_API_IMPL(int, MPI_Comm_get_info, MPI_Comm comm, MPI_Info *info)
 {
-  AMPI_API("AMPI_Comm_get_info");
+  AMPI_API("AMPI_Comm_get_info", comm, info);
   /* FIXME: no-op implementation */
   *info = MPI_INFO_NULL;
   return MPI_SUCCESS;
@@ -10689,14 +10690,14 @@ AMPI_API_IMPL(int, MPI_Comm_create_keyval, MPI_Comm_copy_attr_function *copy_fn,
                                            MPI_Comm_delete_attr_function *delete_fn,
                                            int *keyval, void* extra_state)
 {
-  AMPI_API("AMPI_Comm_create_keyval");
+  AMPI_API("AMPI_Comm_create_keyval", copy_fn, delete_fn, keyval, extra_state);
   int ret = getAmpiParent()->createKeyval(copy_fn,delete_fn,keyval,extra_state);
   return ampiErrhandler("AMPI_Comm_create_keyval", ret);
 }
 
 AMPI_API_IMPL(int, MPI_Comm_free_keyval, int *keyval)
 {
-  AMPI_API("AMPI_Comm_free_keyval");
+  AMPI_API("AMPI_Comm_free_keyval", keyval);
   int ret = getAmpiParent()->freeKeyval(*keyval);
   *keyval = MPI_KEYVAL_INVALID;
   return ampiErrhandler("AMPI_Comm_free_keyval", ret);
@@ -10704,7 +10705,7 @@ AMPI_API_IMPL(int, MPI_Comm_free_keyval, int *keyval)
 
 AMPI_API_IMPL(int, MPI_Comm_set_attr, MPI_Comm comm, int keyval, void* attribute_val)
 {
-  AMPI_API("AMPI_Comm_set_attr");
+  AMPI_API("AMPI_Comm_set_attr", comm, keyval, attribute_val);
   ampiParent *parent = getAmpiParent();
   int ret = parent->setAttr(comm, parent->getAttributes(comm), keyval, attribute_val);
   return ampiErrhandler("AMPI_Comm_set_attr", ret);
@@ -10712,7 +10713,7 @@ AMPI_API_IMPL(int, MPI_Comm_set_attr, MPI_Comm comm, int keyval, void* attribute
 
 AMPI_API_IMPL(int, MPI_Comm_get_attr, MPI_Comm comm, int keyval, void *attribute_val, int *flag)
 {
-  AMPI_API("AMPI_Comm_get_attr");
+  AMPI_API("AMPI_Comm_get_attr", comm, keyval, attribute_val, flag);
   ampiParent *parent = getAmpiParent();
   int ret = parent->getAttr(comm, parent->getAttributes(comm), keyval, attribute_val, flag);
   return ampiErrhandler("AMPI_Comm_get_attr", ret);
@@ -10720,7 +10721,7 @@ AMPI_API_IMPL(int, MPI_Comm_get_attr, MPI_Comm comm, int keyval, void *attribute
 
 AMPI_API_IMPL(int, MPI_Comm_delete_attr, MPI_Comm comm, int keyval)
 {
-  AMPI_API("AMPI_Comm_delete_attr");
+  AMPI_API("AMPI_Comm_delete_attr", comm, keyval);
   ampiParent *parent = getAmpiParent();
   int ret = parent->deleteAttr(comm, parent->getAttributes(comm), keyval);
   return ampiErrhandler("AMPI_Comm_delete_attr", ret);
@@ -10729,38 +10730,38 @@ AMPI_API_IMPL(int, MPI_Comm_delete_attr, MPI_Comm comm, int keyval)
 AMPI_API_IMPL(int, MPI_Keyval_create, MPI_Copy_function *copy_fn, MPI_Delete_function *delete_fn,
                                       int *keyval, void* extra_state)
 {
-  AMPI_API("AMPI_Keyval_create");
+  AMPI_API("AMPI_Keyval_create", copy_fn, delete_fn, keyval, extra_state);
   return MPI_Comm_create_keyval(copy_fn, delete_fn, keyval, extra_state);
 }
 
 AMPI_API_IMPL(int, MPI_Keyval_free, int *keyval)
 {
-  AMPI_API("AMPI_Keyval_free");
+  AMPI_API("AMPI_Keyval_free", keyval);
   return MPI_Comm_free_keyval(keyval);
 }
 
 AMPI_API_IMPL(int, MPI_Attr_put, MPI_Comm comm, int keyval, void* attribute_val)
 {
-  AMPI_API("AMPI_Attr_put");
+  AMPI_API("AMPI_Attr_put", comm, keyval, attribute_val);
   return MPI_Comm_set_attr(comm, keyval, attribute_val);
 }
 
 AMPI_API_IMPL(int, MPI_Attr_get, MPI_Comm comm, int keyval, void *attribute_val, int *flag)
 {
-  AMPI_API("AMPI_Attr_get");
+  AMPI_API("AMPI_Attr_get", comm, keyval, attribute_val, flag);
   return MPI_Comm_get_attr(comm, keyval, attribute_val, flag);
 }
 
 AMPI_API_IMPL(int, MPI_Attr_delete, MPI_Comm comm, int keyval)
 {
-  AMPI_API("AMPI_Attr_delete");
+  AMPI_API("AMPI_Attr_delete", comm, keyval);
   return MPI_Comm_delete_attr(comm, keyval);
 }
 
 AMPI_API_IMPL(int, MPI_Cart_map, MPI_Comm comm, int ndims, const int *dims,
                                  const int *periods, int *newrank)
 {
-  AMPI_API("AMPI_Cart_map");
+  AMPI_API("AMPI_Cart_map", comm, ndims, dims, periods, newrank);
 
   ampi* ptr = getAmpiInstance(comm);
   int nranks;
@@ -10786,7 +10787,7 @@ AMPI_API_IMPL(int, MPI_Cart_map, MPI_Comm comm, int ndims, const int *dims,
 AMPI_API_IMPL(int, MPI_Graph_map, MPI_Comm comm, int nnodes, const int *index,
                                   const int *edges, int *newrank)
 {
-  AMPI_API("AMPI_Graph_map");
+  AMPI_API("AMPI_Graph_map", comm, nnodes, index, edges, newrank);
 
   ampi* ptr = getAmpiInstance(comm);
 
@@ -10801,7 +10802,7 @@ AMPI_API_IMPL(int, MPI_Graph_map, MPI_Comm comm, int nnodes, const int *index,
 AMPI_API_IMPL(int, MPI_Cart_create, MPI_Comm comm_old, int ndims, const int *dims,
                                     const int *periods, int reorder, MPI_Comm *comm_cart)
 {
-  AMPI_API("AMPI_Cart_create");
+  AMPI_API("AMPI_Cart_create", comm_old, ndims, dims, periods, reorder, comm_cart);
 
   /* Create new cartesian communicator. No attention is being paid to mapping
      virtual processes to processors, which ideally should be handled by the
@@ -10835,7 +10836,7 @@ AMPI_API_IMPL(int, MPI_Cart_create, MPI_Comm comm_old, int ndims, const int *dim
 AMPI_API_IMPL(int, MPI_Graph_create, MPI_Comm comm_old, int nnodes, const int *index,
                                      const int *edges, int reorder, MPI_Comm *comm_graph)
 {
-  AMPI_API("AMPI_Graph_create");
+  AMPI_API("AMPI_Graph_create", comm_old, nnodes, index, edges, reorder, comm_graph);
 
   if (nnodes == 0) {
     *comm_graph = MPI_COMM_NULL;
@@ -10870,7 +10871,7 @@ AMPI_API_IMPL(int, MPI_Dist_graph_create_adjacent, MPI_Comm comm_old, int indegr
                                                    const int destinations[], const int destweights[],
                                                    MPI_Info info, int reorder, MPI_Comm *comm_dist_graph)
 {
-  AMPI_API("AMPI_Dist_graph_create_adjacent");
+  AMPI_API("AMPI_Dist_graph_create_adjacent", comm_old, indegree, sources, sourceweights, outdegree, destinations, destweights, info, reorder, comm_dist_graph);
 
 #if AMPI_ERROR_CHECKING
   if (indegree < 0 || outdegree < 0) {
@@ -10922,7 +10923,7 @@ AMPI_API_IMPL(int, MPI_Dist_graph_create, MPI_Comm comm_old, int n, const int so
                                           const int destinations[], const int weights[], MPI_Info info,
                                           int reorder, MPI_Comm *comm_dist_graph)
 {
-  AMPI_API("AMPI_Dist_graph_create");
+  AMPI_API("AMPI_Dist_graph_create", comm_old, n, sources, degrees, destinations, weights, info, reorder, comm_dist_graph);
 
 #if AMPI_ERROR_CHECKING
     if (n < 0) {
@@ -11059,7 +11060,7 @@ AMPI_API_IMPL(int, MPI_Dist_graph_create, MPI_Comm comm_old, int n, const int so
 
 AMPI_API_IMPL(int, MPI_Topo_test, MPI_Comm comm, int *status)
 {
-  AMPI_API("AMPI_Topo_test");
+  AMPI_API("AMPI_Topo_test", comm, status);
 
   ampiParent *ptr = getAmpiParent();
 
@@ -11076,7 +11077,7 @@ AMPI_API_IMPL(int, MPI_Topo_test, MPI_Comm comm, int *status)
 
 AMPI_API_IMPL(int, MPI_Cartdim_get, MPI_Comm comm, int *ndims)
 {
-  AMPI_API("AMPI_Cartdim_get");
+  AMPI_API("AMPI_Cartdim_get", comm, ndims);
 
 #if AMPI_ERROR_CHECKING
   if (!getAmpiParent()->isCart(comm))
@@ -11092,7 +11093,7 @@ AMPI_API_IMPL(int, MPI_Cart_get, MPI_Comm comm, int maxdims, int *dims, int *per
 {
   int i, ndims;
 
-  AMPI_API("AMPI_Cart_get");
+  AMPI_API("AMPI_Cart_get", comm, maxdims, dims, periods, coords);
 
 #if AMPI_ERROR_CHECKING
   if (!getAmpiParent()->isCart(comm))
@@ -11123,7 +11124,7 @@ AMPI_API_IMPL(int, MPI_Cart_get, MPI_Comm comm, int maxdims, int *dims, int *per
 
 AMPI_API_IMPL(int, MPI_Cart_rank, MPI_Comm comm, const int *coords, int *rank)
 {
-  AMPI_API("AMPI_Cart_rank");
+  AMPI_API("AMPI_Cart_rank", comm, coords, rank);
 
 #if AMPI_ERROR_CHECKING
   if (!getAmpiParent()->isCart(comm))
@@ -11163,7 +11164,7 @@ AMPI_API_IMPL(int, MPI_Cart_rank, MPI_Comm comm, const int *coords, int *rank)
 
 AMPI_API_IMPL(int, MPI_Cart_coords, MPI_Comm comm, int rank, int maxdims, int *coords)
 {
-  AMPI_API("AMPI_Cart_coords");
+  AMPI_API("AMPI_Cart_coords", comm, rank, maxdims, coords);
 
 #if AMPI_ERROR_CHECKING
   if (!getAmpiParent()->isCart(comm))
@@ -11211,7 +11212,7 @@ static void cart_clamp_coord(MPI_Comm comm, const std::vector<int> &dims,
 AMPI_API_IMPL(int, MPI_Cart_shift, MPI_Comm comm, int direction, int disp,
                                    int *rank_source, int *rank_dest)
 {
-  AMPI_API("AMPI_Cart_shift");
+  AMPI_API("AMPI_Cart_shift", comm, direction, disp, rank_source, rank_dest);
 
 #if AMPI_ERROR_CHECKING
   if (!getAmpiParent()->isCart(comm))
@@ -11242,7 +11243,7 @@ AMPI_API_IMPL(int, MPI_Cart_shift, MPI_Comm comm, int direction, int disp,
 
 AMPI_API_IMPL(int, MPI_Graphdims_get, MPI_Comm comm, int *nnodes, int *nedges)
 {
-  AMPI_API("AMPI_Graphdim_get");
+  AMPI_API("AMPI_Graphdim_get", comm, nnodes, nedges);
 
   ampiCommStruct &c = getAmpiParent()->getGraph(comm);
   ampiTopology *topo = c.getTopology();
@@ -11255,7 +11256,7 @@ AMPI_API_IMPL(int, MPI_Graphdims_get, MPI_Comm comm, int *nnodes, int *nedges)
 
 AMPI_API_IMPL(int, MPI_Graph_get, MPI_Comm comm, int maxindex, int maxedges, int *index, int *edges)
 {
-  AMPI_API("AMPI_Graph_get");
+  AMPI_API("AMPI_Graph_get", comm, maxindex, maxedges, index, edges);
 
 #if AMPI_ERROR_CHECKING
   if (!getAmpiParent()->isGraph(comm))
@@ -11282,7 +11283,7 @@ AMPI_API_IMPL(int, MPI_Graph_get, MPI_Comm comm, int maxindex, int maxedges, int
 
 AMPI_API_IMPL(int, MPI_Graph_neighbors_count, MPI_Comm comm, int rank, int *nneighbors)
 {
-  AMPI_API("AMPI_Graph_neighbors_count");
+  AMPI_API("AMPI_Graph_neighbors_count", comm, rank, nneighbors);
 
 #if AMPI_ERROR_CHECKING
   if (!getAmpiParent()->isGraph(comm))
@@ -11308,7 +11309,7 @@ AMPI_API_IMPL(int, MPI_Graph_neighbors_count, MPI_Comm comm, int rank, int *nnei
 
 AMPI_API_IMPL(int, MPI_Graph_neighbors, MPI_Comm comm, int rank, int maxneighbors, int *neighbors)
 {
-  AMPI_API("AMPI_Graph_neighbors");
+  AMPI_API("AMPI_Graph_neighbors", comm, rank, maxneighbors, neighbors);
 
 #if AMPI_ERROR_CHECKING
   if (!getAmpiParent()->isGraph(comm))
@@ -11343,7 +11344,7 @@ AMPI_API_IMPL(int, MPI_Graph_neighbors, MPI_Comm comm, int rank, int maxneighbor
 
 AMPI_API_IMPL(int, MPI_Dist_graph_neighbors_count, MPI_Comm comm, int *indegree, int *outdegree, int *weighted)
 {
-  AMPI_API("AMPI_Dist_graph_neighbors_count");
+  AMPI_API("AMPI_Dist_graph_neighbors_count", comm, indegree, outdegree, weighted);
 
 #if AMPI_ERROR_CHECKING
   if (!getAmpiParent()->isDistGraph(comm)) {
@@ -11364,7 +11365,7 @@ AMPI_API_IMPL(int, MPI_Dist_graph_neighbors_count, MPI_Comm comm, int *indegree,
 AMPI_API_IMPL(int, MPI_Dist_graph_neighbors, MPI_Comm comm, int maxindegree, int sources[], int sourceweights[],
                                              int maxoutdegree, int destinations[], int destweights[])
 {
-  AMPI_API("AMPI_Dist_graph_neighbors");
+  AMPI_API("AMPI_Dist_graph_neighbors", comm, maxindegree, sources, sourceweights, maxoutdegree, destinations, destweights);
 
 #if AMPI_ERROR_CHECKING
   if (!getAmpiParent()->isDistGraph(comm)) {
@@ -11476,7 +11477,7 @@ bool factors(int n, int d, int *dims, int m) noexcept {
 
 AMPI_API_IMPL(int, MPI_Dims_create, int nnodes, int ndims, int *dims)
 {
-  AMPI_API("AMPI_Dims_create");
+  AMPI_API("AMPI_Dims_create", nnodes, ndims, dims);
 
   int i, n, d;
 
@@ -11530,7 +11531,7 @@ AMPI_API_IMPL(int, MPI_Dims_create, int nnodes, int ndims, int *dims)
  */
 AMPI_API_IMPL(int, MPI_Cart_sub, MPI_Comm comm, const int *remain_dims, MPI_Comm *newcomm)
 {
-  AMPI_API("AMPI_Cart_sub");
+  AMPI_API("AMPI_Cart_sub", comm, remain_dims, newcomm);
 
   int i, ndims;
   int color = 1, key = 1;
@@ -11595,7 +11596,7 @@ AMPI_API_IMPL(int, MPI_Cart_sub, MPI_Comm comm, const int *remain_dims, MPI_Comm
 AMPI_API_IMPL(int, MPI_Type_get_envelope, MPI_Datatype datatype, int *ni, int *na,
                                           int *nd, int *combiner)
 {
-  AMPI_API("AMPI_Type_get_envelope");
+  AMPI_API("AMPI_Type_get_envelope", datatype, ni, na, nd, combiner);
 
 #if AMPI_ERROR_CHECKING
   int ret = checkData("AMPI_Type_get_envelope", datatype);
@@ -11609,7 +11610,7 @@ AMPI_API_IMPL(int, MPI_Type_get_envelope, MPI_Datatype datatype, int *ni, int *n
 AMPI_API_IMPL(int, MPI_Type_get_contents, MPI_Datatype datatype, int ni, int na, int nd,
                                           int i[], MPI_Aint a[], MPI_Datatype d[])
 {
-  AMPI_API("AMPI_Type_get_contents");
+  AMPI_API("AMPI_Type_get_contents", datatype, ni, na, nd, i, a, d);
 
 #if AMPI_ERROR_CHECKING
   int ret = checkData("AMPI_Type_get_contents", datatype);
@@ -11631,7 +11632,7 @@ AMPI_API_IMPL(int, MPI_Pcontrol, const int level, ...)
 
 AMPI_API_IMPL(int, MPIR_Status_set_bytes, MPI_Status *sts, MPI_Datatype dtype, MPI_Count nbytes)
 {
-  AMPI_API("AMPIR_Status_set_bytes");
+  AMPI_API("AMPIR_Status_set_bytes", sts, dtype, nbytes);
   return MPI_Status_set_elements_x(sts, MPI_BYTE, nbytes);
 }
 
@@ -11639,7 +11640,7 @@ AMPI_API_IMPL(int, MPIR_Status_set_bytes, MPI_Status *sts, MPI_Datatype dtype, M
 
 CLINKAGE int AMPI_Init_universe(int * unicomm)
 {
-  AMPI_API("AMPI_Init_universe");
+  AMPI_API("AMPI_Init_universe", unicomm);
   for(int i=0; i<_mpi_nworlds; i++) {
     unicomm[i] = MPI_COMM_UNIVERSE[i];
   }
@@ -11658,7 +11659,7 @@ CLINKAGE int AMPI_Get_argc()
 
 CLINKAGE int AMPI_Migrate(MPI_Info hints)
 {
-  AMPI_API("AMPI_Migrate");
+  AMPI_API("AMPI_Migrate", hints);
   int nkeys, exists;
   char key[MPI_MAX_INFO_KEY], value[MPI_MAX_INFO_VAL];
 
@@ -11756,7 +11757,7 @@ int AMPI_Evacuate(void)
 CLINKAGE
 int AMPI_Migrate_to_pe(int dest)
 {
-  AMPI_API("AMPI_Migrate_to_pe");
+  AMPI_API("AMPI_Migrate_to_pe", dest);
   TCHARM_Migrate_to(dest);
 #if CMK_BIGSIM_CHARM
   TRACE_BG_ADD_TAG("AMPI_MIGRATE_TO_PE");
@@ -11767,7 +11768,7 @@ int AMPI_Migrate_to_pe(int dest)
 CLINKAGE
 int AMPI_Set_migratable(int mig)
 {
-  AMPI_API("AMPI_Set_migratable");
+  AMPI_API("AMPI_Set_migratable", mig);
 #if CMK_LBDB_ON
   getAmpiParent()->setMigratable((mig!=0));
 #else
@@ -11779,7 +11780,7 @@ int AMPI_Set_migratable(int mig)
 CLINKAGE
 int AMPI_Load_start_measure(void)
 {
-  AMPI_API("AMPI_Load_start_measure");
+  AMPI_API("AMPI_Load_start_measure", "");
   LBTurnInstrumentOn();
   return MPI_SUCCESS;
 }
@@ -11787,7 +11788,7 @@ int AMPI_Load_start_measure(void)
 CLINKAGE
 int AMPI_Load_stop_measure(void)
 {
-  AMPI_API("AMPI_Load_stop_measure");
+  AMPI_API("AMPI_Load_stop_measure", "");
   LBTurnInstrumentOff();
   return MPI_SUCCESS;
 }
@@ -11795,7 +11796,7 @@ int AMPI_Load_stop_measure(void)
 CLINKAGE
 int AMPI_Load_reset_measure(void)
 {
-  AMPI_API("AMPI_Load_reset_measure");
+  AMPI_API("AMPI_Load_reset_measure", "");
   LBClearLoads();
   return MPI_SUCCESS;
 }
@@ -11803,7 +11804,7 @@ int AMPI_Load_reset_measure(void)
 CLINKAGE
 int AMPI_Load_set_value(double value)
 {
-  AMPI_API("AMPI_Load_set_value");
+  AMPI_API("AMPI_Load_set_value", value);
   ampiParent *ptr = getAmpiParent();
   ptr->setObjTime(value);
   return MPI_SUCCESS;
@@ -11816,7 +11817,7 @@ void _registerampif(void) {
 CLINKAGE
 int AMPI_Register_main(MPI_MainFn mainFn,const char *name)
 {
-  AMPI_API("AMPI_Register_main");
+  AMPI_API("AMPI_Register_main", mainFn, name);
   if (TCHARM_Element()==0)
   { // I'm responsible for building the TCHARM threads:
     ampiCreateMain(mainFn,name,strlen(name));
@@ -11828,7 +11829,7 @@ FLINKAGE
 void FTN_NAME(MPI_REGISTER_MAIN,mpi_register_main)
 (MPI_MainFn mainFn,const char *name,int nameLen)
 {
-  AMPI_API("AMPI_register_main");
+  AMPI_API("AMPI_register_main", name, nameLen);
   if (TCHARM_Element()==0)
   { // I'm responsible for building the TCHARM threads:
     ampiCreateMain(mainFn,name,nameLen);
@@ -11838,7 +11839,7 @@ void FTN_NAME(MPI_REGISTER_MAIN,mpi_register_main)
 CLINKAGE
 int AMPI_Register_pup(MPI_PupFn fn, void *data, int *idx)
 {
-  AMPI_API("AMPI_Register_pup");
+  AMPI_API("AMPI_Register_pup", fn, data, idx);
   *idx = TCHARM_Register(data, fn);
   return MPI_SUCCESS;
 }
@@ -11846,7 +11847,7 @@ int AMPI_Register_pup(MPI_PupFn fn, void *data, int *idx)
 CLINKAGE
 int AMPI_Register_about_to_migrate(MPI_MigrateFn fn)
 {
-  AMPI_API("AMPI_Register_about_to_migrate");
+  AMPI_API("AMPI_Register_about_to_migrate", fn);
   ampiParent *thisParent = getAmpiParent();
   thisParent->setUserAboutToMigrateFn(fn);
   return MPI_SUCCESS;
@@ -11855,7 +11856,7 @@ int AMPI_Register_about_to_migrate(MPI_MigrateFn fn)
 CLINKAGE
 int AMPI_Register_just_migrated(MPI_MigrateFn fn)
 {
-  AMPI_API("AMPI_Register_just_migrated");
+  AMPI_API("AMPI_Register_just_migrated", fn);
   ampiParent *thisParent = getAmpiParent();
   thisParent->setUserJustMigratedFn(fn);
   return MPI_SUCCESS;
@@ -11864,7 +11865,7 @@ int AMPI_Register_just_migrated(MPI_MigrateFn fn)
 CLINKAGE
 int AMPI_Get_pup_data(int idx, void *data)
 {
-  AMPI_API("AMPI_Get_pup_data");
+  AMPI_API("AMPI_Get_pup_data", idx, data);
   data = TCHARM_Get_userdata(idx);
   return MPI_SUCCESS;
 }
@@ -11872,7 +11873,7 @@ int AMPI_Get_pup_data(int idx, void *data)
 CLINKAGE
 int AMPI_Type_is_contiguous(MPI_Datatype datatype, int *flag)
 {
-  AMPI_API("AMPI_Type_is_contiguous");
+  AMPI_API("AMPI_Type_is_contiguous", datatype, flag);
   *flag = getDDT()->isContig(datatype);
   return MPI_SUCCESS;
 }
@@ -11880,7 +11881,7 @@ int AMPI_Type_is_contiguous(MPI_Datatype datatype, int *flag)
 CLINKAGE
 int AMPI_Print(const char *str)
 {
-  AMPI_API("AMPI_Print");
+  AMPI_API("AMPI_Print", str);
   ampiParent *ptr = getAmpiParent();
   CkPrintf("[%d] %s\n", ptr->thisIndex, str);
   return MPI_SUCCESS;
@@ -11889,7 +11890,7 @@ int AMPI_Print(const char *str)
 CLINKAGE
 int AMPI_Suspend(void)
 {
-  AMPI_API("AMPI_Suspend");
+  AMPI_API("AMPI_Suspend", "");
   ampiParent* unused = getAmpiParent()->block();
   return MPI_SUCCESS;
 }
@@ -11897,7 +11898,7 @@ int AMPI_Suspend(void)
 CLINKAGE
 int AMPI_Yield(void)
 {
-  AMPI_API("AMPI_Yield");
+  AMPI_API("AMPI_Yield", "");
   ampiParent* unused = getAmpiParent()->yield();
   return MPI_SUCCESS;
 }
@@ -11905,7 +11906,7 @@ int AMPI_Yield(void)
 CLINKAGE
 int AMPI_Resume(int dest, MPI_Comm comm)
 {
-  AMPI_API("AMPI_Resume");
+  AMPI_API("AMPI_Resume", dest, comm);
   getAmpiInstance(comm)->getProxy()[dest].unblock();
   return MPI_SUCCESS;
 }
@@ -11960,7 +11961,7 @@ extern "C" void startCFnCall(void *param,void *msg)
 CLINKAGE
 int AMPI_Set_start_event(MPI_Comm comm)
 {
-  AMPI_API("AMPI_Set_start_event");
+  AMPI_API("AMPI_Set_start_event", comm);
   CkAssert(comm == MPI_COMM_WORLD);
 
   ampi *ptr = getAmpiInstance(comm);
@@ -11986,7 +11987,7 @@ int AMPI_Set_start_event(MPI_Comm comm)
 CLINKAGE
 int AMPI_Set_end_event(void)
 {
-  AMPI_API("AMPI_Set_end_event");
+  AMPI_API("AMPI_Set_end_event", "");
   return MPI_SUCCESS;
 }
 #endif // CMK_BIGSIM_CHARM
@@ -12046,7 +12047,7 @@ void AMPI_GPU_complete(void *request, void* dummy) noexcept
 CLINKAGE
 int AMPI_GPU_Iinvoke_wr(hapiWorkRequest *to_call, MPI_Request *request)
 {
-  AMPI_API("AMPI_GPU_Iinvoke");
+  AMPI_API("AMPI_GPU_Iinvoke", to_call, request);
 
   ampi* ptr = getAmpiInstance(MPI_COMM_WORLD);
   GPUReq* newreq = new GPUReq();
@@ -12064,7 +12065,7 @@ int AMPI_GPU_Iinvoke_wr(hapiWorkRequest *to_call, MPI_Request *request)
 CLINKAGE
 int AMPI_GPU_Iinvoke(cudaStream_t stream, MPI_Request *request)
 {
-  AMPI_API("AMPI_GPU_Iinvoke");
+  AMPI_API("AMPI_GPU_Iinvoke", stream, request);
 
   ampi* ptr = getAmpiInstance(MPI_COMM_WORLD);
   GPUReq* newreq = new GPUReq();
@@ -12079,7 +12080,7 @@ int AMPI_GPU_Iinvoke(cudaStream_t stream, MPI_Request *request)
 CLINKAGE
 int AMPI_GPU_Invoke_wr(hapiWorkRequest *to_call)
 {
-  AMPI_API("AMPI_GPU_Invoke");
+  AMPI_API("AMPI_GPU_Invoke", to_call);
 
   MPI_Request req;
   AMPI_GPU_Iinvoke_wr(to_call, &req);
@@ -12091,7 +12092,7 @@ int AMPI_GPU_Invoke_wr(hapiWorkRequest *to_call)
 CLINKAGE
 int AMPI_GPU_Invoke(cudaStream_t stream)
 {
-  AMPI_API("AMPI_GPU_Invoke");
+  AMPI_API("AMPI_GPU_Invoke", stream);
 
   MPI_Request req;
   AMPI_GPU_Iinvoke(stream, &req);

--- a/src/libs/ck-libs/ampi/ampi.C
+++ b/src/libs/ck-libs/ampi/ampi.C
@@ -4624,8 +4624,7 @@ AMPI_API_IMPL(int, MPI_Issend, const void *buf, int count, MPI_Datatype type, in
 AMPI_API_IMPL(int, MPI_Recv, void *buf, int count, MPI_Datatype type, int src, int tag,
                              MPI_Comm comm, MPI_Status *status)
 {
-  AMPI_API("AMPI_Recv", buf, count, type, src, tag,
-                              comm, status);
+  AMPI_API("AMPI_Recv", buf, count, type, src, tag, comm, status);
 
   handle_MPI_BOTTOM(buf, type);
 

--- a/src/libs/ck-libs/ampi/ampiMisc.C
+++ b/src/libs/ck-libs/ampi/ampiMisc.C
@@ -316,21 +316,21 @@ void ampiParent::defineInfoMigration() noexcept {
 
 AMPI_API_IMPL(int, MPI_Info_create, MPI_Info *info)
 {
-  AMPI_API("AMPI_Info_create");
+  AMPI_API("AMPI_Info_create", info);
   int ret = getAmpiParent()->createInfo(info);
   return ampiErrhandler("AMPI_Info_create", ret);
 }
 
 AMPI_API_IMPL(int, MPI_Info_set, MPI_Info info, const char *key, const char *value)
 {
-  AMPI_API("AMPI_Info_set");
+  AMPI_API("AMPI_Info_set", info, key, value);
   int ret = getAmpiParent()->setInfo(info, key, value);
   return ampiErrhandler("AMPI_Info_set", ret);
 }
 
 AMPI_API_IMPL(int, MPI_Info_delete, MPI_Info info, const char *key)
 {
-  AMPI_API("AMPI_Info_delete");
+  AMPI_API("AMPI_Info_delete", info, key);
   int ret = getAmpiParent()->deleteInfo(info, key);
   return ampiErrhandler("AMPI_Info_delete", ret);
 }
@@ -338,7 +338,7 @@ AMPI_API_IMPL(int, MPI_Info_delete, MPI_Info info, const char *key)
 AMPI_API_IMPL(int, MPI_Info_get, MPI_Info info, const char *key, int valuelen,
                                  char *value, int *flag)
 {
-  AMPI_API("AMPI_Info_get");
+  AMPI_API("AMPI_Info_get", info, key, valuelen, value, flag);
   getAmpiParent()->getInfo(info, key, valuelen, value, flag);
   return MPI_SUCCESS; // It is not an error if the requested key does not exist
 }
@@ -346,35 +346,35 @@ AMPI_API_IMPL(int, MPI_Info_get, MPI_Info info, const char *key, int valuelen,
 AMPI_API_IMPL(int, MPI_Info_get_valuelen, MPI_Info info, const char *key,
                                           int *valuelen, int *flag)
 {
-  AMPI_API("AMPI_Info_get_valuelen");
+  AMPI_API("AMPI_Info_get_valuelen", info, key, valuelen, flag);
   getAmpiParent()->getInfoValuelen(info, key, valuelen, flag);
   return MPI_SUCCESS; // It is not an error if the requested key does not exist
 }
 
 AMPI_API_IMPL(int, MPI_Info_get_nkeys, MPI_Info info, int *nkeys)
 {
-  AMPI_API("AMPI_Info_get_nkeys");
+  AMPI_API("AMPI_Info_get_nkeys", info, nkeys);
   int ret = getAmpiParent()->getInfoNkeys(info, nkeys);
   return ampiErrhandler("AMPI_Info_get_nkeys", ret);
 }
 
 AMPI_API_IMPL(int, MPI_Info_get_nthkey, MPI_Info info, int n, char *key)
 {
-  AMPI_API("AMPI_Info_get_nthkey");
+  AMPI_API("AMPI_Info_get_nthkey", info, n, key);
   int ret = getAmpiParent()->getInfoNthkey(info, n, key);
   return ampiErrhandler("AMPI_Info_get_nthkey", ret);
 }
 
 AMPI_API_IMPL(int, MPI_Info_dup, MPI_Info info, MPI_Info *newinfo)
 {
-  AMPI_API("AMPI_Info_dup");
+  AMPI_API("AMPI_Info_dup", info, newinfo);
   int ret = getAmpiParent()->dupInfo(info, newinfo);
   return ampiErrhandler("AMPI_Info_dup", ret);
 }
 
 AMPI_API_IMPL(int, MPI_Info_free, MPI_Info *info)
 {
-  AMPI_API("AMPI_Info_free");
+  AMPI_API("AMPI_Info_free", info);
   int ret = getAmpiParent()->freeInfo(*info);
   *info = MPI_INFO_NULL;
   return ampiErrhandler("AMPI_Info_free", ret);

--- a/src/libs/ck-libs/ampi/ampiOneSided.C
+++ b/src/libs/ck-libs/ampi/ampiOneSided.C
@@ -374,7 +374,7 @@ AmpiMsg* ampi::winRemoteIget(MPI_Aint orgdisp, int orgcnt, MPI_Datatype orgtype,
 
 int ampi::winIgetWait(MPI_Request *request, MPI_Status *status) noexcept {
   // Wait on the Future object
-  AMPI_DEBUG("    [%d] Iget Waiting\n", thisIndex, *request);
+  AMPI_DEBUG("    [%d] Iget Waiting [%d]\n", thisIndex, *request);
   status->msg = (AmpiMsg*)CkWaitReleaseFuture(*request);
   AMPI_DEBUG("    [%d] Iget Waiting [%d] awaken\n", thisIndex, *request);
   return MPI_SUCCESS;
@@ -667,7 +667,7 @@ MPI_Win ampi::createWinInstance(void *base, MPI_Aint size, int disp_unit, MPI_In
   win_obj *newobj = new win_obj((char*)(NULL), base, size, disp_unit, myComm.getComm());
   winObjects.push_back(newobj);
   WinStruct *newwin = new WinStruct(myComm.getComm(),winObjects.size()-1);
-  AMPI_DEBUG("     Creating MPI_WIN at (%p) with {%d, %d}\n", &newwin, myComm.getComm(), winObjects.size()-1);
+  AMPI_DEBUG("     Creating MPI_WIN at (%p) with {%d, %ld}\n", &newwin, myComm.getComm(), winObjects.size()-1);
   return (parent->addWinStruct(newwin));
 }
 
@@ -724,7 +724,7 @@ win_obj* ampi::getWinObjInstance(WinStruct *win) const noexcept {
 AMPI_API_IMPL(int, MPI_Win_create, void *base, MPI_Aint size, int disp_unit,
                                    MPI_Info info, MPI_Comm comm, MPI_Win *newwin)
 {
-  AMPI_API("AMPI_Win_create");
+  AMPI_API("AMPI_Win_create", base, size, disp_unit, info, comm, newwin);
   ampiParent *parent = getAmpiParent();
   ampi *ptr = getAmpiInstance(comm);
   *newwin = ptr->createWinInstance(base, size, disp_unit, info);
@@ -740,7 +740,7 @@ AMPI_API_IMPL(int, MPI_Win_create, void *base, MPI_Aint size, int disp_unit,
 
 AMPI_API_IMPL(int, MPI_Win_allocate, MPI_Aint size, int disp_unit, MPI_Info info, MPI_Comm comm, void *baseptr, MPI_Win *win)
 {
-  AMPI_API("AMPI_Win_allocate");
+  AMPI_API("AMPI_Win_allocate", size, disp_unit, info, comm, baseptr, win);
 
   int res = MPI_Alloc_mem(size, info, (void**)baseptr);
   if(res != MPI_SUCCESS)
@@ -768,7 +768,7 @@ AMPI_API_IMPL(int, MPI_Win_allocate, MPI_Aint size, int disp_unit, MPI_Info info
 // MPI_Win object deleted LOCALLY on all processes when the call returns
 AMPI_API_IMPL(int, MPI_Win_free, MPI_Win *win)
 {
-  AMPI_API("AMPI_Win_free");
+  AMPI_API("AMPI_Win_free", win);
   if(win==NULL) { return ampiErrhandler("AMPI_Win_free", MPI_ERR_WIN); }
 
   ampiParent *parent = getAmpiParent();
@@ -794,7 +794,7 @@ AMPI_API_IMPL(int, MPI_Win_free, MPI_Win *win)
 AMPI_API_IMPL(int, MPI_Put, const void *orgaddr, int orgcnt, MPI_Datatype orgtype, int rank,
                             MPI_Aint targdisp, int targcnt, MPI_Datatype targtype, MPI_Win win)
 {
-  AMPI_API("AMPI_Put");
+  AMPI_API("AMPI_Put", orgaddr, orgcnt, orgtype, rank, targdisp, targcnt, targtype, win);
   if (targtype > AMPI_MAX_PREDEFINED_TYPE) {CkAbort("AMPI does not currently support RMA with derived datatypes.");}
   handle_MPI_BOTTOM((void*&)orgaddr, orgtype);
   WinStruct *winStruct = getAmpiParent()->getWinStruct(win);
@@ -811,7 +811,7 @@ AMPI_API_IMPL(int, MPI_Get, void *orgaddr, int orgcnt, MPI_Datatype orgtype, int
                             MPI_Aint targdisp, int targcnt, MPI_Datatype targtype,
                             MPI_Win win)
 {
-  AMPI_API("AMPI_Get");
+  AMPI_API("AMPI_Get", orgaddr, orgcnt, orgtype, rank, targdisp, targcnt, targtype, win);
   if (targtype > AMPI_MAX_PREDEFINED_TYPE) {CkAbort("AMPI does not currently support RMA with derived datatypes.");}
   handle_MPI_BOTTOM(orgaddr, orgtype);
   WinStruct *winStruct = getAmpiParent()->getWinStruct(win);
@@ -834,7 +834,7 @@ AMPI_API_IMPL(int, MPI_Accumulate, const void *orgaddr, int orgcnt, MPI_Datatype
                                    int rank, MPI_Aint targdisp, int targcnt,
                                    MPI_Datatype targtype, MPI_Op op, MPI_Win win)
 {
-  AMPI_API("AMPI_Accumulate");
+  AMPI_API("AMPI_Accumulate", orgaddr, orgcnt, orgtype, rank, targdisp, targcnt, targtype, op, win);
   if (targtype > AMPI_MAX_PREDEFINED_TYPE) {CkAbort("AMPI does not currently support RMA with derived datatypes.");}
   handle_MPI_BOTTOM((void*&)orgaddr, orgtype);
   WinStruct *winStruct = getAmpiParent()->getWinStruct(win);
@@ -855,7 +855,7 @@ AMPI_API_IMPL(int, MPI_Get_accumulate, const void *orgaddr, int orgcnt, MPI_Data
                                        int rank, MPI_Aint targdisp, int targcnt,
                                        MPI_Datatype targtype, MPI_Op op, MPI_Win win)
 {
-  AMPI_API("AMPI_Get_accumulate");
+  AMPI_API("AMPI_Get_accumulate", orgaddr, orgcnt, orgtype, rank, targdisp, targcnt, targtype, op, win);
   if (targtype > AMPI_MAX_PREDEFINED_TYPE) {CkAbort("AMPI does not currently support RMA with derived datatypes.");}
   handle_MPI_BOTTOM((void*&)orgaddr, orgtype);
   WinStruct *winStruct = getAmpiParent()->getWinStruct(win);
@@ -876,7 +876,7 @@ AMPI_API_IMPL(int, MPI_Rput, const void *orgaddr, int orgcnt, MPI_Datatype orgty
                              MPI_Aint targdisp, int targcnt, MPI_Datatype targtype, MPI_Win win,
                              MPI_Request *request)
 {
-  AMPI_API("AMPI_Rput");
+  AMPI_API("AMPI_Rput", orgaddr, orgcnt, orgtype, rank, targdisp, targcnt, targtype, win, request);
   if (targtype > AMPI_MAX_PREDEFINED_TYPE) {CkAbort("AMPI does not currently support RMA with derived datatypes.");}
   WinStruct *winStruct = getAmpiParent()->getWinStruct(win);
   ampi *ptr = getAmpiInstance(winStruct->comm);
@@ -895,7 +895,7 @@ AMPI_API_IMPL(int, MPI_Rget, void *orgaddr, int orgcnt, MPI_Datatype orgtype, in
                              MPI_Aint targdisp, int targcnt, MPI_Datatype targtype,
                              MPI_Win win, MPI_Request *request)
 {
-  AMPI_API("AMPI_Rget");
+  AMPI_API("AMPI_Rget", orgaddr, orgcnt, orgtype, rank, targdisp, targcnt, targtype, win, request);
   if (targtype > AMPI_MAX_PREDEFINED_TYPE) {CkAbort("AMPI does not currently support RMA with derived datatypes.");}
   WinStruct *winStruct = getAmpiParent()->getWinStruct(win);
   ampi *ptr = getAmpiInstance(winStruct->comm);
@@ -915,7 +915,7 @@ AMPI_API_IMPL(int, MPI_Raccumulate, const void *orgaddr, int orgcnt, MPI_Datatyp
                                     MPI_Aint targdisp, int targcnt, MPI_Datatype targtype,
                                     MPI_Op op, MPI_Win win, MPI_Request *request)
 {
-  AMPI_API("AMPI_Raccumulate");
+  AMPI_API("AMPI_Raccumulate", orgaddr, orgcnt, orgtype, rank, targdisp, targcnt, targtype, op, win, request);
   if (targtype > AMPI_MAX_PREDEFINED_TYPE) {CkAbort("AMPI does not currently support RMA with derived datatypes.");}
   WinStruct *winStruct = getAmpiParent()->getWinStruct(win);
   ampi *ptr = getAmpiInstance(winStruct->comm);
@@ -938,7 +938,7 @@ AMPI_API_IMPL(int, MPI_Rget_accumulate, const void *orgaddr, int orgcnt, MPI_Dat
                                         MPI_Datatype targtype, MPI_Op op, MPI_Win win,
                                         MPI_Request *request)
 {
-  AMPI_API("AMPI_Rget_accumulate");
+  AMPI_API("AMPI_Rget_accumulate", orgaddr, orgcnt, orgtype, rank, targdisp, targcnt, targtype, op, win, request);
   if (targtype > AMPI_MAX_PREDEFINED_TYPE) {CkAbort("AMPI does not currently support RMA with derived datatypes.");}
   WinStruct *winStruct = getAmpiParent()->getWinStruct(win);
   ampi *ptr = getAmpiInstance(winStruct->comm);
@@ -955,7 +955,7 @@ AMPI_API_IMPL(int, MPI_Rget_accumulate, const void *orgaddr, int orgcnt, MPI_Dat
 AMPI_API_IMPL(int, MPI_Fetch_and_op, const void *orgaddr, void *resaddr, MPI_Datatype type,
                                      int rank, MPI_Aint targdisp, MPI_Op op, MPI_Win win)
 {
-  AMPI_API("AMPI_Fetch_and_op");
+  AMPI_API("AMPI_Fetch_and_op", orgaddr, resaddr, type, rank, targdisp, op, win);
   #if AMPI_ERROR_CHECKING
     if (type > AMPI_MAX_PREDEFINED_TYPE)
     {
@@ -978,7 +978,7 @@ AMPI_API_IMPL(int, MPI_Fetch_and_op, const void *orgaddr, void *resaddr, MPI_Dat
 AMPI_API_IMPL(int, MPI_Compare_and_swap, const void *orgaddr, const void *compaddr, void *resaddr,
                                          MPI_Datatype type, int rank, MPI_Aint targdisp, MPI_Win win)
 {
-  AMPI_API("AMPI_Compare_and_swap");
+  AMPI_API("AMPI_Compare_and_swap", orgaddr, compaddr, resaddr, type, rank, targdisp, win);
   #if AMPI_ERROR_CHECKING
     if (type > AMPI_MAX_PREDEFINED_TYPE)
     {
@@ -1002,7 +1002,7 @@ AMPI_API_IMPL(int, MPI_Compare_and_swap, const void *orgaddr, const void *compad
  */
 AMPI_API_IMPL(int, MPI_Win_fence, int assertion, MPI_Win win)
 {
-  AMPI_API("AMPI_Win_fence");
+  AMPI_API("AMPI_Win_fence", assertion, win);
   WinStruct *winStruct = getAmpiParent()->getWinStruct(win);
   MPI_Comm comm = winStruct->comm;
 
@@ -1025,7 +1025,7 @@ AMPI_API_IMPL(int, MPI_Win_fence, int assertion, MPI_Win win)
  */
 AMPI_API_IMPL(int, MPI_Win_lock, int lock_type, int rank, int assertion, MPI_Win win)
 {
-  AMPI_API("AMPI_Win_lock");
+  AMPI_API("AMPI_Win_lock", lock_type, rank, assertion, win);
   WinStruct *winStruct = getAmpiParent()->getWinStruct(win);
   ampi *ptr = getAmpiInstance(winStruct->comm);
 
@@ -1046,7 +1046,7 @@ AMPI_API_IMPL(int, MPI_Win_lock, int lock_type, int rank, int assertion, MPI_Win
   // process assertion here: HOW???
 AMPI_API_IMPL(int, MPI_Win_unlock, int rank, MPI_Win win)
 {
-  AMPI_API("AMPI_Win_unlock");
+  AMPI_API("AMPI_Win_unlock", rank, win);
   WinStruct *winStruct = getAmpiParent()->getWinStruct(win);
   ampi *ptr = getAmpiInstance(winStruct->comm);
 
@@ -1065,7 +1065,7 @@ AMPI_API_IMPL(int, MPI_Win_unlock, int rank, MPI_Win win)
  */
 AMPI_API_IMPL(int, MPI_Win_lock_all, int assert, MPI_Win win)
 {
-  AMPI_API("AMPI_Win_lock_all");
+  AMPI_API("AMPI_Win_lock_all", assert, win);
   WinStruct *winStruct = getAmpiParent()->getWinStruct(win);
   ampi *ptr = getAmpiInstance(winStruct->comm);
   int size = ptr->getSize();
@@ -1087,7 +1087,7 @@ AMPI_API_IMPL(int, MPI_Win_lock_all, int assert, MPI_Win win)
 // The RMA call is completed both locally and remotely after unlock.
 AMPI_API_IMPL(int, MPI_Win_unlock_all, MPI_Win win)
 {
-  AMPI_API("AMPI_Win_unlock_all");
+  AMPI_API("AMPI_Win_unlock_all", win);
   WinStruct *winStruct = getAmpiParent()->getWinStruct(win);
   ampi *ptr = getAmpiInstance(winStruct->comm);
   int size = ptr->getSize();
@@ -1112,7 +1112,7 @@ AMPI_API_IMPL(int, MPI_Win_unlock_all, MPI_Win win)
  */
 AMPI_API_IMPL(int, MPI_Win_post, MPI_Group group, int assertion, MPI_Win win)
 {
-  AMPI_API("AMPI_Win_post");
+  AMPI_API("AMPI_Win_post", group, assertion, win);
 
   WinStruct *winStruct = getAmpiParent()->getWinStruct(win);
   if (winStruct->isInEpoch()) {
@@ -1154,7 +1154,7 @@ AMPI_API_IMPL(int, MPI_Win_post, MPI_Group group, int assertion, MPI_Win win)
 
 AMPI_API_IMPL(int, MPI_Win_wait, MPI_Win win)
 {
-  AMPI_API("AMPI_Win_wait");
+  AMPI_API("AMPI_Win_wait", win);
 
   WinStruct *winStruct = getAmpiParent()->getWinStruct(win);
   if (!winStruct->isInEpoch()) {
@@ -1180,7 +1180,7 @@ AMPI_API_IMPL(int, MPI_Win_wait, MPI_Win win)
 
 AMPI_API_IMPL(int, MPI_Win_start, MPI_Group group, int assertion, MPI_Win win)
 {
-  AMPI_API("AMPI_Win_start");
+  AMPI_API("AMPI_Win_start", group, assertion, win);
 
   WinStruct *winStruct = getAmpiParent()->getWinStruct(win);
   if (winStruct->isInEpoch()) {
@@ -1221,7 +1221,7 @@ AMPI_API_IMPL(int, MPI_Win_start, MPI_Group group, int assertion, MPI_Win win)
 
 AMPI_API_IMPL(int, MPI_Win_complete, MPI_Win win)
 {
-  AMPI_API("AMPI_Win_complete");
+  AMPI_API("AMPI_Win_complete", win);
 
   WinStruct *winStruct = getAmpiParent()->getWinStruct(win);
   if (!winStruct->isInEpoch()) {
@@ -1243,7 +1243,7 @@ AMPI_API_IMPL(int, MPI_Win_complete, MPI_Win win)
 
 AMPI_API_IMPL(int, MPI_Win_test, MPI_Win win, int *flag)
 {
-  AMPI_API("AMPI_Win_test");
+  AMPI_API("AMPI_Win_test", win, flag);
 
   WinStruct *winStruct = getAmpiParent()->getWinStruct(win);
   if (!winStruct->isInEpoch()) {
@@ -1275,7 +1275,7 @@ CLINKAGE
 int AMPI_Iget(MPI_Aint orgdisp, int orgcnt, MPI_Datatype orgtype, int rank,
               MPI_Aint targdisp, int targcnt, MPI_Datatype targtype, MPI_Win win,
               MPI_Request *request) {
-  AMPI_API("AMPI_Iget");
+  AMPI_API("AMPI_Iget", orgdisp, orgcnt, orgtype, rank, targdisp, targcnt, targtype, win, request);
   WinStruct *winStruct = getAmpiParent()->getWinStruct(win);
   ampi *ptr = getAmpiInstance(winStruct->comm);
   // winGet is a local function which will call the remote method on #rank processor
@@ -1285,7 +1285,7 @@ int AMPI_Iget(MPI_Aint orgdisp, int orgcnt, MPI_Datatype orgtype, int rank,
 
 CLINKAGE
 int AMPI_Iget_wait(MPI_Request *request, MPI_Status *status, MPI_Win win) {
-  AMPI_API("AMPI_Iget_wait");
+  AMPI_API("AMPI_Iget_wait", request, status, win);
   WinStruct *winStruct = getAmpiParent()->getWinStruct(win);
   ampi *ptr = getAmpiInstance(winStruct->comm);
   // winGet is a local function which will call the remote method on #rank processor
@@ -1294,7 +1294,7 @@ int AMPI_Iget_wait(MPI_Request *request, MPI_Status *status, MPI_Win win) {
 
 CLINKAGE
 int AMPI_Iget_free(MPI_Request *request, MPI_Status *status, MPI_Win win) {
-  AMPI_API("AMPI_Iget_free");
+  AMPI_API("AMPI_Iget_free", request, status, win);
   WinStruct *winStruct = getAmpiParent()->getWinStruct(win);
   ampi *ptr = getAmpiInstance(winStruct->comm);
   // winGet is a local function which will call the remote method on #rank processor
@@ -1341,7 +1341,7 @@ AMPI_API_IMPL(int, MPI_Free_mem, void *baseptr)
 
 AMPI_API_IMPL(int, MPI_Win_get_group, MPI_Win win, MPI_Group *group)
 {
-  AMPI_API("AMPI_Win_get_group");
+  AMPI_API("AMPI_Win_get_group", win, group);
   WinStruct *winStruct = getAmpiParent()->getWinStruct(win);
   ampi *ptr = getAmpiInstance(winStruct->comm);
   ptr->winGetGroup(winStruct, group);
@@ -1350,7 +1350,7 @@ AMPI_API_IMPL(int, MPI_Win_get_group, MPI_Win win, MPI_Group *group)
 
 AMPI_API_IMPL(int, MPI_Win_delete_attr, MPI_Win win, int key)
 {
-  AMPI_API("AMPI_Win_delete_attr");
+  AMPI_API("AMPI_Win_delete_attr", win, key);
   ampiParent *parent = getAmpiParent();
   WinStruct *winStruct = parent->getWinStruct(win);
   auto & attributes = getAmpiInstance(winStruct->comm)->getWinObjInstance(winStruct)->getAttributes();
@@ -1359,7 +1359,7 @@ AMPI_API_IMPL(int, MPI_Win_delete_attr, MPI_Win win, int key)
 
 AMPI_API_IMPL(int, MPI_Win_get_attr, MPI_Win win, int key, void* value, int* flag)
 {
-  AMPI_API("AMPI_Win_get_attr");
+  AMPI_API("AMPI_Win_get_attr", win, key, value, flag);
   ampiParent *parent = getAmpiParent();
   WinStruct *winStruct = parent->getWinStruct(win);
   auto & attributes = getAmpiInstance(winStruct->comm)->getWinObjInstance(winStruct)->getAttributes();
@@ -1368,7 +1368,7 @@ AMPI_API_IMPL(int, MPI_Win_get_attr, MPI_Win win, int key, void* value, int* fla
 
 AMPI_API_IMPL(int, MPI_Win_set_attr, MPI_Win win, int key, void* value)
 {
-  AMPI_API("AMPI_Win_set_attr");
+  AMPI_API("AMPI_Win_set_attr", win, key, value);
   ampiParent *parent = getAmpiParent();
   WinStruct *winStruct = parent->getWinStruct(win);
   auto & attributes = getAmpiInstance(winStruct->comm)->getWinObjInstance(winStruct)->getAttributes();
@@ -1377,7 +1377,7 @@ AMPI_API_IMPL(int, MPI_Win_set_attr, MPI_Win win, int key, void* value)
 
 AMPI_API_IMPL(int, MPI_Win_set_name, MPI_Win win, const char *name)
 {
-  AMPI_API("AMPI_Win_set_name");
+  AMPI_API("AMPI_Win_set_name", win, name);
   WinStruct *winStruct = getAmpiParent()->getWinStruct(win);
   ampi *ptr = getAmpiInstance(winStruct->comm);
   ptr->winSetName(winStruct, name);
@@ -1386,14 +1386,14 @@ AMPI_API_IMPL(int, MPI_Win_set_name, MPI_Win win, const char *name)
 
 AMPI_API_IMPL(int, MPI_Win_set_info, MPI_Win win, MPI_Info info)
 {
-  AMPI_API("AMPI_Win_set_info");
+  AMPI_API("AMPI_Win_set_info", win, info);
   /* FIXME: no-op implementation */
   return MPI_SUCCESS;
 }
 
 AMPI_API_IMPL(int, MPI_Win_get_info, MPI_Win win, MPI_Info *info)
 {
-  AMPI_API("AMPI_Win_get_info");
+  AMPI_API("AMPI_Win_get_info", win, info);
   /* FIXME: no-op implementation */
   *info = MPI_INFO_NULL;
   return MPI_SUCCESS;
@@ -1402,26 +1402,26 @@ AMPI_API_IMPL(int, MPI_Win_get_info, MPI_Win win, MPI_Info *info)
 AMPI_API_IMPL(int, MPI_Win_create_errhandler, MPI_Win_errhandler_function *win_errhandler_fn,
                                               MPI_Errhandler *errhandler)
 {
-  AMPI_API("AMPI_Win_create_errhandler");
+  AMPI_API("AMPI_Win_create_errhandler", win_errhandler_fn, errhandler);
   return MPI_SUCCESS;
 }
 
 AMPI_API_IMPL(int, MPI_Win_call_errhandler, MPI_Win win, int errorcode)
 {
-  AMPI_API("AMPI_Win_call_errhandler");
+  AMPI_API("AMPI_Win_call_errhandler", win, errorcode);
   CkPrintf("WARNING: AMPI does not support MPI_Win_call_errhandler (errorcode = %d)\n", errorcode);
   return MPI_SUCCESS;
 }
 
 AMPI_API_IMPL(int, MPI_Win_get_errhandler, MPI_Win win, MPI_Errhandler *errhandler)
 {
-  AMPI_API("AMPI_Win_get_errhandler");
+  AMPI_API("AMPI_Win_get_errhandler", win, errhandler);
   return MPI_SUCCESS;
 }
 
 AMPI_API_IMPL(int, MPI_Win_set_errhandler, MPI_Win win, MPI_Errhandler errhandler)
 {
-  AMPI_API("AMPI_Win_set_errhandler");
+  AMPI_API("AMPI_Win_set_errhandler", win, errhandler);
   return MPI_SUCCESS;
 }
 
@@ -1446,19 +1446,19 @@ AMPI_API_IMPL(int, MPI_Win_create_keyval, MPI_Win_copy_attr_function *copy_fn,
                                           MPI_Win_delete_attr_function *delete_fn,
                                           int *keyval, void *extra_state)
 {
-  AMPI_API("AMPI_Win_create_keyval");
+  AMPI_API("AMPI_Win_create_keyval", copy_fn, delete_fn, keyval, extra_state);
   return MPI_Comm_create_keyval(copy_fn, delete_fn, keyval, extra_state);
 }
 
 AMPI_API_IMPL(int, MPI_Win_free_keyval, int *keyval)
 {
-  AMPI_API("AMPI_Win_free_keyval");
+  AMPI_API("AMPI_Win_free_keyval", keyval);
   return MPI_Comm_free_keyval(keyval);
 }
 
 AMPI_API_IMPL(int, MPI_Win_get_name, MPI_Win win, char *name, int *length)
 {
-  AMPI_API("AMPI_Win_get_name");
+  AMPI_API("AMPI_Win_get_name", win, name, length);
   WinStruct *winStruct = getAmpiParent()->getWinStruct(win);
   ampi *ptr = getAmpiInstance(winStruct->comm);
   ptr->winGetName(winStruct, name, length);

--- a/src/libs/ck-libs/ampi/ampi_mpix.C
+++ b/src/libs/ck-libs/ampi/ampi_mpix.C
@@ -11,7 +11,7 @@ AMPI_API_IMPL(int, MPIX_Grequest_start, MPI_Grequest_query_function *query_fn,
   MPI_Grequest_free_function *free_fn, MPI_Grequest_cancel_function *cancel_fn,
   MPIX_Grequest_poll_function *poll_fn, void *extra_state, MPI_Request *request)
 {
-  AMPI_API("AMPIX_Grequest_start");
+  AMPI_API("AMPIX_Grequest_start", query_fn, free_fn, cancel_fn, poll_fn, extra_state, request);
 
   ampi* ptr = getAmpiInstance(MPI_COMM_SELF); // All GReq's are posted to MPI_COMM_SELF
   GReq *newreq = new GReq(query_fn, free_fn, cancel_fn, poll_fn, extra_state);
@@ -26,7 +26,7 @@ AMPI_API_IMPL(int, MPIX_Grequest_class_create, MPI_Grequest_query_function *quer
   MPIX_Grequest_poll_function *poll_fn, MPIX_Grequest_wait_function *wait_fn,
   MPIX_Grequest_class *greq_class)
 {
-  AMPI_API("AMPIX_Grequest_class_create");
+  AMPI_API("AMPIX_Grequest_class_create", query_fn, free_fn, cancel_fn, poll_fn, wait_fn, greq_class);
 
   greq_class_desc g;
   g.query_fn = query_fn;
@@ -47,7 +47,7 @@ AMPI_API_IMPL(int, MPIX_Grequest_class_create, MPI_Grequest_query_function *quer
 AMPI_API_IMPL(int, MPIX_Grequest_class_allocate, MPIX_Grequest_class greq_class,
   void *extra_state, MPI_Request *request)
 {
-  AMPI_API("AMPIX_Grequest_class_allocate");
+  AMPI_API("AMPIX_Grequest_class_allocate", greq_class, extra_state, request);
 
   ampi* ptr = getAmpiInstance(MPI_COMM_SELF); // All GReq's are posted to MPI_COMM_SELF
 

--- a/src/libs/ck-libs/ampi/ampi_noimpl.C
+++ b/src/libs/ck-libs/ampi/ampi_noimpl.C
@@ -9,7 +9,7 @@ unsupported in AMPI. Calling these functions aborts the application.
 
 #define AMPI_NOIMPL_BODY(function_name) \
     { \
-        AMPI_API(STRINGIFY(function_name)); \
+        AMPI_API(STRINGIFY(function_name), ""); \
         CkAbort(STRINGIFY(function_name) " is not implemented in AMPI."); \
     }
 

--- a/src/libs/ck-libs/ampi/ampiimpl.h
+++ b/src/libs/ck-libs/ampi/ampiimpl.h
@@ -20,7 +20,7 @@
 
 #define AMPI_DEBUG(...) CkPrintf(__VA_ARGS__)
 
-// Support for variable-argument macros
+// Support for variable-argument macros (up to 16 arguments)
 #define FE_1(WHAT, X) WHAT(X, true) 
 #define FE_2(WHAT, X, ...) WHAT(X, false)FE_1(WHAT, __VA_ARGS__)
 #define FE_3(WHAT, X, ...) WHAT(X, false)FE_2(WHAT, __VA_ARGS__)
@@ -44,12 +44,13 @@
 #define FOR_EACH(action,...) \
   GET_MACRO(__VA_ARGS__,FE_16,FE_15,FE_14,FE_13,FE_12,FE_11,FE_10,FE_9,FE_8,FE_7,FE_6,FE_5,FE_4,FE_3,FE_2,FE_1)(action,__VA_ARGS__)
 
-// Print a single argument name and its value (unless the argument name is '""', which indicates a nonexistent argument)
+// Prints a single argument name and its value (unless the argument name is
+// '""', which indicates a nonexistent argument)
 #define PRINT_ARG(arg, last) if ("\"\""!=#arg) std::cout << #arg << "=" << arg << (last ? "" : ", ");
 
-// Prints the rank, function name, and argument name/value for each function argument
+// Prints PE:VP, function name, and argument name/value for each function argument
 #define AMPI_DEBUG_ARGS(function_name, ...) \
-  std::cout << "[" << (isAmpiThread() ? getAmpiParent()->thisIndex : -1) << "] "<< function_name <<"("; \
+  std::cout << "[" << CkMyPe() << ":" << (isAmpiThread() ? getAmpiParent()->thisIndex : -1) << "] "<< function_name <<"("; \
   FOR_EACH(PRINT_ARG, __VA_ARGS__); \
   std::cout << ")" << std::endl;
 

--- a/src/libs/ck-libs/ampi/ampiimpl.h
+++ b/src/libs/ck-libs/ampi/ampiimpl.h
@@ -50,12 +50,15 @@
 #define PRINT_ARG(arg, last) \
   if ("\"\""!=#arg) std::cout << #arg << "=" << arg << (last ? "" : ", ");
 
+extern int quietModeRequested;
+
 // Prints PE:VP, function name, and argument name/value for each function argument
 #define AMPI_DEBUG_ARGS(function_name, ...) \
+  if(!quietModeRequested) { \
   std::cout << "[" << CkMyPe() << ":" << \
   (isAmpiThread() ? getAmpiParent()->thisIndex : -1) << "] "<< function_name <<"("; \
   FOR_EACH(PRINT_ARG, __VA_ARGS__); \
-  std::cout << ")" << std::endl;
+  std::cout << ")" << std::endl; }
 
 #else // !AMPI_DO_DEBUG
 

--- a/src/libs/ck-libs/ampi/ampiimpl.h
+++ b/src/libs/ck-libs/ampi/ampiimpl.h
@@ -20,6 +20,7 @@
 
 #define AMPI_DEBUG(...) CkPrintf(__VA_ARGS__)
 
+// Support for variable-argument macros
 #define FE_1(WHAT, X) WHAT(X, true) 
 #define FE_2(WHAT, X, ...) WHAT(X, false)FE_1(WHAT, __VA_ARGS__)
 #define FE_3(WHAT, X, ...) WHAT(X, false)FE_2(WHAT, __VA_ARGS__)
@@ -37,12 +38,16 @@
 #define FE_15(WHAT, X, ...) WHAT(X,false)FE_14(WHAT, __VA_ARGS__)
 #define FE_16(WHAT, X, ...) WHAT(X,false)FE_15(WHAT, __VA_ARGS__)
 
-#define GET_MACRO(_1,_2,_3,_4,_5,_6,_7,_8,_9,_10,_11,_12,_13,_14,_15,_16,NAME,...) NAME 
+#define GET_MACRO(_1,_2,_3,_4,_5,_6,_7,_8,_9,_10,_11,_12,_13,_14,_15,_16,NAME,...) NAME
+
+// Perform 'action' (PRINT_ARG in this case) on each argument
 #define FOR_EACH(action,...) \
   GET_MACRO(__VA_ARGS__,FE_16,FE_15,FE_14,FE_13,FE_12,FE_11,FE_10,FE_9,FE_8,FE_7,FE_6,FE_5,FE_4,FE_3,FE_2,FE_1)(action,__VA_ARGS__)
 
+// Print a single argument name and its value (unless the argument name is '""', which indicates a nonexistent argument)
 #define PRINT_ARG(arg, last) if ("\"\""!=#arg) std::cout << #arg << "=" << arg << (last ? "" : ", ");
 
+// Prints the rank, function name, and argument name/value for each function argument
 #define AMPI_DEBUG_ARGS(function_name, ...) \
   std::cout << "[" << (isAmpiThread() ? getAmpiParent()->thisIndex : -1) << "] "<< function_name <<"("; \
   FOR_EACH(PRINT_ARG, __VA_ARGS__); \

--- a/src/libs/ck-libs/ampi/ampiimpl.h
+++ b/src/libs/ck-libs/ampi/ampiimpl.h
@@ -21,7 +21,7 @@
 #define AMPI_DEBUG(...) CkPrintf(__VA_ARGS__)
 
 // Support for variable-argument macros (up to 16 arguments)
-#define FE_1(WHAT, X) WHAT(X, true) 
+#define FE_1(WHAT, X) WHAT(X, true /*last argument*/) 
 #define FE_2(WHAT, X, ...) WHAT(X, false)FE_1(WHAT, __VA_ARGS__)
 #define FE_3(WHAT, X, ...) WHAT(X, false)FE_2(WHAT, __VA_ARGS__)
 #define FE_4(WHAT, X, ...) WHAT(X, false)FE_3(WHAT, __VA_ARGS__)
@@ -42,15 +42,18 @@
 
 // Perform 'action' (PRINT_ARG in this case) on each argument
 #define FOR_EACH(action,...) \
-  GET_MACRO(__VA_ARGS__,FE_16,FE_15,FE_14,FE_13,FE_12,FE_11,FE_10,FE_9,FE_8,FE_7,FE_6,FE_5,FE_4,FE_3,FE_2,FE_1)(action,__VA_ARGS__)
+  GET_MACRO(__VA_ARGS__,FE_16,FE_15,FE_14,FE_13,\
+    FE_12,FE_11,FE_10,FE_9,FE_8,FE_7,FE_6,FE_5,FE_4,FE_3,FE_2,FE_1)(action,__VA_ARGS__)
 
 // Prints a single argument name and its value (unless the argument name is
 // '""', which indicates a nonexistent argument)
-#define PRINT_ARG(arg, last) if ("\"\""!=#arg) std::cout << #arg << "=" << arg << (last ? "" : ", ");
+#define PRINT_ARG(arg, last) \
+  if ("\"\""!=#arg) std::cout << #arg << "=" << arg << (last ? "" : ", ");
 
 // Prints PE:VP, function name, and argument name/value for each function argument
 #define AMPI_DEBUG_ARGS(function_name, ...) \
-  std::cout << "[" << CkMyPe() << ":" << (isAmpiThread() ? getAmpiParent()->thisIndex : -1) << "] "<< function_name <<"("; \
+  std::cout << "[" << CkMyPe() << ":" << \
+  (isAmpiThread() ? getAmpiParent()->thisIndex : -1) << "] "<< function_name <<"("; \
   FOR_EACH(PRINT_ARG, __VA_ARGS__); \
   std::cout << ")" << std::endl;
 

--- a/src/libs/ck-libs/ampi/ampiimpl.h
+++ b/src/libs/ck-libs/ampi/ampiimpl.h
@@ -7,13 +7,54 @@
 #include <forward_list>
 #include <bitset>
 #include <complex>
+#include <iostream>
 
 #include "ampi.h"
 #include "ddt.h"
 #include "charm++.h"
 
-//Uncomment for debug print statements
-#define AMPI_DEBUG(...) //CkPrintf(__VA_ARGS__)
+// Set to 1 to print debug statements
+#define AMPI_DO_DEBUG 0
+
+#if AMPI_DO_DEBUG
+
+#define AMPI_DEBUG(...) CkPrintf(__VA_ARGS__)
+
+#define FE_1(WHAT, X) WHAT(X, true) 
+#define FE_2(WHAT, X, ...) WHAT(X, false)FE_1(WHAT, __VA_ARGS__)
+#define FE_3(WHAT, X, ...) WHAT(X, false)FE_2(WHAT, __VA_ARGS__)
+#define FE_4(WHAT, X, ...) WHAT(X, false)FE_3(WHAT, __VA_ARGS__)
+#define FE_5(WHAT, X, ...) WHAT(X, false)FE_4(WHAT, __VA_ARGS__)
+#define FE_6(WHAT, X, ...) WHAT(X, false)FE_5(WHAT, __VA_ARGS__)
+#define FE_7(WHAT, X, ...) WHAT(X, false)FE_6(WHAT, __VA_ARGS__)
+#define FE_8(WHAT, X, ...) WHAT(X, false)FE_7(WHAT, __VA_ARGS__)
+#define FE_9(WHAT, X, ...) WHAT(X, false)FE_8(WHAT, __VA_ARGS__)
+#define FE_10(WHAT, X, ...) WHAT(X,false)FE_9(WHAT, __VA_ARGS__)
+#define FE_11(WHAT, X, ...) WHAT(X,false)FE_10(WHAT, __VA_ARGS__)
+#define FE_12(WHAT, X, ...) WHAT(X,false)FE_11(WHAT, __VA_ARGS__)
+#define FE_13(WHAT, X, ...) WHAT(X,false)FE_12(WHAT, __VA_ARGS__)
+#define FE_14(WHAT, X, ...) WHAT(X,false)FE_13(WHAT, __VA_ARGS__)
+#define FE_15(WHAT, X, ...) WHAT(X,false)FE_14(WHAT, __VA_ARGS__)
+#define FE_16(WHAT, X, ...) WHAT(X,false)FE_15(WHAT, __VA_ARGS__)
+
+#define GET_MACRO(_1,_2,_3,_4,_5,_6,_7,_8,_9,_10,_11,_12,_13,_14,_15,_16,NAME,...) NAME 
+#define FOR_EACH(action,...) \
+  GET_MACRO(__VA_ARGS__,FE_16,FE_15,FE_14,FE_13,FE_12,FE_11,FE_10,FE_9,FE_8,FE_7,FE_6,FE_5,FE_4,FE_3,FE_2,FE_1)(action,__VA_ARGS__)
+
+#define PRINT_ARG(arg, last) if ("\"\""!=#arg) std::cout << #arg << "=" << arg << (last ? "" : ", ");
+
+#define AMPI_DEBUG_ARGS(function_name, ...) \
+  std::cout << "[" << (isAmpiThread() ? getAmpiParent()->thisIndex : -1) << "] "<< function_name <<"("; \
+  FOR_EACH(PRINT_ARG, __VA_ARGS__); \
+  std::cout << ")" << std::endl;
+
+#else // !AMPI_DO_DEBUG
+
+#define AMPI_DEBUG(...) /*empty*/
+#define AMPI_DEBUG_ARGS(...) /*empty*/
+
+#endif // AMPI_DO_DEBUG
+
 
 /*
  * All MPI_* routines must be defined using the AMPI_API_IMPL macro.
@@ -2938,14 +2979,16 @@ static const char *funclist[] = {"AMPI_Abort", "AMPI_Add_error_class", "AMPI_Add
 
 //Use this to mark the start of AMPI interface routines that can only be called on AMPI threads:
 #if CMK_ERROR_CHECKING
-#define AMPI_API(routineName) \
+#define AMPI_API(routineName, ...) \
   if (!isAmpiThread()) { CkAbort("AMPI> cannot call MPI routines from non-AMPI threads!"); } \
-  TCHARM_API_TRACE(routineName, "ampi");
+  TCHARM_API_TRACE(routineName, "ampi"); AMPI_DEBUG_ARGS(routineName, __VA_ARGS__)
 #else
-#define AMPI_API(routineName) TCHARM_API_TRACE(routineName, "ampi")
+#define AMPI_API(routineName, ...) TCHARM_API_TRACE(routineName, "ampi"); \
+  AMPI_DEBUG_ARGS(routineName, __VA_ARGS__) 
 #endif
 
 //Use this for MPI_Init and routines than can be called before AMPI threads have been initialized:
-#define AMPI_API_INIT(routineName) TCHARM_API_TRACE(routineName, "ampi")
+#define AMPI_API_INIT(routineName, ...) TCHARM_API_TRACE(routineName, "ampi"); \
+  AMPI_DEBUG_ARGS(routineName, __VA_ARGS__)
 
 #endif // _AMPIIMPL_H


### PR DESCRIPTION
When enabled, prints each MPI function call of an application with the PE/VP that made the call, as well as the names and values of the call arguments.

This is disabled by default, and needs to be enabled by setting `AMPI_DO_DEBUG` to 1. This will also enable `AMPI_DEBUG`.

Printing is done using `std::cout`, and not `CmiPrintf` or `ckout` since:
- `CmiPrintf` etc. can't do automatic formatting of arguments based on their types.
- `ckout` can't print (e.g.) function pointers.

Example output:

```
[3:3] AMPI_Barrier(comm=9000000)
[0:0] AMPI_Scatter(sendbuf=0x7fb5b91066c0, sendcount=1, sendtype=1, recvbuf=0x580103a64, recvcount=1, recvtype=1, root=3, comm=9000000)
[0:0] AMPI_Reduce(inbuf=0x58010393c, outbuf=0x580103930, count=1, type=1, op=2, root=3, comm=9000000)
[2:2] AMPI_Isend(buf=0x3fdb80103e78, count=1, type=1, dest=0, tag=12387, comm=1000000, request=0x3fdb80103afc)
[2:2] AMPI_Wait(request=0x3fdb80103afc, sts=0x0)
```