### PR TITLE
Fixed uninitialized pointer in LBObjUserData copy constructor

### DIFF
--- a/src/ck-ldb/lbdb.h
+++ b/src/ck-ldb/lbdb.h
@@ -141,12 +141,16 @@ public:
     if (d.data != NULL) {
       if (data==NULL) init();
       memcpy(data, d.data, CkpvAccess(lbobjdatalayout).size());
+    } else if (data != NULL) {
+      delete [] data;
+      data = NULL;
     }
     return *this;
   }
-  inline void init() { data = new char[CkpvAccess(lbobjdatalayout).size()]; }
   inline void pup(PUP::er &p);
   void *getData(int idx) { if (data==NULL) init(); return (void*)(data+idx); }
+private:
+  inline void init() { data = new char[CkpvAccess(lbobjdatalayout).size()]; }
 };
 
 typedef struct {

--- a/src/ck-ldb/lbdb.h
+++ b/src/ck-ldb/lbdb.h
@@ -131,6 +131,8 @@ public:
     if (d.data != NULL) {
       init();
       memcpy(data, d.data, CkpvAccess(lbobjdatalayout).size());
+    } else {
+      data = NULL;
     }
   }
 


### PR DESCRIPTION
If d.data is NULL, the 'data' pointer of the new instance remains
unintialized, which can cause segfaults if the instance is deleted
afterwards.