### PR TITLE
charmc/ampicc: pass through certain compiler options even without file to compile

### DIFF
--- a/src/libs/ck-libs/ampi/ampiCC
+++ b/src/libs/ck-libs/ampi/ampiCC
@@ -14,7 +14,7 @@ FSGLOBALS=''
 PIPGLOBALS=''
 EXPLICIT_COMPILATION=''
 BUILD_SHARE=''
-SHOW_COMPILER_VERSION=''
+PASSTHROUGH_COMPILER_OPTIONS=''
 
 ARGS=''
 OBJECT=''
@@ -28,9 +28,8 @@ do
      echo "charmc"
      exit 0
      ;;
-  -v|--version)
-     SHOW_COMPILER_VERSION=$arg
-     ARGS+=" $arg"
+  -v|--version|-print-search-dirs)
+     PASSTHROUGH_COMPILER_OPTIONS+=" $arg"
      ;;
   -verbose)
      VERBOSE='true'
@@ -80,13 +79,15 @@ done
 
 eval processArgs "$@"
 
-# If there are no args except -v or --version specified, just run
-# charmc with -v or --version. Helps with configure scripts that
-# parse the output to detect compiler versions.
-if [[ -z $ARGS ]] && [[ -n $SHOW_COMPILER_VERSION ]]; then
-  $CHARMBIN/charmc $SHOW_COMPILER_VERSION
+# If there are no filename arguments specified, just pass through
+# compiler options to charmc. Helps with configure scripts that
+# parse the output to detect compiler versions, search paths, etc.
+if [[ -z "$ARGS" && -n "$PASSTHROUGH_COMPILER_OPTIONS" ]]; then
+  $CHARMBIN/charmc $PASSTHROUGH_COMPILER_OPTIONS
   exit $?
 fi
+
+ARGS+=" $PASSTHROUGH_COMPILER_OPTIONS"
 
 Do() {
   [ -n "$VERBOSE" ] && echo "$AMPICC: Executing $@" 1>&2

--- a/src/libs/ck-libs/ampi/ampiCC
+++ b/src/libs/ck-libs/ampi/ampiCC
@@ -30,6 +30,7 @@ do
      ;;
   -v|--version)
      SHOW_COMPILER_VERSION=$arg
+     ARGS+=" $arg"
      ;;
   -verbose)
      VERBOSE='true'

--- a/src/libs/ck-libs/ampi/ampiCC
+++ b/src/libs/ck-libs/ampi/ampiCC
@@ -14,6 +14,7 @@ FSGLOBALS=''
 PIPGLOBALS=''
 EXPLICIT_COMPILATION=''
 BUILD_SHARE=''
+SHOW_COMPILER_VERSION=''
 
 ARGS=''
 OBJECT=''
@@ -26,6 +27,9 @@ do
   -show)
      echo "charmc"
      exit 0
+     ;;
+  -v|--version)
+     SHOW_COMPILER_VERSION=$arg
      ;;
   -verbose)
      VERBOSE='true'
@@ -74,6 +78,14 @@ done
 }
 
 eval processArgs "$@"
+
+# If there are no args except -v or --version specified, just run
+# charmc with -v or --version. Helps with configure scripts that
+# parse the output to detect compiler versions.
+if [[ -z $ARGS ]] && [[ -n $SHOW_COMPILER_VERSION ]]; then
+  $CHARMBIN/charmc $SHOW_COMPILER_VERSION
+  exit $?
+fi
 
 Do() {
   [ -n "$VERBOSE" ] && echo "$AMPICC: Executing $@" 1>&2

--- a/src/scripts/charmc
+++ b/src/scripts/charmc
@@ -2036,7 +2036,7 @@ MakeSO() {
 
 if [ -z "$OBJECT" -o ! -z "$SKIPLINK" ]
 then
-	[[ -n $PASSTHROUGH_COMPILER_OPTIONS ]] && $CHARM_CXX $PASSTHROUGH_COMPILER_OPTIONS
+	[[ -n "$PASSTHROUGH_COMPILER_OPTIONS" ]] && $CHARM_CXX $PASSTHROUGH_COMPILER_OPTIONS
 # We have no target object, or are playing preprocessor tricks-- just end
 	Debugf "No target object-- finished"
 	Success

--- a/src/scripts/charmc
+++ b/src/scripts/charmc
@@ -425,7 +425,8 @@ do
 		;;
 
 	-v|--version|-print-search-dirs)
-		# Make sure compiler version is printed even if no file to compile is specified
+		# Make sure these compiler options are passed through even if no
+		# file to compile is specified
 		PASSTHROUGH_COMPILER_OPTIONS+=" $arg"
 		OPTS="$OPTS $arg"
 		;;

--- a/src/scripts/charmc
+++ b/src/scripts/charmc
@@ -118,7 +118,7 @@ NO_MAIN=""
 CUSTOM_PARTITION=""
 PREPROCESS_CI="yes"
 INPUT_GIVEN=""
-SHOW_COMPILER_VERSION=""
+PASSTHROUGH_COMPILER_OPTIONS=""
 
 ####################################################################
 #
@@ -424,9 +424,9 @@ do
 		exit 0
 		;;
 
-	-v|--version)
+	-v|--version|-print-search-dirs)
 		# Make sure compiler version is printed even if no file to compile is specified
-		SHOW_COMPILER_VERSION="$arg"
+		PASSTHROUGH_COMPILER_OPTIONS+=" $arg"
 		OPTS="$OPTS $arg"
 		;;
 
@@ -2035,7 +2035,7 @@ MakeSO() {
 
 if [ -z "$OBJECT" -o ! -z "$SKIPLINK" ]
 then
-	[[ -n $SHOW_COMPILER_VERSION ]] && $CHARM_CXX $SHOW_COMPILER_VERSION
+	[[ -n $PASSTHROUGH_COMPILER_OPTIONS ]] && $CHARM_CXX $PASSTHROUGH_COMPILER_OPTIONS
 # We have no target object, or are playing preprocessor tricks-- just end
 	Debugf "No target object-- finished"
 	Success

--- a/src/scripts/charmc
+++ b/src/scripts/charmc
@@ -118,6 +118,7 @@ NO_MAIN=""
 CUSTOM_PARTITION=""
 PREPROCESS_CI="yes"
 INPUT_GIVEN=""
+SHOW_COMPILER_VERSION=""
 
 ####################################################################
 #
@@ -421,6 +422,12 @@ do
 	"-V")
 		printVersion
 		exit 0
+		;;
+
+	-v|--version)
+		# Make sure compiler version is printed even if no file to compile is specified
+		SHOW_COMPILER_VERSION="$arg"
+		OPTS="$OPTS $arg"
 		;;
 
 	"-machine")
@@ -2028,6 +2035,7 @@ MakeSO() {
 
 if [ -z "$OBJECT" -o ! -z "$SKIPLINK" ]
 then
+	[[ -n $SHOW_COMPILER_VERSION ]] && $CHARM_CXX $SHOW_COMPILER_VERSION
 # We have no target object, or are playing preprocessor tricks-- just end
 	Debugf "No target object-- finished"
 	Success


### PR DESCRIPTION
Helps with (e.g.) configure scripts that parse the output of `-v`, `--version`, `-print-search-dirs` to detect compiler configurations.