### PR TITLE
CkDDT: Replace vector type with set freeTypes

### DIFF
--- a/src/libs/ck-libs/ampi/ddt.C
+++ b/src/libs/ck-libs/ampi/ddt.C
@@ -12,7 +12,9 @@ CkDDT::pup(PUP::er &p) noexcept
   if (p.isPacking()) {
     types.resize(numTypes);
     for (int i=0; i<userTypeTable.size(); i++) {
-      types[i] = userTypeTable[i] == nullptr ? MPI_DATATYPE_NULL : std::max(AMPI_MAX_PREDEFINED_TYPE, std::min(CkDDT_MAX_PREDEFINED_TYPE, userTypeTable[i]->getType()));
+      types[i] = userTypeTable[i] == nullptr
+        ? MPI_DATATYPE_NULL
+        : std::max(AMPI_MAX_PREDEFINED_TYPE, std::min(CkDDT_FIRST_USER_TYPE, userTypeTable[i]->getType()));
     }
     p(types.data(), numTypes);
     types.clear();

--- a/src/libs/ck-libs/ampi/ddt.h
+++ b/src/libs/ck-libs/ampi/ddt.h
@@ -4,7 +4,7 @@
 #include <string>
 #include <vector>
 #include <array>
-#include <set>
+#include <queue>
 #include "charm++.h"
 #include "ampi.h"
 
@@ -448,14 +448,14 @@ class CkDDT_Struct final : public CkDDT_DataType
  *                       (to minimize per-rank memory footprint), which holds the CkDDT_DataType
  *                       object pointers for all predefined types.
  * userTypeTable - a vector that holds the CkDDT_DataType object pointers for all user-defined types
- * freeTypes - an ordered set of freed slot indexes in the userTypeTable, available for reuse.
+ * freeTypes - a priority queue of freed slot indexes in the userTypeTable, available for reuse.
  */
 class CkDDT
 {
  private:
   const std::array<const CkDDT_DataType *, AMPI_MAX_PREDEFINED_TYPE+1>& predefinedTypeTable;
   std::vector<CkDDT_DataType *> userTypeTable;
-  std::set<int> freeTypes;
+  std::priority_queue<int, std::vector<int>, std::greater<int>> freeTypes;
 
  public:
   // static methods used by ampi.C for predefined types creation:

--- a/src/libs/ck-libs/ampi/ddt.h
+++ b/src/libs/ck-libs/ampi/ddt.h
@@ -455,7 +455,7 @@ class CkDDT
  private:
   const std::array<const CkDDT_DataType *, AMPI_MAX_PREDEFINED_TYPE+1>& predefinedTypeTable;
   std::vector<CkDDT_DataType *> userTypeTable;
-  std::set<int> freeTypes; // TODO: replace with a priority queue structure that can be serialized trivially
+  std::set<int> freeTypes;
 
  public:
   // static methods used by ampi.C for predefined types creation:

--- a/src/libs/ck-libs/ampi/ddt.h
+++ b/src/libs/ck-libs/ampi/ddt.h
@@ -44,7 +44,7 @@
 #define CkDDT_INDEXED             47
 #define CkDDT_HINDEXED            48
 #define CkDDT_STRUCT              49
-#define CkDDT_MAX_PREDEFINED_TYPE 50
+#define CkDDT_FIRST_USER_TYPE     50
 
 enum CkDDT_Dir : bool {
   PACK   = true,
@@ -445,9 +445,10 @@ class CkDDT_Struct final : public CkDDT_DataType
  * This class maintains the table of all datatypes (predefined and user-defined).
  *
  * predefinedTypeTable - a reference to a const array declared as a static global variable
- *                       (to minimize per-rank memory fooprint), which holds the CkDDT_DataType
+ *                       (to minimize per-rank memory footprint), which holds the CkDDT_DataType
  *                       object pointers for all predefined types.
  * userTypeTable - a vector that holds the CkDDT_DataType object pointers for all user-defined types
+ * freeTypes - an ordered set of freed slot indexes in the userTypeTable, available for reuse.
  */
 class CkDDT
 {

--- a/src/libs/ck-libs/ampi/ddt.h
+++ b/src/libs/ck-libs/ampi/ddt.h
@@ -4,6 +4,7 @@
 #include <string>
 #include <vector>
 #include <array>
+#include <set>
 #include "charm++.h"
 #include "ampi.h"
 
@@ -43,6 +44,7 @@
 #define CkDDT_INDEXED             47
 #define CkDDT_HINDEXED            48
 #define CkDDT_STRUCT              49
+#define CkDDT_MAX_PREDEFINED_TYPE 50
 
 enum CkDDT_Dir : bool {
   PACK   = true,
@@ -446,15 +448,13 @@ class CkDDT_Struct final : public CkDDT_DataType
  *                       (to minimize per-rank memory fooprint), which holds the CkDDT_DataType
  *                       object pointers for all predefined types.
  * userTypeTable - a vector that holds the CkDDT_DataType object pointers for all user-defined types
- * types - used to identify which CkDDT_DataType derived class a type object really is,
- *         for PUPing the userTypeTable
  */
 class CkDDT
 {
  private:
   const std::array<const CkDDT_DataType *, AMPI_MAX_PREDEFINED_TYPE+1>& predefinedTypeTable;
   std::vector<CkDDT_DataType *> userTypeTable;
-  std::vector<int> types;
+  std::set<int> freeTypes; // TODO: replace with a priority queue structure that can be serialized trivially
 
  public:
   // static methods used by ampi.C for predefined types creation:


### PR DESCRIPTION
Solves a performance bug where CkDDT::insertType was linear in
the number of total types.