### PR TITLE
Expose logical bool reducers to Charm4py

### DIFF
--- a/src/ck-core/ckreduction.h
+++ b/src/ck-core/ckreduction.h
@@ -337,6 +337,10 @@ struct CkReductionTypesExt {
     int min_ulong_long = CkReduction::min_ulong_long;
     int min_float = CkReduction::min_float;
     int min_double = CkReduction::min_double;
+    // logical and, or, xor
+    int logical_and_bool = CkReduction::logical_and_bool;
+    int logical_or_bool = CkReduction::logical_or_bool;
+    int logical_xor_bool = CkReduction::logical_xor_bool;
     // External custom reducer in Python
     int external_py = CkReduction::external_py;
 };


### PR DESCRIPTION
Can we merge this and #2485 before the release? I'm not sure when 6.10 release is going to happen, and this is stopping me from merging some things on charm4py master. These won't break Charm++ and the changes are in #CMK_CHARMPY blocks