### PR TITLE
add C++ demangling API and use it for backtraces

### DIFF
--- a/src/conv-core/CMakeLists.txt
+++ b/src/conv-core/CMakeLists.txt
@@ -3,7 +3,7 @@ set(conv-core-c-sources cmipool.C conv-conds.C
     global-nop.C isomalloc.C mem-arena.C memoryaffinity.C msgmgr.C quiescence.C
     random.C)
 
-set(conv-core-h-sources ../util/cmitls.h cmipool.h
+set(conv-core-h-sources ../util/cmitls.h cmipool.h cmidemangle.h
     conv-config.h conv-cpath.h conv-cpm.h conv-header.h conv-ooc.h
     conv-qd.h conv-random.h conv-rdma.h conv-taskQ.h conv-trace.h converse.h
     cpthreads.h debug-conv++.h debug-conv.h hrctimer.h mem-arena.h memory-gnu-threads.h

--- a/src/conv-core/cmidemangle.h
+++ b/src/conv-core/cmidemangle.h
@@ -1,0 +1,138 @@
+#ifndef BOOST_CORE_DEMANGLE_HPP_INCLUDED
+#define BOOST_CORE_DEMANGLE_HPP_INCLUDED
+
+// Added for Charm++:
+#define BOOST_NOEXCEPT noexcept
+
+// core::demangle
+//
+// Copyright 2014 Peter Dimov
+// Copyright 2014 Andrey Semashev
+//
+// Distributed under the Boost Software License, Version 1.0.
+// See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt
+
+// Commented for Charm++:
+// #include <boost/config.hpp>
+#include <string>
+
+#if defined(BOOST_HAS_PRAGMA_ONCE)
+# pragma once
+#endif
+
+// __has_include is currently supported by GCC and Clang. However GCC 4.9 may have issues and
+// returns 1 for 'defined( __has_include )', while '__has_include' is actually not supported:
+// https://gcc.gnu.org/bugzilla/show_bug.cgi?id=63662
+#if defined( __has_include ) && (!defined( BOOST_GCC ) || (__GNUC__ + 0) >= 5)
+# if __has_include(<cxxabi.h>)
+#  define BOOST_CORE_HAS_CXXABI_H
+# endif
+#elif defined( __GLIBCXX__ ) || defined( __GLIBCPP__ )
+# define BOOST_CORE_HAS_CXXABI_H
+#endif
+
+#if defined( BOOST_CORE_HAS_CXXABI_H )
+# include <cxxabi.h>
+// For some archtectures (mips, mips64, x86, x86_64) cxxabi.h in Android NDK is implemented by gabi++ library
+// (https://android.googlesource.com/platform/ndk/+/master/sources/cxx-stl/gabi++/), which does not implement
+// abi::__cxa_demangle(). We detect this implementation by checking the include guard here.
+# if defined( __GABIXX_CXXABI_H__ )
+#  undef BOOST_CORE_HAS_CXXABI_H
+# else
+#  include <cstdlib>
+#  include <cstddef>
+# endif
+#endif
+
+namespace boost
+{
+
+namespace core
+{
+
+inline char const * demangle_alloc( char const * name ) BOOST_NOEXCEPT;
+inline void demangle_free( char const * name ) BOOST_NOEXCEPT;
+
+class scoped_demangled_name
+{
+private:
+    char const * m_p;
+
+public:
+    explicit scoped_demangled_name( char const * name ) BOOST_NOEXCEPT :
+        m_p( demangle_alloc( name ) )
+    {
+    }
+
+    ~scoped_demangled_name() BOOST_NOEXCEPT
+    {
+        demangle_free( m_p );
+    }
+
+    char const * get() const BOOST_NOEXCEPT
+    {
+        return m_p;
+    }
+
+    // Changed for Charm++:
+    scoped_demangled_name( scoped_demangled_name const& ) = delete;
+    scoped_demangled_name& operator= ( scoped_demangled_name const& ) = delete;
+};
+
+
+#if defined( BOOST_CORE_HAS_CXXABI_H )
+
+inline char const * demangle_alloc( char const * name ) BOOST_NOEXCEPT
+{
+    int status = 0;
+    std::size_t size = 0;
+    return abi::__cxa_demangle( name, NULL, &size, &status );
+}
+
+inline void demangle_free( char const * name ) BOOST_NOEXCEPT
+{
+    std::free( const_cast< char* >( name ) );
+}
+
+inline std::string demangle( char const * name )
+{
+    scoped_demangled_name demangled_name( name );
+    char const * p = demangled_name.get();
+    if( !p )
+        p = name;
+    return p;
+}
+
+#else
+
+inline char const * demangle_alloc( char const * name ) BOOST_NOEXCEPT
+{
+    return name;
+}
+
+inline void demangle_free( char const * ) BOOST_NOEXCEPT
+{
+}
+
+inline std::string demangle( char const * name )
+{
+    return name;
+}
+
+#endif
+
+} // namespace core
+
+} // namespace boost
+
+
+// Added for Charm++:
+inline std::string CmiDemangle(char const * name)
+{
+    return boost::core::demangle(name);
+}
+
+#undef BOOST_CORE_HAS_CXXABI_H
+
+#endif // #ifndef BOOST_CORE_DEMANGLE_HPP_INCLUDED

--- a/src/conv-core/cmidemangle.h
+++ b/src/conv-core/cmidemangle.h
@@ -126,13 +126,15 @@ inline std::string demangle( char const * name )
 
 } // namespace boost
 
+#undef BOOST_CORE_HAS_CXXABI_H
 
 // Added for Charm++:
 inline std::string CmiDemangle(char const * name)
 {
+    if(!name)
+        return "";
     return boost::core::demangle(name);
 }
 
-#undef BOOST_CORE_HAS_CXXABI_H
 
 #endif // #ifndef BOOST_CORE_DEMANGLE_HPP_INCLUDED

--- a/src/scripts/Make.depends
+++ b/src/scripts/Make.depends
@@ -2388,7 +2388,7 @@ convcore.o: convcore.C converse.h conv-header.h conv-config.h \
  conv-cpm.h conv-cpath.h conv-qd.h conv-random.h conv-lists.h \
  conv-trace.h persistent.h conv-rdma.h cmirdmautils.h debug-conv.h \
  sockRoutines.h conv-ccs.h ccs-server.h ckhashtable.h pup.h \
- memory-isomalloc.h quiescence.h cmibacktrace.C hrctimer.h
+ memory-isomalloc.h quiescence.h cmibacktrace.C hrctimer.h cmidemangle.h
 
 converseProjections.o: converseProjections.C converse.h conv-header.h \
  conv-config.h conv-autoconfig.h conv-common.h conv-mach-common.h \


### PR DESCRIPTION
Adds a new API function, `std::string CmiDemangle(const char *name)`, to demangle C++ symbol names platform-independently. Use this function to print demangled stack traces, e.g. on `CmiAbort()`.

Based on boost 1.71.0.

old:
```
------------- Processor 0 Exiting: Called CmiAbort ------------
Reason: Usage: ./simpleBcast <array-size>
[0] Stack Traceback:
  [0:0] 0   simpleBcast   0x000000010aec75c1 CmiAbort + 177
  [0:1] 1   simpleBcast   0x000000010ad72418 _ZN4MainC1EP8CkArgMsg + 104
  [0:2] 2   simpleBcast   0x000000010ad7235a _ZN12CkIndex_Main19_call_Main_CkArgMsgEPvS0_ + 74
  [0:3] 3   simpleBcast   0x000000010adb843f _Z10_initCharmiPPc + 4751
  [0:4] 4   simpleBcast   0x000000010aec8e3f ConverseInit + 1247
  [0:5] 5   simpleBcast   0x000000010adb93ee charm_main + 46
  [0:6] 6   simpleBcast   0x000000010ad71fa4 start + 52
CHARM++ FATAL ERROR: Usage: ./simpleBcast <array-size>
```

new:
```
------------- Processor 0 Exiting: Called CmiAbort ------------
Reason: Usage: ./simpleBcast <array-size>
[0] Stack Traceback:
  [0:0] simpleBcast 0x100322851 CmiAbortHelper(char const*, char const*, char const*, int, int)
  [0:1] simpleBcast 0x10031f381 CmiAbort
  [0:2] simpleBcast 0x1001ca1d8 Main::Main(CkArgMsg*)
  [0:3] simpleBcast 0x1001ca11a CkIndex_Main::_call_Main_CkArgMsg(void*, void*)
  [0:4] simpleBcast 0x1002101ff _initCharm(int, char**)
  [0:5] simpleBcast 0x100320bff ConverseInit
  [0:6] simpleBcast 0x1002111ae charm_main
  [0:7] simpleBcast 0x1001c9d64 start
CHARM++ FATAL ERROR: Usage: ./simpleBcast <array-size>
```