### PR TITLE
charmrun: const_cast CreateProcess argument

### DIFF
--- a/src/util/charmrun-src/charmrun.C
+++ b/src/util/charmrun-src/charmrun.C
@@ -4509,7 +4509,7 @@ struct local_nodestart
 
     int ret;
     ret = CreateProcess(NULL,          /* application name */
-                        cmdLine.c_str(), /* command line */
+                        const_cast<char*>(cmdLine.c_str()), /* command line */
                         NULL, /*&sa,*/ /* process SA */
                         NULL, /*&sa,*/ /* thread SA */
                         FALSE,         /* inherit flag */


### PR DESCRIPTION
Prevents error 
`
charmrun.C(4528): error C2664: 'BOOL CreateProcessA(LPCSTR,LPSTR,LPSECURITY_ATTRIBUTES,LPSECURITY_ATTRIBUTES,BOOL,DWORD,LPVOID,LPCSTR,LPSTARTUPINFOA,LPPROCESS_INFORMATION)': cannot convert argument 2 from 'const char *' to 'LPSTR'
`