### PR TITLE
ZC Bcast API: Fix de-registration bug on parent nodes after reverse op

### DIFF
--- a/src/ck-core/ckrdma.C
+++ b/src/ck-core/ckrdma.C
@@ -694,7 +694,7 @@ void performEmApiCmaTransfer(CkNcpyBuffer &source, CkNcpyBuffer &dest, CmiSpanni
 }
 #endif
 
-void performEmApiRget(CkNcpyBuffer &source, CkNcpyBuffer &dest, int opIndex, char *ref, int extraSize, unsigned int rootNode, ncpyEmApiMode emMode) {
+void performEmApiRget(CkNcpyBuffer &source, CkNcpyBuffer &dest, int opIndex, char *ref, int extraSize, int rootNode, ncpyEmApiMode emMode) {
 
   int layerInfoSize = CMK_COMMON_NOCOPY_DIRECT_BYTES + CMK_NOCOPY_DIRECT_BYTES;
   if(dest.regMode == CK_BUFFER_UNREG) {
@@ -750,7 +750,7 @@ void performEmApiRget(CkNcpyBuffer &source, CkNcpyBuffer &dest, int opIndex, cha
   // on the comm. thread as the message is being inside this for loop on the worker thread
 }
 
-void performEmApiNcpyTransfer(CkNcpyBuffer &source, CkNcpyBuffer &dest, int opIndex, CmiSpanningTreeInfo *t, char *ref, int extraSize, CkNcpyMode ncpyMode, unsigned int rootNode, ncpyEmApiMode emMode){
+void performEmApiNcpyTransfer(CkNcpyBuffer &source, CkNcpyBuffer &dest, int opIndex, CmiSpanningTreeInfo *t, char *ref, int extraSize, CkNcpyMode ncpyMode, int rootNode, ncpyEmApiMode emMode){
 
   switch(ncpyMode) {
     case CkNcpyMode::MEMCPY: performEmApiMemcpy(source, dest, emMode);

--- a/src/ck-core/ckrdma.C
+++ b/src/ck-core/ckrdma.C
@@ -80,6 +80,7 @@ void CkNcpyBuffer::rdmaGet(CkNcpyBuffer &source) {
                 isRegistered,
                 pe,
                 ref,
+                -1,  // -1 is the rootNode for p2p operations
                 ncpyOpInfo);
 
   CmiIssueRget(ncpyOpInfo);
@@ -226,6 +227,7 @@ void CkNcpyBuffer::rdmaPut(CkNcpyBuffer &destination) {
                 destination.isRegistered,
                 destination.pe,
                 destination.ref,
+                -1,  // -1 is the rootNode for p2p operations
                 ncpyOpInfo);
 
   CmiIssueRput(ncpyOpInfo);
@@ -439,6 +441,7 @@ void CkRdmaDirectAckHandler(void *ack) {
 
     case CMK_BCAST_EM_API_REVERSE   : handleBcastReverseEntryMethodApiCompletion(info); // Ncpy EM Bcast API invoked through a PUT
                                       break;
+
     case CMK_READONLY_BCAST         : readonlyGetCompleted(info);
                                       break;
 #endif
@@ -691,7 +694,7 @@ void performEmApiCmaTransfer(CkNcpyBuffer &source, CkNcpyBuffer &dest, CmiSpanni
 }
 #endif
 
-void performEmApiRget(CkNcpyBuffer &source, CkNcpyBuffer &dest, int opIndex, char *ref, int extraSize, ncpyEmApiMode emMode) {
+void performEmApiRget(CkNcpyBuffer &source, CkNcpyBuffer &dest, int opIndex, char *ref, int extraSize, unsigned int rootNode, ncpyEmApiMode emMode) {
 
   int layerInfoSize = CMK_COMMON_NOCOPY_DIRECT_BYTES + CMK_NOCOPY_DIRECT_BYTES;
   if(dest.regMode == CK_BUFFER_UNREG) {
@@ -727,6 +730,7 @@ void performEmApiRget(CkNcpyBuffer &source, CkNcpyBuffer &dest, int opIndex, cha
                 dest.isRegistered,
                 dest.pe,
                 (char *)(ncpyEmBufferInfo), // destRef
+                rootNode,
                 ncpyOpInfo);
 
   // set opMode
@@ -746,7 +750,7 @@ void performEmApiRget(CkNcpyBuffer &source, CkNcpyBuffer &dest, int opIndex, cha
   // on the comm. thread as the message is being inside this for loop on the worker thread
 }
 
-void performEmApiNcpyTransfer(CkNcpyBuffer &source, CkNcpyBuffer &dest, int opIndex, CmiSpanningTreeInfo *t, char *ref, int extraSize, CkNcpyMode ncpyMode, ncpyEmApiMode emMode){
+void performEmApiNcpyTransfer(CkNcpyBuffer &source, CkNcpyBuffer &dest, int opIndex, CmiSpanningTreeInfo *t, char *ref, int extraSize, CkNcpyMode ncpyMode, unsigned int rootNode, ncpyEmApiMode emMode){
 
   switch(ncpyMode) {
     case CkNcpyMode::MEMCPY: performEmApiMemcpy(source, dest, emMode);
@@ -755,7 +759,7 @@ void performEmApiNcpyTransfer(CkNcpyBuffer &source, CkNcpyBuffer &dest, int opIn
     case CkNcpyMode::CMA   : performEmApiCmaTransfer(source, dest, t, emMode);
                                    break;
 #endif
-    case CkNcpyMode::RDMA  : performEmApiRget(source, dest, opIndex, ref, extraSize, emMode);
+    case CkNcpyMode::RDMA  : performEmApiRget(source, dest, opIndex, ref, extraSize, rootNode, emMode);
                                    break;
 
     default                      : CkAbort("Invalid Mode");
@@ -983,7 +987,7 @@ envelope* CkRdmaIssueRgets(envelope *env, ncpyEmApiMode emMode, void *forwardMsg
     // destination buffer
     CkNcpyBuffer dest((const void *)buf, source.cnt, CK_BUFFER_UNREG);
 
-    performEmApiNcpyTransfer(source, dest, i, t, ref, extraSize, ncpyMode, emMode);
+    performEmApiNcpyTransfer(source, dest, i, t, ref, extraSize, ncpyMode, rootNode, emMode);
 
     //Update the CkRdmaWrapper pointer of the new message
     source.ptr = buf;
@@ -1118,7 +1122,7 @@ void CkRdmaIssueRgets(envelope *env, ncpyEmApiMode emMode, void *forwardMsg, int
     // destination buffer
     CkNcpyBuffer dest((const void *)arrPtrs[i], arrSizes[i], postStructs[i].regMode, postStructs[i].deregMode);
 
-    performEmApiNcpyTransfer(source, dest, i, t, ref, extraSize, ncpyMode, emMode);
+    performEmApiNcpyTransfer(source, dest, i, t, ref, extraSize, ncpyMode, rootNode, emMode);
 
     //Update the CkRdmaWrapper pointer of the new message
     source.ptr = arrPtrs[i];
@@ -1555,9 +1559,10 @@ void handleBcastReverseEntryMethodApiCompletion(NcpyOperationInfo *info) {
     invokeRemoteNcpyAckHandler(info->destPe, info->refPtr, ncpyHandlerIdx::EM_ACK);
   }
 #if CMK_REG_REQUIRED
-  // De-register source for reverse operations when regMode == UNREG and deregMode == DEREG
-  if(info->isSrcRegistered == 1 && info->srcRegMode == CK_BUFFER_UNREG && info->srcDeregMode == CK_BUFFER_DEREG)
-    deregisterSrcBuffer(info);
+  // De-register source for reverse operations when regMode == UNREG and deregMode == DEREG on the root node
+  if(info->rootNode == CkMyNode())
+    if(info->isSrcRegistered == 1 && info->srcRegMode == CK_BUFFER_UNREG && info->srcDeregMode == CK_BUFFER_DEREG)
+      deregisterSrcBuffer(info);
 #endif
 
   if(info->freeMe == CMK_FREE_NCPYOPINFO)
@@ -2088,6 +2093,7 @@ void readonlyGet(CkNcpyBuffer &src, CkNcpyBuffer &dest, void *refPtr) {
                   dest.isRegistered,
                   dest.pe,
                   dest.ref,
+                  0, // Root Node is always 0 for Readonly bcast (the spanning tree is rooted at Node 0)
                   ncpyOpInfo);
 
     ncpyOpInfo->opMode = CMK_READONLY_BCAST;

--- a/src/ck-core/ckrdma.h
+++ b/src/ck-core/ckrdma.h
@@ -254,9 +254,9 @@ class CkNcpyBuffer{
   friend void readonlyCreateOnSource(CkNcpyBuffer &src);
 
 
-  friend void performEmApiNcpyTransfer(CkNcpyBuffer &source, CkNcpyBuffer &dest, int opIndex, CmiSpanningTreeInfo *t, char *ref, int extraSize, CkNcpyMode ncpyMode, unsigned int rootNode, ncpyEmApiMode emMode);
+  friend void performEmApiNcpyTransfer(CkNcpyBuffer &source, CkNcpyBuffer &dest, int opIndex, CmiSpanningTreeInfo *t, char *ref, int extraSize, CkNcpyMode ncpyMode, int rootNode, ncpyEmApiMode emMode);
 
-  friend void performEmApiRget(CkNcpyBuffer &source, CkNcpyBuffer &dest, int opIndex, char *ref, int extraSize, unsigned int rootNode, ncpyEmApiMode emMode);
+  friend void performEmApiRget(CkNcpyBuffer &source, CkNcpyBuffer &dest, int opIndex, char *ref, int extraSize, int rootNode, ncpyEmApiMode emMode);
 
   friend void performEmApiCmaTransfer(CkNcpyBuffer &source, CkNcpyBuffer &dest, CmiSpanningTreeInfo *t, ncpyEmApiMode emMode);
 

--- a/src/ck-core/ckrdma.h
+++ b/src/ck-core/ckrdma.h
@@ -254,9 +254,9 @@ class CkNcpyBuffer{
   friend void readonlyCreateOnSource(CkNcpyBuffer &src);
 
 
-  friend void performEmApiNcpyTransfer(CkNcpyBuffer &source, CkNcpyBuffer &dest, int opIndex, CmiSpanningTreeInfo *t, char *ref, int extraSize, CkNcpyMode ncpyMode, ncpyEmApiMode emMode);
+  friend void performEmApiNcpyTransfer(CkNcpyBuffer &source, CkNcpyBuffer &dest, int opIndex, CmiSpanningTreeInfo *t, char *ref, int extraSize, CkNcpyMode ncpyMode, unsigned int rootNode, ncpyEmApiMode emMode);
 
-  friend void performEmApiRget(CkNcpyBuffer &source, CkNcpyBuffer &dest, int opIndex, char *ref, int extraSize, ncpyEmApiMode emMode);
+  friend void performEmApiRget(CkNcpyBuffer &source, CkNcpyBuffer &dest, int opIndex, char *ref, int extraSize, unsigned int rootNode, ncpyEmApiMode emMode);
 
   friend void performEmApiCmaTransfer(CkNcpyBuffer &source, CkNcpyBuffer &dest, CmiSpanningTreeInfo *t, ncpyEmApiMode emMode);
 

--- a/src/util/cmirdmautils.C
+++ b/src/util/cmirdmautils.C
@@ -35,7 +35,7 @@ void setNcpyOpInfo(
     unsigned short int isDestRegistered,
     int destPe,
     const void *destRef,
-    unsigned int rootNode,
+    int rootNode,
     NcpyOperationInfo *ncpyOpInfo) {
 
   char *base = (char *)ncpyOpInfo + sizeof(NcpyOperationInfo);

--- a/src/util/cmirdmautils.C
+++ b/src/util/cmirdmautils.C
@@ -35,6 +35,7 @@ void setNcpyOpInfo(
     unsigned short int isDestRegistered,
     int destPe,
     const void *destRef,
+    unsigned int rootNode,
     NcpyOperationInfo *ncpyOpInfo) {
 
   char *base = (char *)ncpyOpInfo + sizeof(NcpyOperationInfo);
@@ -94,6 +95,8 @@ void setNcpyOpInfo(
   ncpyOpInfo->opMode  = CMK_DIRECT_API; // default operation mode is CMK_DIRECT_API
   ncpyOpInfo->ackMode = CMK_SRC_DEST_ACK; // default ack mode is CMK_SRC_DEST_ACK
   ncpyOpInfo->freeMe  = CMK_FREE_NCPYOPINFO; // default ack mode is CMK_FREE_NCPYOPINFO
+
+  ncpyOpInfo->rootNode = rootNode;
 
   ncpyOpInfo->ncpyOpInfoSize = sizeof(NcpyOperationInfo) + srcLayerSize + destLayerSize + srcAckSize + destAckSize;
 }

--- a/src/util/cmirdmautils.h
+++ b/src/util/cmirdmautils.h
@@ -53,6 +53,8 @@ typedef struct ncpystruct{
 
   int ncpyOpInfoSize;
 
+  unsigned int rootNode; // used only for Broadcast, -1 for p2p operations
+
 }NcpyOperationInfo;
 
 #ifdef __cplusplus
@@ -88,6 +90,7 @@ void setNcpyOpInfo(
   unsigned short int isdestRegistered,
   int destPe,
   const void *destRef,
+  unsigned int rootNode,
   NcpyOperationInfo *ncpyOpInfo);
 
 void resetNcpyOpInfoPointers(NcpyOperationInfo *ncpyOpInfo);

--- a/src/util/cmirdmautils.h
+++ b/src/util/cmirdmautils.h
@@ -53,7 +53,7 @@ typedef struct ncpystruct{
 
   int ncpyOpInfoSize;
 
-  unsigned int rootNode; // used only for Broadcast, -1 for p2p operations
+  int rootNode; // used only for Broadcast, -1 for p2p operations
 
 }NcpyOperationInfo;
 
@@ -90,7 +90,7 @@ void setNcpyOpInfo(
   unsigned short int isdestRegistered,
   int destPe,
   const void *destRef,
-  unsigned int rootNode,
+  int rootNode,
   NcpyOperationInfo *ncpyOpInfo);
 
 void resetNcpyOpInfoPointers(NcpyOperationInfo *ncpyOpInfo);


### PR DESCRIPTION
Previously, on intermediate nodes, when rgets on the child nodes were being
executed as reverse operations (PUT from source instead of a GET from destination),
the source buffer was de-registered twice on the intermediate nodes, causing a failure.
This de-registration (for UNREG modes) is only applicable to root nodes.
With this commit, the root node for a ZC Bcast is stored in NcpyOperationInfo
and de-registration is performed only when the reverse operation involves
the root node as the source. (and not when an intermediate node is the source)