### PR TITLE
Armv8 does not build with UCX

### DIFF
--- a/doc/charm++/manual.rst
+++ b/doc/charm++/manual.rst
@@ -10730,6 +10730,7 @@ appropriate choices for the build one wants to perform.
    IBVERBS with 64 bit Linux                                        ``./build charm++ verbs-linux-x86_64 --with-production -j8``
    OFI with 64 bit Linux                                            ``./build charm++ ofi-linux-x86_64 --with-production -j8``
    UCX with 64 bit Linux                                            ``./build charm++ ucx-linux-x86_64 --with-production -j8``
+   UCX with 64 bit Linux (Armv8)                                    ``./build charm++ ucx-linux-arm8 --with-production -j8``
    Net with 64 bit Windows                                          ``./build charm++ netlrts-win-x86_64 --with-production -j8``
    MPI with 64 bit Windows                                          ``./build charm++ mpi-win-x86_64 --with-production -j8``
    Net with 64 bit Mac                                              ``./build charm++ netlrts-darwin-x86_64 --with-production -j8``

--- a/src/arch/ucx-linux-arm8/conv-mach-ompipmix.h
+++ b/src/arch/ucx-linux-arm8/conv-mach-ompipmix.h
@@ -1,0 +1,5 @@
+#undef CMK_USE_PMI
+#undef CMK_USE_PMI2
+#undef CMK_USE_PMIX
+#undef CMK_USE_SIMPLEPMI
+#define CMK_USE_PMIX                                    1

--- a/src/arch/ucx-linux-arm8/conv-mach-ompipmix.sh
+++ b/src/arch/ucx-linux-arm8/conv-mach-ompipmix.sh
@@ -1,0 +1,1 @@
+CMK_LIBS="$CMK_LIBS -lpmix -lopen-pal -lopen-rte"

--- a/src/arch/ucx-linux-arm8/conv-mach-slurmpmi.h
+++ b/src/arch/ucx-linux-arm8/conv-mach-slurmpmi.h
@@ -1,0 +1,4 @@
+#undef CMK_USE_PMI
+#undef CMK_USE_PMI2
+#undef CMK_USE_SIMPLEPMI
+#define CMK_USE_PMI                                     1

--- a/src/arch/ucx-linux-arm8/conv-mach-slurmpmi.sh
+++ b/src/arch/ucx-linux-arm8/conv-mach-slurmpmi.sh
@@ -1,0 +1,2 @@
+CMK_INCDIR="$CMK_INCDIR -I/usr/include/slurm/"
+CMK_LIBS="$CMK_LIBS -lpmi"

--- a/src/arch/ucx-linux-arm8/conv-mach-slurmpmi2.h
+++ b/src/arch/ucx-linux-arm8/conv-mach-slurmpmi2.h
@@ -1,0 +1,4 @@
+#undef CMK_USE_PMI
+#undef CMK_USE_PMI2
+#undef CMK_USE_SIMPLEPMI
+#define CMK_USE_PMI2                                    1

--- a/src/arch/ucx-linux-arm8/conv-mach-slurmpmi2.sh
+++ b/src/arch/ucx-linux-arm8/conv-mach-slurmpmi2.sh
@@ -1,0 +1,2 @@
+CMK_INCDIR="$CMK_INCDIR -I/usr/include/slurm/"
+CMK_LIBS="$CMK_LIBS -lpmi2"

--- a/src/arch/ucx-linux-arm8/conv-mach-smp.h
+++ b/src/arch/ucx-linux-arm8/conv-mach-smp.h
@@ -1,0 +1,11 @@
+#define CMK_SMP						                       1
+
+#undef CMK_SHARED_VARS_UNAVAILABLE
+#undef CMK_SHARED_VARS_POSIX_THREADS_SMP
+#define CMK_SHARED_VARS_UNAVAILABLE                        0
+#define CMK_SHARED_VARS_POSIX_THREADS_SMP                  1
+
+#undef CMK_TIMER_USE_GETRUSAGE
+#undef CMK_TIMER_USE_SPECIAL
+#define CMK_TIMER_USE_GETRUSAGE                            1
+#define CMK_TIMER_USE_SPECIAL                              0

--- a/src/arch/ucx-linux-arm8/conv-mach-smp.sh
+++ b/src/arch/ucx-linux-arm8/conv-mach-smp.sh
@@ -1,0 +1,3 @@
+CMK_DEFS=' -D_REENTRANT '
+CMK_LIBS=" -lpthread $CMK_LIBS "
+CMK_SMP='1'

--- a/src/arch/ucx-linux-arm8/conv-mach.h
+++ b/src/arch/ucx-linux-arm8/conv-mach.h
@@ -1,0 +1,94 @@
+#ifndef _CONV_MACH_H
+#define _CONV_MACH_H
+
+#define CMK_UCX 1
+
+/* define the default linker, together with its options */
+#define CMK_DLL_CC   "g++ -shared -O3 -o "
+
+/* 1 if the machine has a function called "getpagesize()", 0 otherwise .
+   used in the memory files of converse */
+#define CMK_GETPAGESIZE_AVAILABLE                          1
+
+/* defines which version of memory handlers should be used.
+   used in conv-core/machine.C */
+#define CMK_MALLOC_USE_GNU_MALLOC                          0
+#define CMK_MALLOC_USE_OS_BUILTIN                          1
+
+#define CMK_MEMORY_PAGESIZE                                4096
+#define CMK_MEMORY_PROTECTABLE                             1
+
+/* the following definitions set the type of shared variables to be used. only
+   one of them must be 1, all the others 0. The different implementations are in
+   convserve.h Typically used are UNAVAILABLE for non SMP versions and
+   POSIX_THREADS_SMP for SMP versions. The others are used only in special
+   cases: UNIPROCESSOR in sim and uth, PTHREADS in origin,
+   and NT_THREADS in windows. */
+#define CMK_SHARED_VARS_UNAVAILABLE                        1 /* non SMP versions */
+#define CMK_SHARED_VARS_POSIX_THREADS_SMP                  0 /* SMP versions */
+#define CMK_SHARED_VARS_UNIPROCESSOR                       0
+#define CMK_SHARED_VARS_NT_THREADS                         0
+
+/* the following define if signal handlers should be used, both equal to zero
+   means that signals will not be used. only one of the following can be 1, the
+   other must be 0. they differ in the fact that the second (_WITH_RESTART)
+   enables retry on interrupt (a function is recalled upon interrupt and does
+   not return EINTR as in the first case) */
+#define CMK_SIGNAL_USE_SIGACTION                           0
+#define CMK_SIGNAL_USE_SIGACTION_WITH_RESTART              1
+
+/* specifies whether the CthCpv variables should be defined as Cpv (0) or
+   directly as normal c variables (1) */
+#define CMK_THREADS_REQUIRE_NO_CPV                         0
+
+/* decide which is the default implementation of the threads (see threads.c)
+   Only one of the following can be 1. If none of them is selected, qthreads
+   will be used as default. This default can be overwritten at compile time
+   using -DCMK_THREADS_BUILD_"type"=1 */
+#define CMK_THREADS_USE_CONTEXT                            0
+#define CMK_THREADS_USE_FCONTEXT                           1
+#define CMK_THREADS_USE_JCONTEXT                           0
+#define CMK_THREADS_USE_PTHREADS                           0
+
+/* Specifies what kind of timer to use, and the correspondent headers will be
+   included in convcore.c. If none is selected, then the machine.C file needs to
+   implement the timer primitives. */
+#define CMK_TIMER_USE_RTC                                  0
+#define CMK_TIMER_USE_RDTSC                                0
+#define CMK_TIMER_USE_GETRUSAGE                            1
+#define CMK_TIMER_USE_SPECIAL                              0
+#define CMK_TIMER_USE_TIMES                                0
+#define CMK_TIMER_USE_BLUEGENEL                            0
+
+/* Specifies what the processor will do when it is idle, either sleep (1) or go
+   into busy waiting mode (0). In convcore.c there are a few files included if
+   sleeping mode, but the real distinct implementation is in the machine.C
+   file. */
+#define CMK_WHEN_PROCESSOR_IDLE_USLEEP                     0
+
+/* specifies whether there is a web server collecting utilization statistics (1)
+   or not (0) */
+#define CMK_WEB_MODE                                       1
+
+#define CMK_DEBUG_MODE                                     0
+
+/* enables the load balancer framework. set to 1 for almost all the machines */
+#define CMK_LBDB_ON                    1
+
+#define CMK_64BIT                      1
+#define CMK_AMD64                      1
+
+/* By default use simple PMI */
+#define CMK_USE_PMI                    1
+#define CMK_USE_SIMPLEPMI              1
+#define CMK_USE_PMI2                   0
+#define CMK_USE_PMIX                   0
+
+/* Other possible definitions:
+
+In fault tolerant architectures, CK_MEM_CHECKPOINT can be set. In this case the
+extended header must contain also another field called "pn" (phase number).
+
+*/
+
+#endif

--- a/src/arch/ucx-linux-arm8/conv-mach.h
+++ b/src/arch/ucx-linux-arm8/conv-mach.h
@@ -76,7 +76,7 @@
 #define CMK_LBDB_ON                    1
 
 #define CMK_64BIT                      1
-#define CMK_AMD64                      1
+#define CMK_AMD64                      0
 
 /* By default use simple PMI */
 #define CMK_USE_PMI                    1

--- a/src/arch/ucx-linux-arm8/conv-mach.sh
+++ b/src/arch/ucx-linux-arm8/conv-mach.sh
@@ -1,0 +1,28 @@
+. $CHARMINC/cc-gcc.sh
+
+CMK_CF90=`which f95 2>/dev/null`
+if test -n "$CMK_CF90"
+then
+    . $CHARMINC/conv-mach-gfortran.sh
+else
+    CMK_CF77='g77 '
+    CMK_CF90='f90 '
+    CMK_CF90_FIXED="$CMK_CF90 -W132 "
+    CMK_F90LIBS='-L/usr/absoft/lib -L/opt/absoft/lib -lf90math -lfio -lU77 -lf77math '
+    CMK_F77LIBS='-lg2c '
+    CMK_F90_USE_MODDIR=1
+    CMK_F90_MODINC='-p'
+fi
+
+if test -z "$USER_OPTS_LD"
+then
+    CMK_INCDIR="-I/usr/include/"
+    CMK_LIBDIR="-L/usr/lib64/"
+fi
+
+CMK_LIBS="$CMK_LIBS -lucp -luct -lucs -lucm"
+
+# For runtime
+CMK_INCDIR="$CMK_INCDIR -I./proc_management/ -I./proc_management/simple_pmi/"
+
+CMK_QT='generic64-light'


### PR DESCRIPTION
Adding the file to src/arch/ucx-linux-arm8 that allow "ucx-linux-arm8" to build.