### PR TITLE
Bug #2591: Only set __registerDone on rank 0

### DIFF
--- a/src/ck-core/register.C
+++ b/src/ck-core/register.C
@@ -314,7 +314,9 @@ extern void CpdCharmInit(void);
 
 void _registerDone(void)
 {
-  __registerDone = 1;
+  if (CkMyRank() == 0)
+    __registerDone = 1;
+
 #if CMK_CHARMDEBUG
   CpdListRegister(new CpdSimpleListAccessor<EntryInfo>("charm/entries",&_entryTable,pupEntry));
   CpdListRegister(new CpdSimpleListAccessor<MsgInfo>("charm/messages",&_msgTable,pupMsg));


### PR DESCRIPTION
Should fix CkLoop registration. Please test.