### PR TITLE
Distributed will not try to migrate tasks to itself

### DIFF
--- a/src/ck-ldb/DistributedLB.C
+++ b/src/ck-ldb/DistributedLB.C
@@ -459,7 +459,7 @@ void DistributedLB::MapObjsToPe(minHeap *objs, CkVec<int> &obj_no,
       if (rand_pe == -1) break;
       p_id = pe_no[rand_pe];
       p_load = loads[rand_pe];
-      if (p_load + obj->load < transfer_threshold) {
+      if ((p_load + obj->load < transfer_threshold) && (CkMyPe() != p_id)) {
         success = true;
       }
       kMaxTrials--;


### PR DESCRIPTION
Related to issue #2629 , stop DistributedLB agents from migrating tasks to itself, in order to avoid execution stall in some applications.