### PR TITLE
Support logical PU indices in +pemap and +commap

### DIFF
--- a/doc/charm++/manual.rst
+++ b/doc/charm++/manual.rst
@@ -11541,8 +11541,10 @@ are available:
    ``0-15:4.3``. ``++ppn 10 +pemap 0-11:6.5+12`` equals
    ``++ppn 10 +pemap 0,12,1,13,2,14,3,15,4,16,6,18,7,19,8,20,9,21,10,22``
 
-   By default, this option accepts PU indices assigned by the OS. To
-   provide logical PU indices, prepend the sequence with an alphabet L
+   By default, this option accepts PU indices assigned by the OS. The
+   user might want to instead provide logical PU indices used by hwloc
+   (see `link <https://www.open-mpi.org/projects/hwloc/doc/v2.1.0/a00342.php#faq_indexes>`
+   for details). To do this, prepend the sequence with an alphabet L
    (case-insensitive). For instance, ``+pemap L0-3`` will instruct the
    runtime to bind threads to PUs with logical indices 0-3.
 

--- a/doc/charm++/manual.rst
+++ b/doc/charm++/manual.rst
@@ -11541,6 +11541,11 @@ are available:
    ``0-15:4.3``. ``++ppn 10 +pemap 0-11:6.5+12`` equals
    ``++ppn 10 +pemap 0,12,1,13,2,14,3,15,4,16,6,18,7,19,8,20,9,21,10,22``
 
+   By default, this option accepts PU indices assigned by the OS. To
+   provide logical PU indices, prepend the sequence with an alphabet L
+   (case-insensitive). For instance, ``+pemap L0-3`` will instruct the
+   runtime to bind threads to PUs with logical indices 0-3.
+
 ``+commap p[,q,...]``
    Bind communication threads to the listed cores, one per process.
 

--- a/src/conv-core/cpuaffinity.C
+++ b/src/conv-core/cpuaffinity.C
@@ -784,7 +784,7 @@ static int set_default_affinity(void)
 // Logical indices are used if the first character of the map string is an L
 // (case-insensitive).
 static int check_logical_indices(char **mapptr) {
-  if ((*mapptr)[0] == 'l' || (*mapptr)[1] == 'L') {
+  if ((*mapptr)[0] == 'l' || (*mapptr)[0] == 'L') {
     (*mapptr)++; // Exclude the L character from the string
     return 1;
   }

--- a/src/conv-core/cpuaffinity.C
+++ b/src/conv-core/cpuaffinity.C
@@ -231,7 +231,7 @@ int CmiSetCPUAffinity(int mycore)
   return result;
 }
 
-// Uses logical PU indices
+// Uses logical PU indices as determined by hwloc
 int CmiSetCPUAffinityLogical(int mycore)
 {
   int core = mycore;

--- a/src/conv-core/cpuaffinity.C
+++ b/src/conv-core/cpuaffinity.C
@@ -780,6 +780,18 @@ static int set_default_affinity(void)
   return n != -1;
 }
 
+// Check if provided mapping string uses logical indices as assigned by hwloc.
+// Logical indices are used if the first character of the map string is an L
+// (case-insensitive).
+static int check_logical_indices(char **mapptr) {
+  if ((*mapptr)[0] == 'l' || (*mapptr)[1] == 'L') {
+    (*mapptr)++; // Exclude the L character from the string
+    return 1;
+  }
+
+  return 0;
+}
+
 void CmiInitCPUAffinity(char **argv)
 {
   static skt_ip_t myip;
@@ -793,7 +805,8 @@ void CmiInitCPUAffinity(char **argv)
 
   int affinity_flag = CmiGetArgFlagDesc(argv,"+setcpuaffinity",
                                                "set cpu affinity");
-  int logical_indices_flag = 0;
+  int pemap_logical_flag = 0;
+  int commap_logical_flag = 0;
 
   while (CmiGetArgIntDesc(argv,"+excludecore", &exclude, "avoid core when setting cpuaffinity"))  {
     if (CmiMyRank() == 0) add_exclude(exclude);
@@ -824,13 +837,14 @@ void CmiInitCPUAffinity(char **argv)
 
   if (pemap!=NULL || commap!=NULL) affinity_flag = 1;
 
-  // Check if provided pemap uses OS indices or logical indices.
-  // Logical indices are used if the first character of the pemap string
-  // is an L (case-insensitive).
-  if (pemap != NULL) {
-    if (pemap[0] == 'l' || pemap[0] == 'L') {
-      logical_indices_flag = 1;
-      pemap++; // Exclude the L character from pemap
+  // Check if provided pemap and/or commap use OS indices or logical indices
+  if (pemap != NULL) pemap_logical_flag = check_logical_indices(&pemap);
+  if (commap != NULL) commap_logical_flag = check_logical_indices(&commap);
+
+  // Issue warning if pemap and commap do not use the same type of indices
+  if (pemap != NULL && commap != NULL && pemap_logical_flag != commap_logical_flag) {
+    if (CmiMyPe() == 0) {
+      CmiPrintf("WARNING: Different types of indices are used for +pemap and +commap.\n");
     }
   }
 
@@ -899,7 +913,7 @@ void CmiInitCPUAffinity(char **argv)
      }
      if (pemap!=NULL)
        CmiPrintf("Charm++> cpuaffinity PE-core map (%s): %s\n",
-           logical_indices_flag ? "logical indices" : "OS indices", pemap);
+           pemap_logical_flag ? "logical indices" : "OS indices", pemap);
   }
 
   if (CmiMyPe() >= CmiNumPes()) {         /* this is comm thread */
@@ -908,14 +922,17 @@ void CmiInitCPUAffinity(char **argv)
     CmiNodeAllBarrier();
     if (commap != NULL) {
       int mycore = search_pemap(commap, CmiMyPeGlobal()-CmiNumPesGlobal());
-      if (CmiPhysicalNodeID(CmiMyPe()) == 0) CmiPrintf("Charm++> set comm %d on node %d to core #%d\n", CmiMyPe()-CmiNumPes(), CmiMyNode(), mycore);
-      if (logical_indices_flag) {
+      if (commap_logical_flag) {
         if (-1 == CmiSetCPUAffinityLogical(mycore))
           CmiAbort("CmiSetCPUAffinityLogical failed!");
       }
       else {
         if (-1 == CmiSetCPUAffinity(mycore))
           CmiAbort("CmiSetCPUAffinity failed!");
+      }
+      if (CmiPhysicalNodeID(CmiMyPe()) == 0) {
+        CmiPrintf("Charm++> set comm %d on node %d to PU %c#%d\n",
+            CmiMyPe()-CmiNumPes(), CmiMyNode(), commap_logical_flag ? 'L' : 'P', mycore);
       }
       CmiNodeAllBarrier();
       if (show_affinity_flag) CmiPrintCPUAffinity();
@@ -948,7 +965,7 @@ void CmiInitCPUAffinity(char **argv)
 
   if (pemap != NULL && CmiMyPe()<CmiNumPes()) {    /* work thread */
     int mycore = search_pemap(pemap, CmiMyPeGlobal());
-    if (logical_indices_flag) {
+    if (pemap_logical_flag) {
       if (CmiSetCPUAffinityLogical(mycore) == -1) CmiAbort("CmiSetCPUAffinityLogical failed");
     }
     else {
@@ -956,7 +973,7 @@ void CmiInitCPUAffinity(char **argv)
     }
     if (show_affinity_flag) {
       CmiPrintf("Charm++> set PE %d on node %d to PU %c#%d\n", CmiMyPe(), CmiMyNode(),
-          logical_indices_flag ? 'L' : 'P', mycore);
+          pemap_logical_flag ? 'L' : 'P', mycore);
     }
     CmiNodeAllBarrier();
     CmiNodeAllBarrier();


### PR DESCRIPTION
Closes #2657.

The user can pass options like `+pemap L0-7` to use logical PU indices instead of indices assigned by the OS.
Also updates program output and error messages to make it clear which version (OS indices vs. logical indices) is being used.
Tested on LLNL Lassen.