### PR TITLE
UCX: Replace recursion with iteration in UcxPostRxReq

### DIFF
--- a/src/arch/ucx/machine.C
+++ b/src/arch/ucx/machine.C
@@ -337,17 +337,16 @@ static inline UcxRequest* UcxPostRxReq(ucp_tag_t tag, size_t size,
                                        ucp_tag_message_h msg)
 {
     UcxRequest *req = UcxPostRxReqInternal(tag, size, msg);
+    int idx = req->idx;
 
     do {
         if (req->completed) {
-            int idx = req->idx;
-
             UCX_REQUEST_FREE(req);
 
             if (tag & UCX_MSG_TAG_EAGER) {
                 req = UcxPostRxReqInternal(UCX_MSG_TAG_EAGER, ucxCtx.eagerSize, NULL);
-                req->idx = idx;
                 ucxCtx.rxReqs[idx] = req;
+                std::swap(req->idx, idx);
             } else {
                 return NULL;
             }

--- a/src/arch/ucx/machine.C
+++ b/src/arch/ucx/machine.C
@@ -345,8 +345,8 @@ static inline UcxRequest* UcxPostRxReq(ucp_tag_t tag, size_t size,
 
             if (tag & UCX_MSG_TAG_EAGER) {
                 req = UcxPostRxReqInternal(UCX_MSG_TAG_EAGER, ucxCtx.eagerSize, NULL);
+                req->idx = idx;
                 ucxCtx.rxReqs[idx] = req;
-                std::swap(req->idx, idx);
             } else {
                 return NULL;
             }


### PR DESCRIPTION
@brminich, do you see anything wrong with this patch? I believe each request will end up with the same idx as it would have without the patch, but the order in which `handleOneRecvedMsg` is called and `ucxCtx.rxReqs[idx]` is assigned is now FIFO instead of LIFO. Hopefully that won't break anything.