### PR TITLE
ckCheckpoint: create subdirectories for nodegroup files, if needed.

### DIFF
--- a/src/ck-core/ckcheckpoint.C
+++ b/src/ck-core/ckcheckpoint.C
@@ -230,25 +230,27 @@ void CkCheckpointMgr::Checkpoint(const char *dirname, CkCallback cb, bool _reque
 	}
 
 	// Due to file system issues we have observed, divide checkpoints
-	// into subdirectories to avoid having too many files in a single directory
-	// Nodegroups are NOT fine since they could go into a
-	// different subdirectory
-        ostringstream dirPathNode;
+	// into subdirectories to avoid having too many files in a single directory.
+	// Nodegroups should be checked separately since they could go into
+	// different subdirectory.
+
+	// Save current path for later use with nodegroups
+	ostringstream dirPathNode;
 	dirPathNode << dirPath.rdbuf();
-        
+
+	// Create subdirectories
 	int mySubDir = CkMyPe() / SUBDIR_SIZE;
 	dirPath << "/sub" << mySubDir;
 	CmiMkdir(dirPath.str().c_str());
 
+	// Create Nodegroup subdirectory if needed
 	if (CkMyRank() == 0) {
-            // Create Nodegroup subdirectory, if needed.
-            int mySubDirNode = CkMyNode() / SUBDIR_SIZE;
-            if(mySubDirNode != mySubDir) {
-                dirPathNode << "/sub" << mySubDirNode;
-                CmiMkdir(dirPathNode.str().c_str());
-            }
-        }
-        
+		int mySubDirNode = CkMyNode() / SUBDIR_SIZE;
+		if (mySubDirNode != mySubDir) {
+			dirPathNode << "/sub" << mySubDirNode;
+			CmiMkdir(dirPathNode.str().c_str());
+		}
+	}
 
 	bool success = true;
 	if (CkMyPe() == 0) {


### PR DESCRIPTION
Here is my proposed fix to issue #2627.  The nodegroup file goes into a different directory than the group or array files, so make sure that directory is created if needed.