### PR TITLE
Prevent self migrations in LB strategies

### DIFF
--- a/src/ck-ldb/CentralLB.C
+++ b/src/ck-ldb/CentralLB.C
@@ -1064,6 +1064,10 @@ void CentralLB::ProcessMigrationDecision() {
     MigrateDecision& move = m->moves[i];
     const int me = CkMyPe();
     if (move.fromPe == me) {
+      if (move.toPe == me) {
+        CkAbort("[%d] Error, attempting to migrate from myself to myself\n",
+            CkMyPe());
+      }
       DEBUGF(("[%d] migrating object to %d\n", move.fromPe, move.toPe));
       // migrate object, in case it is already gone, inform toPe
       LDObjHandle objInfo = theLbdb->GetObjHandle(move.dbIndex);

--- a/src/ck-ldb/DistBaseLB.C
+++ b/src/ck-ldb/DistBaseLB.C
@@ -178,7 +178,11 @@ void DistBaseLB::ProcessMigrationDecision(LBMigrateMsg *migrateMsg) {
   // Migrate messages from me to elsewhere
   for(int i=0; i < migrateMsg->n_moves; i++) {
     MigrateInfo& move = migrateMsg->moves[i];
-    if (move.from_pe == me && move.to_pe != me) {
+    if (move.from_pe == me) {
+      if (move.to_pe == me) {
+        CkAbort("[%i] Error, attempting to migrate object myself to myself\n",
+            CkMyPe());
+      }
       theLbdb->Migrate(move.obj,move.to_pe);
     } else if (move.from_pe != me) {
       CkPrintf("[%d] Error, strategy wants to move from %d to  %d\n",


### PR DESCRIPTION
Another fix related to PR #2630. If there are bugs in strategies which create migration requests those are not currently caught. This was the case in Distributed LB, an external collaborator caught the weird behavior.

Change-Id: I75cd3c67bbe3f9d7e705d1f4ca96f9c8451f4b93