### PR TITLE
hwloc: disable C99 check

### DIFF
--- a/contrib/hwloc/config/hwloc.m4
+++ b/contrib/hwloc/config/hwloc.m4
@@ -161,13 +161,14 @@ EOF])
           [AC_DEFINE([HWLOC_SYM_TRANSFORM], [0])],
           [AC_DEFINE([HWLOC_SYM_TRANSFORM], [1])])
 
+    # Disabled for Charm++ due to https://github.com/UIUC-PPL/charm/issues/2606
     # hwloc 2.0+ requires a C99 compliant compiler
-    AC_PROG_CC_C99
+    #AC_PROG_CC_C99
     # The result of AC_PROG_CC_C99 is stored in ac_cv_prog_cc_c99
-    if test "x$ac_cv_prog_cc_c99" = xno ; then
-        AC_MSG_WARN([hwloc requires a C99 compiler])
-        AC_MSG_ERROR([Aborting.])
-    fi
+    #if test "x$ac_cv_prog_cc_c99" = xno ; then
+    #    AC_MSG_WARN([hwloc requires a C99 compiler])
+    #    AC_MSG_ERROR([Aborting.])
+    #fi
 
     # GCC specifics.
     if test "x$GCC" = "xyes"; then

--- a/contrib/hwloc/configure.ac
+++ b/contrib/hwloc/configure.ac
@@ -97,7 +97,6 @@ LT_LANG([C++])
 CFLAGS_save=$CFLAGS
 AC_PROG_CC
 AM_PROG_CC_C_O
-AC_PROG_CC_C99
 CFLAGS=$CFLAGS_save
 
 AC_ARG_VAR(CC_FOR_BUILD,[build system C compiler])


### PR DESCRIPTION
Workaround for #2606. The check is stricter than what
hwloc actually requires, and hwloc compiles fine without it.