### PR TITLE
Cleanup: Make mpi-darwin-x86_64/conv-mach.sh use common/conv-mach-darwin.sh

### DIFF
--- a/src/arch/common/cc-gcc.sh
+++ b/src/arch/common/cc-gcc.sh
@@ -14,30 +14,34 @@ CMK_LIBS="$CMK_LIBS -lckqt"
 CMK_PIC='-fPIC'
 
 if [ "$CMK_MACOSX" ]; then
-  # find real gcc (not Apple's clang) in $PATH on darwin, works with homebrew/macports
-  candidates=$(which gcc gcc-{4..19} gcc-mp-{4..19} 2>/dev/null)
-  for cand in $candidates; do
-    $cand -v 2>&1 | grep -q clang
-    if [ $? -eq 1 ]; then
-      cppcand=$(echo $cand | sed s,cc,++,)
-      CMK_CPP_C="$cand"
-      CMK_CC="$cand "
-      CMK_LD="$cand "
-      CMK_CXX="$cppcand "
-      CMK_LDXX="$cppcand "
+  if [ -z "$CMK_COMPILER_SUFFIX" ]; then
+    # find real gcc (not Apple's clang) in $PATH on darwin, works with homebrew/macports
+    candidates=$(which gcc gcc-{4..19} gcc-mp-{4..19} 2>/dev/null)
+    for cand in $candidates; do
+      $cand -v 2>&1 | grep -q clang
+      if [ $? -eq 1 ]; then
+        cppcand=$(echo $cand | sed s,cc,++,)
+        CMK_CPP_C="$cand"
+        CMK_CC="$cand "
+        CMK_LD="$cand "
+        CMK_CXX="$cppcand "
+        CMK_LDXX="$cppcand "
 
-      CMK_CC_FLAGS="-fPIC"
-      CMK_CXX_FLAGS="-fPIC -Wno-deprecated"
-      CMK_LD_FLAGS="-fPIC"
-      CMK_LDXX_FLAGS="-fPIC -multiply_defined suppress"
-      found=1
-      break
+        found=1
+        break
+      fi
+    done
+    if [ -z "$found" ]; then
+      echo "No suitable non-clang gcc found, exiting"
+      exit 1
     fi
-  done
-  if [ -z "$found" ]; then
-    echo "No suitable non-clang gcc found, exiting"
-    exit 1
   fi
+
+  # keep in sync with mpi-darwin-x86_64/conv-mach.sh
+  CMK_CC_FLAGS="-fPIC"
+  CMK_CXX_FLAGS="-fPIC -Wno-deprecated"
+  CMK_LD_FLAGS="-fPIC"
+  CMK_LDXX_FLAGS="-fPIC -multiply_defined suppress"
 fi
 
 if [ "$CMK_COMPILER" = "msvc" ]; then

--- a/src/arch/common/conv-mach-darwin.sh
+++ b/src/arch/common/conv-mach-darwin.sh
@@ -24,3 +24,13 @@ fi
 # Assumes gfortran compiler:
 CMK_CF77="$CMK_CF77 -mmacosx-version-min=10.7"
 CMK_CF90="$CMK_CF90 -mmacosx-version-min=10.7"
+
+CMK_NATIVE_CC='clang'
+CMK_NATIVE_LD='clang'
+CMK_NATIVE_CXX='clang++'
+CMK_NATIVE_LDXX='clang++'
+
+CMK_NATIVE_CC_FLAGS="$CMK_CC_FLAGS"
+CMK_NATIVE_LD_FLAGS="$CMK_LD_FLAGS"
+CMK_NATIVE_CXX_FLAGS="$CMK_CXX_FLAGS"
+CMK_NATIVE_LDXX_FLAGS="$CMK_LDXX_FLAGS"

--- a/src/arch/mpi-darwin-x86_64/conv-mach.sh
+++ b/src/arch/mpi-darwin-x86_64/conv-mach.sh
@@ -1,58 +1,20 @@
 . $CHARMINC/cc-mpiopts.sh
+. $CHARMINC/conv-mach-darwin.sh
 
-CMK_MACOSX=1
+CMK_CC="$MPICC"
+CMK_CXX="$MPICXX"
 
-CMK_DEFS="$CMK_DEFS -mmacosx-version-min=10.7 -D_DARWIN_C_SOURCE"
-
-CMK_AMD64="-dynamic -fPIC -fno-common -Wno-deprecated-declarations"
-
-CMK_CC="$MPICC "
-CMK_CXX="$MPICXX "
-
-CMK_CPP_C_FLAGS="$CMK_CPP_C_FLAGS"
-CMK_CC_FLAGS="$CMK_CC_FLAGS $CMK_AMD64"
-
-CMK_CLANG_CXX_FLAGS="-stdlib=libc++"
 CMK_REAL_COMPILER=`$MPICXX -show 2>/dev/null | cut -d' ' -f1 `
 case "${CMK_REAL_COMPILER##*/}" in
   gcc|g++|gcc-*|g++-*)
-    CMK_CXX_FLAGS="$CMK_CXX_FLAGS $CMK_AMD64"
+    # keep in sync with common/cc-gcc.sh
+    CMK_CC_FLAGS="-fPIC"
+    CMK_CXX_FLAGS="-fPIC -Wno-deprecated"
+    CMK_LD_FLAGS="-fPIC"
+    CMK_LDXX_FLAGS="-fPIC -multiply_defined suppress"
     CMK_COMPILER='gcc'
     ;;
   clang|clang++|clang-*|clang++-*)
-    CMK_CXX_FLAGS="$CMK_CXX_FLAGS $CMK_AMD64 $CMK_CLANG_CXX_FLAGS"
     CMK_COMPILER='clang'
     ;;
 esac
-
-CMK_XIOPTS=""
-
-CMK_NATIVE_CC='clang'
-CMK_NATIVE_LD='clang'
-CMK_NATIVE_CXX='clang++'
-CMK_NATIVE_LDXX='clang++'
-CMK_NATIVE_LIBS=""
-
-CMK_NATIVE_CC_FLAGS="$CMK_GCC64"
-CMK_NATIVE_LD_FLAGS="$CMK_GCC64"
-CMK_NATIVE_CXX_FLAGS="$CMK_GCC64 -stdlib=libc++"
-CMK_NATIVE_LDXX_FLAGS="$CMK_GCC64 -stdlib=libc++"
-
-CMK_CF90=`which f95 2>/dev/null`
-if test -n "$CMK_CF90"
-then
-    . $CHARMINC/conv-mach-gfortran.sh
-else
-    CMK_CF77="g77 "
-    CMK_CF90="f90 "
-    CMK_CF90_FIXED="$CMK_CF90 -W132 "
-    CMK_F90LIBS="-lf90math -lfio -lU77 -lf77math "
-    CMK_F77LIBS="-lg2c "
-    CMK_F90_USE_MODDIR=1
-    CMK_F90_MODINC="-p"
-fi
-
-# setting for shared lib
-CMK_SHARED_SUF="dylib"
-CMK_LD_SHARED=" -dynamic -dynamiclib -undefined dynamic_lookup "
-CMK_LD_SHARED_ABSOLUTE_PATH=true


### PR DESCRIPTION
This fixes building mpi-darwin-x86_64, which fails due to not seeing -stdlib=libc++.