### PR TITLE
AMPI: work around issue #2472 in ampi::requestPut code path

### DIFF
--- a/src/libs/ck-libs/ampi/ampi.C
+++ b/src/libs/ck-libs/ampi/ampi.C
@@ -2988,10 +2988,13 @@ AmpiMsg *ampi::makeSyncMsg(int t,int sRank,const void *buf,int count,
                            ampi* destPtr) noexcept
 {
   CkAssert(ssendReq >= 0);
+#if AMPI_NODE_LOCAL_IMPL
   if (destLikelyWithinProcess(destProxy, destIdx, destPtr)) {
     return makeNcpyShmMsg(t, sRank, buf, count, type, ssendReq, seq);
   }
-  else {
+  else
+#endif
+  {
     return makeNcpyMsg(t, sRank, buf, count, type, ssendReq, seq);
   }
 }

--- a/src/libs/ck-libs/ampi/ampiimpl.h
+++ b/src/libs/ck-libs/ampi/ampiimpl.h
@@ -154,9 +154,10 @@ class fromzDisk : public zdisk {
 #endif
 
 /* AMPI sends messages using a zero copy protocol to Node-local destination VPs if:
- * BigSim is not being used and if tracing is not being used (such msgs are currently untraced). */
+ * BigSim is not being used and if tracing is not being used (such msgs are currently untraced).
+ * This is currently disabled due to Bug #2472. */
 #ifndef AMPI_NODE_LOCAL_IMPL
-#define AMPI_NODE_LOCAL_IMPL ( CMK_SMP && !CMK_BIGSIM_CHARM && !CMK_TRACE_ENABLED )
+#define AMPI_NODE_LOCAL_IMPL 0 // (CMK_SMP && !CMK_BIGSIM_CHARM && !CMK_TRACE_ENABLED )
 #endif
 
 /* messages larger than or equal to this threshold may block on a matching recv if local to the PE*/


### PR DESCRIPTION
AMPI bug #2472 occurs after migration in SMP mode runs with
multiple processes. It arises when a right after migration a sender
thinks it is in the same process as the recv'er but is not. By disabling
AMPI_NODE_LOCAL_IMPL we fall back to always using the zero copy
get()-based scheme.