### PR TITLE
cmake: fix replaysystem spelling

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -105,10 +105,10 @@ option(F90CHARM            "Build f90charm" OFF)
 set(EXTRA_OPTS "" CACHE STRING "Extra flags to pass to compilers.")
 add_compile_options(${EXTRA_OPTS})
 
-set(CMK_REPLAYSYTEM ${REPLAY})
+set(CMK_REPLAYSYSTEM ${REPLAY})
 
 if(${REPLAY} AND NOT ${TRACING})
-  set(CMK_REPLAYSYTEM 0)
+  set(CMK_REPLAYSYSTEM 0)
   message(WARNING "Charm record/replay is disabled because tracing is disabled")
 endif()
 


### PR DESCRIPTION
Followup from #2449.