### PR TITLE
Revert new ucx changes which are introducing crashes

### DIFF
--- a/src/arch/ucx/machine.C
+++ b/src/arch/ucx/machine.C
@@ -463,6 +463,7 @@ static void UcxPostRxBuffers()
             ucxCtx.rxReqs[i] = UcxPostRxReq(UCX_MSG_TAG_EAGER,
                                             ucxCtx.eagerSize, NULL);
             ++numPosted;
+            CmiAssert(!ucxCtx.rxReqs[i]->completed);
         }
     }
     UCX_LOG(3, "UCX: posted %d of %d rx requests (free reqs %d)",

--- a/src/arch/ucx/machine.C
+++ b/src/arch/ucx/machine.C
@@ -32,11 +32,11 @@
 #define CmiSetMsgSize(msg, sz)    ((((CmiMsgHeaderBasic *)msg)->size) = (sz))
 
 #define UCX_MSG_PROBE_THRESH            32768
-#define UCX_MSG_NUM_RX_REQS             16
+#define UCX_MSG_NUM_RX_REQS             64
 #define UCX_MSG_NUM_RX_REQS_MAX         1024
 #define UCX_TAG_MSG_BITS                4
 #define UCX_TAG_RMA_BITS                4
-#define UCX_MSG_TAG_EAGER               UCS_BIT(0)
+#define UCX_MSG_TAG_DIRECT              UCS_BIT(0)
 #define UCX_MSG_TAG_PROBE               UCS_BIT(1)
 #define UCX_RMA_TAG_GET                 UCS_BIT(UCX_TAG_MSG_BITS + 1)
 #define UCX_RMA_TAG_REG_AND_SEND_BACK   UCS_BIT(UCX_TAG_MSG_BITS + 2)
@@ -70,8 +70,8 @@ enum {
 typedef struct UcxRequest
 {
     void           *msgBuf;
+    int            idx;
     int            completed;
-    ucp_tag_t      tag;
 #if CMK_ONESIDED_IMPL
     void           *ncpyAck;
     ucp_rkey_h     rkey;
@@ -89,8 +89,6 @@ typedef struct UcxContext
 #endif
     int               eagerSize;
     int               numRxReqs;
-    int               numFreeRxReqs;
-    int               rxReqsBatch;
 } UcxContext;
 
 #ifdef CMK_SMP
@@ -111,6 +109,7 @@ static UcxContext ucxCtx;
 
 static void UcxRxReqCompleted(void *request, ucs_status_t status,
                               ucp_tag_recv_info_t *info);
+static void UcxPrepostRxBuffers();
 
 #if CMK_ONESIDED_IMPL
 #include "machine-onesided.h"
@@ -136,123 +135,8 @@ void UcxRequestInit(void *request)
 {
     UcxRequest *req = (UcxRequest*)request;
     req->msgBuf     = NULL;
+    req->idx        = -1;
     req->completed  = 0;
-}
-
-static inline UcxRequest* UcxHandleRxReq(UcxRequest *request, void *rxBuf,
-                                         size_t size, ucp_tag_t tag)
-{
-
-#if CMK_ONESIDED_IMPL
-    if (tag & UCX_RMA_TAG_REG_AND_SEND_BACK) {
-        // Register the source buffer and send back to destination to perform GET
-        NcpyOperationInfo *ncpyOpInfo = (NcpyOperationInfo *)(rxBuf);
-        UCX_LOG(4, "Got ncpy size %d (meta size %d)", ncpyOpInfo->srcSize, ncpyOpInfo->ncpyOpInfoSize);
-        resetNcpyOpInfoPointers(ncpyOpInfo);
-
-        UcxRdmaInfo *info = (UcxRdmaInfo *)(ncpyOpInfo->srcLayerInfo + CmiGetRdmaCommonInfoSize());
-
-        UcxMemMap(info, (void *)ncpyOpInfo->srcPtr, ncpyOpInfo->srcSize);
-
-        ncpyOpInfo->isSrcRegistered = 1;
-
-        ncpyOpInfo->freeMe = CMK_FREE_NCPYOPINFO; // It's a message, not a realy ncpy Obj
-        UCX_LOG(4, "Reset ncpy size %d (meta size %d)", ncpyOpInfo->destSize, ncpyOpInfo->ncpyOpInfoSize);
-
-        // send back to destination process to perform GET
-        UcxSendMsg(CmiNodeOf(ncpyOpInfo->destPe), ncpyOpInfo->destPe,
-                   ncpyOpInfo->ncpyOpInfoSize, (char*)ncpyOpInfo,
-                   UCX_RMA_TAG_GET, UcxRmaSendCompletedAndFree);
-
-    } else if (tag & UCX_RMA_TAG_GET) {
-        NcpyOperationInfo *ncpyOpInfo = (NcpyOperationInfo *)(rxBuf);
-        resetNcpyOpInfoPointers(ncpyOpInfo);
-
-        ncpyOpInfo->freeMe = CMK_FREE_NCPYOPINFO; // It's a message, not a real ncpy Obj
-        UcxRmaOp(ncpyOpInfo, UCX_RMA_OP_GET);
-
-    } else if (tag & UCX_RMA_TAG_DEREG_AND_ACK) {
-        NcpyOperationInfo *ncpyOpInfo = (NcpyOperationInfo *)(rxBuf);
-        resetNcpyOpInfoPointers(ncpyOpInfo);
-        ncpyOpInfo->freeMe = CMK_FREE_NCPYOPINFO;
-
-        if(CmiMyNode() == CmiNodeOf(ncpyOpInfo->srcPe)) { // source node
-            LrtsDeregisterMem(ncpyOpInfo->srcPtr,
-                              ncpyOpInfo->srcLayerInfo + CmiGetRdmaCommonInfoSize(),
-                              ncpyOpInfo->srcPe,
-                              ncpyOpInfo->srcRegMode);
-
-            ncpyOpInfo->isSrcRegistered = 0; // Set isSrcRegistered to 0 after de-registration
-
-            // Invoke source ack
-            if(ncpyOpInfo->opMode != CMK_BCAST_EM_API) {
-                ncpyOpInfo->opMode = CMK_EM_API_SRC_ACK_INVOKE;
-                CmiInvokeNcpyAck(ncpyOpInfo);
-            }
-
-        } else if(CmiMyNode() == CmiNodeOf(ncpyOpInfo->destPe)) { // destination node
-
-            LrtsDeregisterMem(ncpyOpInfo->destPtr,
-                              ncpyOpInfo->destLayerInfo + CmiGetRdmaCommonInfoSize(),
-                              ncpyOpInfo->destPe,
-                              ncpyOpInfo->destRegMode);
-
-            ncpyOpInfo->isDestRegistered = 0; // Set isDestRegistered to 0 after de-registration
-
-            // Invoke destination ack
-            ncpyOpInfo->opMode = CMK_EM_API_DEST_ACK_INVOKE;
-            CmiInvokeNcpyAck(ncpyOpInfo);
-
-        } else {
-            CmiAbort(" Cannot de-register on a different node than the source or destinaton");
-        }
-    }
-#endif
-
-    if (!(tag & UCX_RMA_TAG_MASK)) {
-        handleOneRecvedMsg(size, (char*)rxBuf);
-    }
-
-    if (tag & UCX_MSG_TAG_EAGER) {
-        // Preposted RX request will be released in UcxPostRxBuffers
-        ++ucxCtx.numFreeRxReqs;
-    } else {
-        UCX_REQUEST_FREE(request);
-    }
-}
-
-
-static inline UcxRequest* UcxPostRxReq(ucp_tag_t tag, size_t size,
-                                       ucp_tag_message_h msg)
-{
-    void *buf = CmiAlloc(size);
-    UcxRequest *req;
-
-    if (tag == UCX_MSG_TAG_EAGER) {
-        req = (UcxRequest*)ucp_tag_recv_nb(ucxCtx.worker, buf,
-                                           ucxCtx.eagerSize,
-                                           ucp_dt_make_contig(1), tag,
-                                           UCX_MSG_TAG_MASK,
-                                           UcxRxReqCompleted);
-    } else {
-        CmiEnforce(tag == UCX_MSG_TAG_PROBE);
-        req = (UcxRequest*)ucp_tag_msg_recv_nb(ucxCtx.worker, buf, size,
-                                               ucp_dt_make_contig(1), msg,
-                                               UcxRxReqCompleted);
-    }
-
-    CmiEnforce(!UCS_PTR_IS_ERR(req));
-    UCX_LOG(3, "Posted RX buf %p size %zu, req %p, tag %zu, comp %d\n",
-            req->msgBuf, size, req, tag, req->completed);
-
-    // Request completed immediately
-    if (req->completed) {
-        UcxHandleRxReq(req, buf, size, req->tag);
-    } else {
-        req->msgBuf = buf;
-    }
-
-    return req;
 }
 
 static void UcxInitEps(int numNodes, int myId)
@@ -398,25 +282,9 @@ void LrtsInit(int *argc, char ***argv, int *numNodes, int *myNodeID)
         ucxCtx.eagerSize = UCX_MSG_PROBE_THRESH;
     }
 
-    // We wait for rxReqsBatch requests to complete, before reposting new ones
-    ucxCtx.rxReqsBatch = std::max(1, ucxCtx.numRxReqs / 4);
-    if (CmiGetArgInt(*argv, "+ucx_rx_reqs_batch", &ucxCtx.rxReqsBatch)) {
-        if ((ucxCtx.rxReqsBatch > ucxCtx.numRxReqs) || (ucxCtx.rxReqsBatch <= 0)) {
-            CmiPrintf("UCX: Invalid value of RX reqs batch: %d\n", ucxCtx.rxReqsBatch);
-            CmiAbort(__func__);
-        }
-    }
-
     UcxInitEps(*numNodes, *myNodeID);
 
-    ucxCtx.rxReqs = (UcxRequest**)CmiAlloc(sizeof(UcxRequest*) * ucxCtx.numRxReqs);
-    CmiEnforce(ucxCtx.rxReqs);
-
-    // Post RX requests for eager protocol
-    ucxCtx.numFreeRxReqs = 0;
-    for (int i = 0; i < ucxCtx.numRxReqs; i++) {
-        ucxCtx.rxReqs[i] = UcxPostRxReq(UCX_MSG_TAG_EAGER, ucxCtx.eagerSize, NULL);
-    }
+    UcxPrepostRxBuffers();
 
     // Ensure connects completion
     status = ucp_worker_flush(ucxCtx.worker);
@@ -430,6 +298,72 @@ void LrtsInit(int *argc, char ***argv, int *numNodes, int *myNodeID)
             ucxCtx.numRxReqs, ucxCtx.eagerSize);
 }
 
+static inline UcxRequest* UcxPostRxReq(ucp_tag_t tag, size_t size,
+                                       ucp_tag_message_h msg)
+{
+    void *buf = CmiAlloc(size);
+    UcxRequest *req;
+
+    if (tag == UCX_MSG_TAG_DIRECT) {
+        req = (UcxRequest*)ucp_tag_recv_nb(ucxCtx.worker, buf,
+                                           ucxCtx.eagerSize,
+                                           ucp_dt_make_contig(1), tag,
+                                           UCX_MSG_TAG_MASK,
+                                           UcxRxReqCompleted);
+    } else {
+        CmiEnforce(tag == UCX_MSG_TAG_PROBE);
+        req = (UcxRequest*)ucp_tag_msg_recv_nb(ucxCtx.worker, buf, size,
+                                               ucp_dt_make_contig(1), msg,
+                                               UcxRxReqCompleted);
+    }
+
+    CmiEnforce(!UCS_PTR_IS_ERR(req));
+    UCX_LOG(3, "Posted RX buf %p size %zu, req %p, tag %zu, comp %d\n",
+            req->msgBuf, size, req, tag, req->completed);
+
+    // Request completed immediately
+    if (req->completed) {
+        int idx = req->idx;
+
+        if (!(tag & UCX_RMA_TAG_MASK)) {
+            handleOneRecvedMsg(size, (char*)buf);
+        }
+
+        UCX_REQUEST_FREE(req);
+
+        if (tag & UCX_MSG_TAG_DIRECT) {
+            ucxCtx.rxReqs[idx] = UcxPostRxReq(UCX_MSG_TAG_DIRECT, ucxCtx.eagerSize, NULL);
+            ucxCtx.rxReqs[idx]->idx = idx;
+            req = ucxCtx.rxReqs[idx];
+        } else {
+            return NULL;
+        }
+    } else {
+        req->msgBuf = buf;
+    }
+
+    return req;
+}
+
+static inline UcxRequest* UcxHandleRxReq(UcxRequest *request, char *rxBuf,
+                                         size_t size, ucp_tag_t tag, int idx)
+{
+    if (!(tag & UCX_RMA_TAG_MASK)) {
+        handleOneRecvedMsg(size, rxBuf);
+    }
+
+    UCX_REQUEST_FREE(request);
+
+    if (tag & UCX_MSG_TAG_DIRECT) {
+        ucxCtx.rxReqs[idx]      = UcxPostRxReq(UCX_MSG_TAG_DIRECT,
+                                               ucxCtx.eagerSize, NULL);
+        ucxCtx.rxReqs[idx]->idx = idx;
+        return ucxCtx.rxReqs[idx];
+    }
+
+    return NULL;
+}
+
 static void UcxRxReqCompleted(void *request, ucs_status_t status,
                               ucp_tag_recv_info_t *info)
 {
@@ -438,37 +372,99 @@ static void UcxRxReqCompleted(void *request, ucs_status_t status,
     UCX_LOG(3, "status %d len %zu, buf %p, req %p, tag %zu\n",
             status,  info->length, req->msgBuf, request, info->sender_tag);
 
-    req->completed = 1;
-
     if (ucs_unlikely(status == UCS_ERR_CANCELED)) {
         return;
     }
 
+#if CMK_ONESIDED_IMPL
+    if (info->sender_tag & UCX_RMA_TAG_REG_AND_SEND_BACK) {
+
+        // Register the source buffer and send back to destination to perform GET
+
+        NcpyOperationInfo *ncpyOpInfo = (NcpyOperationInfo *)(req->msgBuf);
+        UCX_LOG(4, "Got ncpy size %d (meta size %d)", ncpyOpInfo->srcSize, ncpyOpInfo->ncpyOpInfoSize);
+        resetNcpyOpInfoPointers(ncpyOpInfo);
+
+        UcxRdmaInfo *info = (UcxRdmaInfo *)(ncpyOpInfo->srcLayerInfo + CmiGetRdmaCommonInfoSize());
+
+        UcxMemMap(info,
+                  (void *)ncpyOpInfo->srcPtr,
+                  ncpyOpInfo->srcSize);
+
+        ncpyOpInfo->isSrcRegistered = 1;
+
+        ncpyOpInfo->freeMe = CMK_FREE_NCPYOPINFO; // It's a message, not a realy ncpy Obj
+        UCX_LOG(4, "Reset ncpy size %d (meta size %d)", ncpyOpInfo->destSize, ncpyOpInfo->ncpyOpInfoSize);
+
+        // send back to destination process to perform GET
+        UcxSendMsg(CmiNodeOf(ncpyOpInfo->destPe), ncpyOpInfo->destPe,
+                   ncpyOpInfo->ncpyOpInfoSize, (char*)ncpyOpInfo,
+                   UCX_RMA_TAG_GET, UcxRmaSendCompletedAndFree);
+
+    } else if (info->sender_tag & UCX_RMA_TAG_GET) {
+        NcpyOperationInfo *ncpyOpInfo = (NcpyOperationInfo *)(req->msgBuf);
+        resetNcpyOpInfoPointers(ncpyOpInfo);
+
+        ncpyOpInfo->freeMe = CMK_FREE_NCPYOPINFO; // It's a message, not a real ncpy Obj
+        UcxRmaOp(ncpyOpInfo, UCX_RMA_OP_GET);
+
+    } else if (info->sender_tag & UCX_RMA_TAG_DEREG_AND_ACK) {
+        NcpyOperationInfo *ncpyOpInfo = (NcpyOperationInfo *)(req->msgBuf);
+        resetNcpyOpInfoPointers(ncpyOpInfo);
+        ncpyOpInfo->freeMe = CMK_FREE_NCPYOPINFO;
+
+        if(CmiMyNode() == CmiNodeOf(ncpyOpInfo->srcPe)) { // source node
+            LrtsDeregisterMem(ncpyOpInfo->srcPtr,
+                              ncpyOpInfo->srcLayerInfo + CmiGetRdmaCommonInfoSize(),
+                              ncpyOpInfo->srcPe,
+                              ncpyOpInfo->srcRegMode);
+
+            ncpyOpInfo->isSrcRegistered = 0; // Set isSrcRegistered to 0 after de-registration
+
+            // Invoke source ack
+            if(ncpyOpInfo->opMode != CMK_BCAST_EM_API) {
+                ncpyOpInfo->opMode = CMK_EM_API_SRC_ACK_INVOKE;
+                CmiInvokeNcpyAck(ncpyOpInfo);
+            }
+
+        } else if(CmiMyNode() == CmiNodeOf(ncpyOpInfo->destPe)) { // destination node
+
+            LrtsDeregisterMem(ncpyOpInfo->destPtr,
+                              ncpyOpInfo->destLayerInfo + CmiGetRdmaCommonInfoSize(),
+                              ncpyOpInfo->destPe,
+                              ncpyOpInfo->destRegMode);
+
+            ncpyOpInfo->isDestRegistered = 0; // Set isDestRegistered to 0 after de-registration
+
+            // Invoke destination ack
+            ncpyOpInfo->opMode = CMK_EM_API_DEST_ACK_INVOKE;
+            CmiInvokeNcpyAck(ncpyOpInfo);
+
+        } else {
+            CmiAbort(" Cannot de-register on a different node than the source or destinaton");
+        }
+    }
+#endif
+
     if (req->msgBuf != NULL) {
-        // Request is not completed immediately
-        UcxHandleRxReq(req, req->msgBuf, info->length, info->sender_tag);
+        // Request is not completed immideately
+        UcxHandleRxReq(req, (char*)req->msgBuf, info->length, info->sender_tag, req->idx);
     } else {
-        // Request completed immediately, save real sender tag
-        req->tag = info->sender_tag;
+        req->completed = 1;
     }
 }
 
-static void UcxPostRxBuffers()
+static void UcxPrepostRxBuffers()
 {
-    int i, numPosted;
+    int i;
 
-    for (i = 0, numPosted = 0; i < ucxCtx.numRxReqs; i++) {
-        if (ucxCtx.rxReqs[i]->completed) {
-            UCX_REQUEST_FREE(ucxCtx.rxReqs[i]);
-            ucxCtx.rxReqs[i] = UcxPostRxReq(UCX_MSG_TAG_EAGER,
-                                            ucxCtx.eagerSize, NULL);
-            ++numPosted;
-            CmiAssert(!ucxCtx.rxReqs[i]->completed);
-        }
+    ucxCtx.rxReqs = (UcxRequest**)CmiAlloc(sizeof(UcxRequest*) * ucxCtx.numRxReqs);
+
+    for (i = 0; i < ucxCtx.numRxReqs; i++) {
+        ucxCtx.rxReqs[i] = UcxPostRxReq(UCX_MSG_TAG_DIRECT, ucxCtx.eagerSize, NULL);
+        ucxCtx.rxReqs[i]->idx = i;
     }
-    UCX_LOG(3, "UCX: posted %d of %d rx requests (free reqs %d)",
-            numPosted, ucxCtx.numRxReqs, ucxCtx.numFreeRxReqs);
-    ucxCtx.numFreeRxReqs = 0;
+    UCX_LOG(3, "UCX: preposted %d rx requests", ucxCtx.numRxReqs);
 }
 
 void UcxTxReqCompleted(void *request, ucs_status_t status)
@@ -491,7 +487,7 @@ inline void* UcxSendMsg(int destNode, int destPE, int size,
     ucp_tag_t sTag;
 
     // Combine tag and sTag: sTag defines msg protocol, tag may indicate RMA requests
-    sTag  = (size > ucxCtx.eagerSize) ? UCX_MSG_TAG_PROBE : UCX_MSG_TAG_EAGER;
+    sTag  = (size > ucxCtx.eagerSize) ? UCX_MSG_TAG_PROBE : UCX_MSG_TAG_DIRECT;
     sTag |= tag;
 
     UCX_LOG(3, "destNode=%i destPE=%i size=%i msg=%p, tag=%" PRIu64,
@@ -614,9 +610,6 @@ void LrtsAdvanceCommunication(int whileidle)
 #if CMK_SMP
        cnt += ProcessTxQueue();
 #endif
-       if (ucxCtx.numFreeRxReqs >= ucxCtx.rxReqsBatch) {
-           UcxPostRxBuffers();
-       }
     } while (cnt);
 }
 
@@ -641,11 +634,9 @@ void LrtsExit(int exitcode)
 
     for (i = 0; i < ucxCtx.numRxReqs; ++i) {
         req = ucxCtx.rxReqs[i];
-        if (!req->completed) {
-            CmiFree(req->msgBuf);
-            ucp_request_cancel(ucxCtx.worker, req);
-        }
-        UCX_REQUEST_FREE(req);
+        CmiFree(req->msgBuf);
+        ucp_request_cancel(ucxCtx.worker, req);
+        ucp_request_free(req);
     }
 
     ucp_worker_destroy(ucxCtx.worker);


### PR DESCRIPTION
Reverting should fix:
https://github.com/UIUC-PPL/charm/issues/2597
https://github.com/UIUC-PPL/charm/issues/2616


Reverting this will cause one of the ChaNGa test cases to fail (reported by @trquinn), so we'd still have to find a fix for that crash generated by the recursion shown. However, the generic case of running charm programs will still work, which is more important.  
```
Core was generated by `./ChaNGa.ucx +ppn 55 +setcpuaffinity +commap 0 +pemap 1-55 h148.cosmo50PLK.6144'.
Program terminated with signal 11, Segmentation fault.
#0  0x00002af5abfe0ab9 in sysmalloc () from /lib64/libc.so.6
warning: File "/opt/apps/gcc/8.3.0/lib64/libstdc++.so.6.0.25-gdb.py" auto-loading has been declined by your `auto-load safe-path' set to "$debugdir:$datadir/auto-load:/usr/bin/mono-gdb.py".
To enable execution of this file add
       add-auto-load-safe-path /opt/apps/gcc/8.3.0/lib64/libstdc++.so.6.0.25-gdb.py
line to your configuration file "/home1/00333/tg456090/.gdbinit".
To completely disable this security protection add
       set auto-load safe-path /
line to your configuration file "/home1/00333/tg456090/.gdbinit".
For more information about this security protection see the
"Auto-loading safe path" section in the GDB manual.  E.g., run from the shell:
       info "(gdb)Auto-loading safe path"
Missing separate debuginfos, use: debuginfo-install glibc-2.17-260.el7_6.6.x86_64 keyutils-libs-1.5.8-3.el7.x86_64 libibcm-41mlnx1-OFED.4.1.0.1.0.46101.x86_64 libibverbs-41mlnx1-OFED.4.6.0.4.1.46101.x86_64 libjpeg-turbo-1.2.90-6.el7.x86_64 libmlx5-41mlnx1-OFED.4.6.0.0.4.46101.x86_64 libnl3-3.2.28-4.el7.x86_64 librdmacm-41mlnx1-OFED.4.6.0.0.1.46101.x86_64 lustre-client-2.10.7_ddn8-1.el7.x86_64 ncurses-libs-5.9-14.20130511.el7_4.x86_64 numactl-libs-2.0.9-7.el7.x86_64 readline-6.2-10.el7.x86_64 zlib-1.2.7-18.el7.x86_64
(gdb) where
#0  0x00002af5abfe0ab9 in sysmalloc () from /lib64/libc.so.6
#1  0x00002af5abfe1c3a in _int_malloc () from /lib64/libc.so.6
#2  0x00002af5abfe432c in malloc () from /lib64/libc.so.6
#3  0x00000000008107c4 in CmiAlloc ()
#4  0x000000000080a718 in UcxPostRxReq(unsigned long, unsigned long, ucp_recv_desc*) ()
#5  0x000000000080a7c9 in UcxPostRxReq(unsigned long, unsigned long, ucp_recv_desc*) ()
#6  0x000000000080a7c9 in UcxPostRxReq(unsigned long, unsigned long, ucp_recv_desc*) ()
#7  0x000000000080a7c9 in UcxPostRxReq(unsigned long, unsigned long, ucp_recv_desc*) ()
#8  0x000000000080a7c9 in UcxPostRxReq(unsigned long, unsigned long, ucp_recv_desc*) ()
#9  0x000000000080a7c9 in UcxPostRxReq(unsigned long, unsigned long, ucp_recv_desc*) ()
#10 0x000000000080a7c9 in UcxPostRxReq(unsigned long, unsigned long, ucp_recv_desc*) ()
#11 0x000000000080a7c9 in UcxPostRxReq(unsigned long, unsigned long, ucp_recv_desc*) ()
#12 0x000000000080a7c9 in UcxPostRxReq(unsigned long, unsigned long, ucp_recv_desc*) ()
#13 0x000000000080a7c9 in UcxPostRxReq(unsigned long, unsigned long, ucp_recv_desc*) ()
#14 0x000000000080a7c9 in UcxPostRxReq(unsigned long, unsigned long, ucp_recv_desc*) ()
#15 0x000000000080a7c9 in UcxPostRxReq(unsigned long, unsigned long, ucp_recv_desc*) ()

```