### PR TITLE
HAPI: Remove dependency on Charm++ layer and fix WorkRequest instrumentation

### DIFF
--- a/src/ck-core/ck.C
+++ b/src/ck-core/ck.C
@@ -437,13 +437,11 @@ void CkSectionID::pup(PUP::er &p) {
 /**** Tiny random API routines */
 
 #if CMK_CUDA
-void CUDACallbackManager(void *fn) {
-  if (fn != NULL) {
-    CkCallback *cb = (CkCallback*) fn;
-    cb->send();
+void CUDACallbackManager(void *fn, void *msg) {
+  if (fn) {
+    ((CkCallback*)fn)->send(msg);
   }
 }
-
 #endif
 
 void QdCreate(int n) {

--- a/src/ck-core/init.C
+++ b/src/ck-core/init.C
@@ -79,6 +79,14 @@ never be excluded...
 
 #if CMK_CUDA
 #include "hapi_impl.h"
+
+extern void (*hapiInvokeCallback)(void*, void*);
+extern void CUDACallbackManager(void*, void*);
+
+extern void (*hapiQdCreate)(int);
+extern void (*hapiQdProcess)(int);
+extern void QdCreate(int);
+extern void QdProcess(int);
 #endif
 
 void CkRestartMain(const char* dirname, CkArgMsg* args);
@@ -1691,6 +1699,9 @@ void _initCharm(int unused_argc, char **argv)
       CmiNodeBarrier();
     }
     hapiRegisterCallbacks();
+    hapiInvokeCallback = CUDACallbackManager;
+    hapiQdCreate = QdCreate;
+    hapiQdProcess = QdProcess;
 #endif
 
     if(CmiMyPe() == 0) {


### PR DESCRIPTION
Resolves #2467 by removing dependencies on the Charm++ layer: `CkVec`, `CkCallback`, `QdCreate`, and `QdProcess`.