### PR TITLE
Bug #2495: remove -isysroot from charmc arguments

### DIFF
--- a/src/scripts/charmc
+++ b/src/scripts/charmc
@@ -441,6 +441,12 @@ do
 		SKIP_MODULEINIT="yes"
 		;;
 
+    "-isysroot")
+        # Ignore -isysroot and the following argument (macOS SDK path), which charmc 
+        # can not parse (#2495).
+        shift
+        ;;
+
 	"-language")
 		# Parse out some fake languages (that are actually modules)
 		case "$1" in

--- a/src/scripts/charmc
+++ b/src/scripts/charmc
@@ -441,11 +441,11 @@ do
 		SKIP_MODULEINIT="yes"
 		;;
 
-    "-isysroot")
-        # Ignore -isysroot and the following argument (macOS SDK path), which charmc 
-        # can not parse (#2495).
-        shift
-        ;;
+	"-isysroot")
+		# Ignore -isysroot and the following argument (macOS SDK path),
+		# which charmc can not parse (Bug #2495).
+		shift
+		;;
 
 	"-language")
 		# Parse out some fake languages (that are actually modules)


### PR DESCRIPTION
This should be cherry-picked for 6.10.