### PR TITLE
circleci: add windows support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,8 @@
 version: 2.1
+
+orbs:
+  win: circleci/windows@2.2.0
+
 jobs:
   NetLRTS:
     machine:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,7 +38,7 @@ jobs:
       - checkout
       - run:
           name: automake
-          command: perl --version && m4 --version
+          command: wget https://ftp.gnu.org/gnu/m4/m4-1.4.18.tar.gz && tar xf m4-1.4.18.tar.gz && cd m4-1.4.18/ && ./configure && make install
           shell: bash.exe
     
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,7 +39,7 @@ jobs:
       - run: choco upgrade --no-progress -y msys2
       - run:
           name: automake
-          command: pacman --sync --noconfirm --needed autoconf libtool automake make autoconf-archive pkg-config
+          command: autoconf --version
           shell: bash.exe
     
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,7 +38,7 @@ jobs:
       - checkout
       - run:
           name: automake
-          command: autoconf --version
+          command: perl --version && m4 --version
           shell: bash.exe
     
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,9 +26,17 @@ jobs:
           name: Test
           command: make -C netlrts-linux-x86_64-smp/tmp -j3 all-test-tests all-test-examples OPTS="-g" && make -C netlrts-linux-x86_64-smp/tmp test-tests test-examples TESTOPTS="++local +setcpuaffinity +isomalloc_sync +CmiSleepOnIdle"
  
+ 
+  winbuild:
+    executor:
+      name: win/default
+    steps:
+      - checkout
+      - run: choco upgrade --no-progress -y msys2
+      - run: pacman --sync --noconfirm --needed autoconf libtool automake make autoconf-archive pkg-config
+    
 workflows:
   version: 2
   build:
     jobs:
-      - NetLRTS
-      - NetLRTS-smp
+      - winbuild

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,9 +37,10 @@ jobs:
     steps:
       - checkout
       - run: choco upgrade --no-progress -y msys2
-      - run: 
-        command: pacman --sync --noconfirm --needed autoconf libtool automake make autoconf-archive pkg-config
-        shell: bash.exe
+      - run:
+          name: automake
+          command: pacman --sync --noconfirm --needed autoconf libtool automake make autoconf-archive pkg-config
+          shell: bash.exe
     
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,7 +37,9 @@ jobs:
     steps:
       - checkout
       - run: choco upgrade --no-progress -y msys2
-      - run: pacman --sync --noconfirm --needed autoconf libtool automake make autoconf-archive pkg-config
+      - run: 
+        command: pacman --sync --noconfirm --needed autoconf libtool automake make autoconf-archive pkg-config
+        shell: bash.exe
     
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,7 +38,7 @@ jobs:
       - checkout
       - run:
           name: automake
-          command: wget https://ftp.gnu.org/gnu/m4/m4-1.4.18.tar.gz && tar xf m4-1.4.18.tar.gz && cd m4-1.4.18/ && ./configure && make install
+          command: curl -O https://ftp.gnu.org/gnu/m4/m4-1.4.18.tar.gz && tar xf m4-1.4.18.tar.gz && tar xf m4-1.4.18.tar.gz && cd m4-1.4.18/ && ./configure && make install
           shell: bash.exe
     
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,7 +38,7 @@ jobs:
       - checkout
       - run:
           name: automake
-          command: curl -O https://ftp.gnu.org/gnu/m4/m4-1.4.18.tar.gz && tar xf m4-1.4.18.tar.gz && tar xf m4-1.4.18.tar.gz && cd m4-1.4.18/ && ./configure && make install
+          command: curl -O https://ftp.gnu.org/gnu/m4/m4-1.4.18.tar.gz && tar xf m4-1.4.18.tar.gz && cd m4-1.4.18/ && ./configure && make install
           shell: bash.exe
     
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,7 +36,6 @@ jobs:
       name: win/default
     steps:
       - checkout
-      - run: choco upgrade --no-progress -y msys2
       - run:
           name: automake
           command: autoconf --version


### PR DESCRIPTION
Has essentially the same issue as #2288: Autoconf/automake are not installed.