### PR TITLE
GitHub CI: run apt-get update to avoid installing old packages

### DIFF
--- a/.github/workflows/verbs.yml
+++ b/.github/workflows/verbs.yml
@@ -12,4 +12,4 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - name: build
-      run: sudo apt-get -y install libibverbs-dev && ./build LIBS verbs-linux-x86_64 smp -j4
+      run: sudo apt-get update && sudo apt-get -y install libibverbs-dev && ./build LIBS verbs-linux-x86_64 smp -j4


### PR DESCRIPTION
Fixes the CI errors seen today.