### PR TITLE
cleanup: remove vestiges of CMK_AIX / CMK_USE_GM / CMK_USE_MX

### DIFF
--- a/examples/ampi/Cjacobi3D/jacobi.C
+++ b/examples/ampi/Cjacobi3D/jacobi.C
@@ -139,11 +139,7 @@ int main(int ac, char** av)
 
   MPI_Bcast(&niter, 1, MPI_INT, 0, MPI_COMM_WORLD);
 
-#if CMK_AIX
-  cp = (chunk*)malloc(sizeof(chunk));
-#else
   cp = new chunk;
-#endif
 #if defined(AMPI) && ! defined(NO_PUP)
   AMPI_Register_pup((MPI_PupFn)chunk_pup, (void*)&cp, &cp_idx);
 #endif

--- a/src/conv-core/cputopology.C
+++ b/src/conv-core/cputopology.C
@@ -448,9 +448,6 @@ extern "C" void LrtsInitCpuTopo(char **argv)
   return;
 #else
 
-#if CMK_USE_GM
-  CmiBarrier();
-#endif
 
 
 #if 0

--- a/src/conv-core/threads.C
+++ b/src/conv-core/threads.C
@@ -302,9 +302,6 @@ void CthAliasEnable(CthThreadBase *t) {
   /* Linux mmap flag MAP_POPULATE, to pre-fault in all the pages,
      only seems to slow down overall performance. */
   /* Linux mmap flag MAP_GROWSDOWN is rejected at runtime under 2.4.25 */
-#if CMK_AIX
-  if (_curMappedStack) munmap(_curMappedStack->stack,_curMappedStack->stacksize);
-#endif
   s=mmap(t->stack,t->stacksize,
       PROT_READ|PROT_WRITE|PROT_EXEC, /* exec for gcc nested function thunks */
       flags, t->aliasStackHandle,0);

--- a/src/util/charmrun-src/charmrun.C
+++ b/src/util/charmrun-src/charmrun.C
@@ -4920,10 +4920,6 @@ static void ssh_script(FILE *f, const nodetab_process & p, const char **argv)
 #ifdef CMK_GFORTRAN
   fprintf(f, "GFORTRAN_UNBUFFERED_ALL=YES; export GFORTRAN_UNBUFFERED_ALL\n");
 #endif
-#if CMK_USE_MX
-  fprintf(f, "MX_MONOTHREAD=1; export MX_MONOTHREAD\n");
-/*fprintf(f,"MX_RCACHE=1; export MX_RCACHE\n");*/
-#endif
 
   if (arg_verbose) {
     printf("Charmrun> Sending \"%s\" to client %d.\n", netstart, nodeno);

--- a/src/util/charmrun-src/charmrun.C
+++ b/src/util/charmrun-src/charmrun.C
@@ -4924,9 +4924,6 @@ static void ssh_script(FILE *f, const nodetab_process & p, const char **argv)
   fprintf(f, "MX_MONOTHREAD=1; export MX_MONOTHREAD\n");
 /*fprintf(f,"MX_RCACHE=1; export MX_RCACHE\n");*/
 #endif
-#if CMK_AIX && CMK_SMP
-  fprintf(f, "MALLOCMULTIHEAP=1; export MALLOCMULTIHEAP\n");
-#endif
 
   if (arg_verbose) {
     printf("Charmrun> Sending \"%s\" to client %d.\n", netstart, nodeno);
@@ -5505,9 +5502,6 @@ static void start_nodes_local(std::vector<nodetab_process> & process_table)
   for (envc = 0; env[envc]; envc++)
     ;
   int extra = 0;
-#if CMK_AIX && CMK_SMP
-  ++extra;
-#endif
   const int proc_active = proc_per.active();
   extra += proc_active;
 #if CMK_SMP
@@ -5521,11 +5515,6 @@ static void start_nodes_local(std::vector<nodetab_process> & process_table)
   envp[envc] = (char *) malloc(256);
   envp[envc + 1] = (char *) malloc(256);
   int n = 2;
-#if CMK_AIX && CMK_SMP
-  envp[envc + n] = (char *) malloc(256);
-  sprintf(envp[envc + n], "MALLOCMULTIHEAP=1");
-  ++n;
-#endif
   // cpu affinity hints
   using Unit = typename TopologyRequest::Unit;
   if (proc_active)

--- a/src/util/sockRoutines.h
+++ b/src/util/sockRoutines.h
@@ -285,9 +285,6 @@ typedef struct {
   ChMessageInt_t nPE; /* Number of worker threads in this OS process */
   ChMessageInt_t dataport; /* node's data port (UDP or GM) */
   ChMessageInt_t mach_id;  /* node's hardware address (GM-only) */
-#if CMK_USE_MX
-  ChMessageLong_t nic_id; /* node's NIC hardware address (MX-only) */
-#endif
   skt_ip_t IP; /* node's IP address */
 } ChNodeinfo;
 

--- a/tests/ampi/jacobi3d/jacobi.C
+++ b/tests/ampi/jacobi3d/jacobi.C
@@ -152,11 +152,7 @@ int main(int ac, char** av)
 
   MPI_Bcast(&niter, 1, MPI_INT, 0, MPI_COMM_WORLD);
 
-#if CMK_AIX
-  cp = (chunk*)malloc(sizeof(chunk));
-#else
   cp = new chunk;
-#endif
 #if defined(AMPI) && ! defined(NO_PUP)
   AMPI_Register_pup((MPI_PupFn)chunk_pup, (void*)&cp, &cp_idx);
 #endif


### PR DESCRIPTION
Followup from the removals of AIX support (39643aa) and Myrinet (102a60c). 