### PR TITLE
AMPI #2655: hide MPI_COMM constant from public Fortran header

### DIFF
--- a/src/libs/ck-libs/ampi/ampif.h
+++ b/src/libs/ck-libs/ampi/ampif.h
@@ -177,7 +177,6 @@
 
        integer, parameter :: MPI_TAG         = 1
        integer, parameter :: MPI_SOURCE      = 2
-       integer, parameter :: MPI_COMM        = 3
        integer, parameter :: MPI_ERROR       = 5
 
        integer, dimension(MPI_STATUS_SIZE) :: MPI_STATUS_IGNORE


### PR DESCRIPTION
The MPI standard specifies the constants MPI_TAG, MPI_SOURCE, and MPI_ERROR
as indices into an MPI_Status object. It allows the definition of more fields inside
the status object, but those fields (such as MPI_COMM for us) should be private
to avoid namespace collisions.