### PR TITLE
CkLocMgr: buffer immigrate messages if array managers don't exist

### DIFF
--- a/src/ck-core/cklocation.h
+++ b/src/ck-core/cklocation.h
@@ -538,6 +538,8 @@ private:
 	CkGroupID lbdbID;
 	CkGroupID metalbID;
 
+	std::list<CkArrayElementMigrateMessage*> pendingImmigrate;
+
 	ck::ArrayIndexCompressor *compressor;
 	CkArrayIndex bounds;
 	void checkInBounds(const CkArrayIndex &idx);


### PR DESCRIPTION
This replaces the buggy busy-wait that reschedules the messages
until the managers are created (which doesn't work because
immigrate messages are expedited).