### PR TITLE
Revert charm4py cmiwrappers

### DIFF
--- a/src/ck-core/charm.h
+++ b/src/ck-core/charm.h
@@ -131,7 +131,6 @@ extern void registerArrayMapProcNumExtCallback(int (*cb)(int, int, const int *))
 extern void StartCharmExt(int argc, char **argv); // start Converse/Charm, argv are the command-line arguments
 extern int CkMyPeHook(void);   // function equivalent of CkMyPe macro
 extern int CkNumPesHook(void); // function equivalent of CkNumPes macro
-extern void CmiAbortHook(const char *msg);
 /// Get current redNo of specified group instance on this PE
 extern int CkGroupGetReductionNumber(int gid);
 /// Get current redNo of specified array element on this PE

--- a/src/ck-core/ck.C
+++ b/src/ck-core/ck.C
@@ -2203,7 +2203,6 @@ void registerArrayMapProcNumExtCallback(int (*cb)(int, int, const int *)) {
 
 int CkMyPeHook() { return CkMyPe(); }
 int CkNumPesHook() { return CkNumPes(); }
-void CmiAbortHook(const char *msg) { CmiAbort("%s", msg); }
 
 void ReadOnlyExt::setData(void *msg, size_t msgSize) {
   ro_data = malloc(msgSize);

--- a/src/conv-core/convcore.C
+++ b/src/conv-core/convcore.C
@@ -3990,11 +3990,6 @@ void CmiIOInit(char **argv) {
 }
 #endif
 
-void CmiPuts(const char * str)
-{
-  CmiPrintf("%s", str);
-}
-
 #if ! CMK_CMIPRINTF_IS_A_BUILTIN
 
 void CmiPrintf(const char *format, ...)

--- a/src/conv-core/converse.h
+++ b/src/conv-core/converse.h
@@ -1092,8 +1092,6 @@ void  CmiError(const char *format, ...);
 
 #endif
 
-void CmiPuts(const char *);
-
 #if defined(__STDC__) || defined(__cplusplus)
 #define __CMK_STRING(x) #x
 #else


### PR DESCRIPTION
I was able to get the different interface layers in Charm4py to work directly with CmiPrintf and CmiAbort