### PR TITLE
UCX: Remove wrong assert from UCX ML

### DIFF
--- a/src/arch/ucx/machine.C
+++ b/src/arch/ucx/machine.C
@@ -463,7 +463,6 @@ static void UcxPostRxBuffers()
             ucxCtx.rxReqs[i] = UcxPostRxReq(UCX_MSG_TAG_EAGER,
                                             ucxCtx.eagerSize, NULL);
             ++numPosted;
-            CmiAssert(!ucxCtx.rxReqs[i]->completed);
         }
     }
     UCX_LOG(3, "UCX: posted %d of %d rx requests (free reqs %d)",


### PR DESCRIPTION
This assertion is not correct, request can be moved to `complete` state inside `UcxPostRxReq` in case of immediate completion.