### PR TITLE
 Memory: Clean up locking around allocator implementations

### DIFF
--- a/src/conv-core/memory-charmdebug.C
+++ b/src/conv-core/memory-charmdebug.C
@@ -12,10 +12,6 @@
  * - sweep of the memory searching for leaks
  */
 
-#if ! CMK_MEMORY_BUILD_OS
-/* Use Gnumalloc as meta-meta malloc fallbacks (mm_*) */
-#include "memory-gnu.C"
-#endif
 #include "tracec.h"
 #include <sys/mman.h>
 
@@ -588,9 +584,7 @@ void deleteAllocationPoint(void *ptr) {
   AllocationPoint *node = (AllocationPoint*)ptr;
   AllocationPoint *child;
   for (child = node->firstChild; child != NULL; child = child->sibling) deleteAllocationPoint(child);
-  BEFORE_MALLOC_CALL;
-  mm_free(node);
-  AFTER_MALLOC_CALL;
+  mm_impl_free(node);
 }
 
 void printAllocationTree(AllocationPoint *node, FILE *fd, int depth) {
@@ -620,9 +614,7 @@ AllocationPoint * CreateAllocationTree(int *nodesCount) {
 
   table = CkCreateHashtable_pointer(sizeof(char *), 10000);
 
-  BEFORE_MALLOC_CALL;
-  root = (AllocationPoint*) mm_malloc(sizeof(AllocationPoint));
-  AFTER_MALLOC_CALL;
+  root = (AllocationPoint*) mm_impl_malloc(sizeof(AllocationPoint));
   *(AllocationPoint**)CkHashtablePut(table, &numNodes) = root;
   numNodes ++;
   root->key = 0;
@@ -640,9 +632,7 @@ AllocationPoint * CreateAllocationTree(int *nodesCount) {
       isnew = 0;
       start = (AllocationPoint**)CkHashtableGet(table, &scanner->from[i]);
       if (start == NULL) {
-        BEFORE_MALLOC_CALL;
-        cur = (AllocationPoint*) mm_malloc(sizeof(AllocationPoint));
-        AFTER_MALLOC_CALL;
+        cur = (AllocationPoint*) mm_impl_malloc(sizeof(AllocationPoint));
         numNodes ++;
         isnew = 1;
         cur->next = cur;
@@ -650,9 +640,7 @@ AllocationPoint * CreateAllocationTree(int *nodesCount) {
       } else {
         for (cur = (*start)->next; cur != *start && cur->parent != parent; cur = cur->next);
         if (cur->parent != parent) {
-          BEFORE_MALLOC_CALL;
-          cur = (AllocationPoint*) mm_malloc(sizeof(AllocationPoint));
-          AFTER_MALLOC_CALL;
+          cur = (AllocationPoint*) mm_impl_malloc(sizeof(AllocationPoint));
           numNodes ++;
           isnew = 1;
           cur->next = (*start)->next;
@@ -735,9 +723,7 @@ void MergeAllocationTreeSingle(AllocationPoint *node, AllocationPoint *remote, i
     }
     if (localChild == NULL) {
       /* This child did not exist locally, allocate it */
-      BEFORE_MALLOC_CALL;
-      localChild = (AllocationPoint*) mm_malloc(sizeof(AllocationPoint));
-      AFTER_MALLOC_CALL;
+      localChild = (AllocationPoint*) mm_impl_malloc(sizeof(AllocationPoint));
       localChild->key = child.key;
       localChild->flags = 0;
       localChild->count = 0;
@@ -811,9 +797,7 @@ void pupMemStat(pup_er p, void *st) {
 }
 
 void deleteMemStat(void *ptr) {
-  BEFORE_MALLOC_CALL;
-  mm_free(ptr);
-  AFTER_MALLOC_CALL;
+  mm_impl_free(ptr);
 }
 
 static int memStatReturnOnlyOne = 1;
@@ -841,9 +825,7 @@ void * mergeMemStat(int *size, void *data, void **remoteData, int numRemote) {
     MemStat r;
     int count = l->count;
     for (i=0; i<numRemote; ++i) count += ((MemStat*)remoteData[i])->count;
-    BEFORE_MALLOC_CALL;
-    res = (MemStat*)mm_malloc(sizeof(MemStat) + (count-1)*sizeof(MemStatSingle));
-    AFTER_MALLOC_CALL;
+    res = (MemStat*)mm_impl_malloc(sizeof(MemStat) + (count-1)*sizeof(MemStatSingle));
     memset(res, 0, sizeof(MemStat)+(count-1)*sizeof(MemStatSingle));
     res->count = count;
     memcpy(res->array, l->array, l->count*sizeof(MemStatSingle));
@@ -864,9 +846,7 @@ MemStat * CreateMemStat(void) {
   Slot *cur;
   MemStat *st;
   MemStatSingle *stat;
-  BEFORE_MALLOC_CALL;
-  st = (MemStat*)mm_calloc(1, sizeof(MemStat));
-  AFTER_MALLOC_CALL;
+  st = (MemStat*)mm_impl_calloc(1, sizeof(MemStat));
   st->count = 1;
   stat = &st->array[0];
   SLOT_ITERATE_START(cur)
@@ -974,9 +954,7 @@ static void backupMemory(void) {
     SLOT_ITERATE_END
   }
   if (reportMEM) CmiPrintf("CPD: total memory in use (%d): %d\n",CmiMyPe(),totalMemory);
-  BEFORE_MALLOC_CALL;
-  *memoryBackup = (char *)mm_malloc(totalMemory);
-  AFTER_MALLOC_CALL;
+  *memoryBackup = (char *)mm_impl_malloc(totalMemory);
 
   ptr = *memoryBackup;
 #ifndef CMK_SEPARATE_SLOT
@@ -1034,9 +1012,7 @@ static void checkBackup(void) {
   }
 #endif
 
-  BEFORE_MALLOC_CALL;
-  mm_free(*memoryBackup);
-  AFTER_MALLOC_CALL;
+  mm_impl_free(*memoryBackup);
   *memoryBackup = NULL;
 }
 
@@ -1067,11 +1043,9 @@ static void CpdMMAPhandler(int sig, siginfo_t *si, void *unused){
   if (unProtectedPagesSize >= unProtectedPagesMaxSize) {
     void **newUnProtectedPages;
     unProtectedPagesMaxSize += 10;
-    BEFORE_MALLOC_CALL;
-    newUnProtectedPages = (void**)mm_malloc((unProtectedPagesMaxSize)*sizeof(void*));
+    newUnProtectedPages = (void**)mm_impl_malloc((unProtectedPagesMaxSize)*sizeof(void*));
     memcpy(newUnProtectedPages, unProtectedPages, unProtectedPagesSize*sizeof(void*));
-    mm_free(unProtectedPages);
-    AFTER_MALLOC_CALL;
+    mm_impl_free(unProtectedPages);
     unProtectedPages = newUnProtectedPages;
   }
   unProtectedPages[unProtectedPagesSize++] = pageToUnprotect;
@@ -1205,11 +1179,14 @@ Slot *slot_first=&slot_first_storage;
 #define CMI_MEMORY_ROUTINES 1
 
 / * Mark all allocated memory as being OK * /
+static inline void CmiMemoryMarkImpl(void) {
+	/ * Just make a new linked list of slots * /
+	slot_first=(Slot *)mm_impl_malloc(sizeof(Slot));
+	slot_first->next=slot_first->prev=slot_first;
+}
 void CmiMemoryMark(void) {
 	CmiMemLock();
-	/ * Just make a new linked list of slots * /
-	slot_first=(Slot *)mm_malloc(sizeof(Slot));
-	slot_first->next=slot_first->prev=slot_first;
+	CmiMemoryMarkImpl();
 	CmiMemUnlock();
 }
 
@@ -1242,8 +1219,8 @@ void CmiMemorySweep(const char *where) {
 			CmiMyPe(),nBlocks,nBytes);
 		/ * CmiAbort("Memory leaks detected!\n"); * /
 	}
+	CmiMemoryMarkImpl();
 	CmiMemUnlock();
-	CmiMemoryMark();
 }
 void CmiMemoryCheck(void) {}
 */
@@ -1339,11 +1316,9 @@ static void *setSlot(Slot **sl,int userSize) {
     if (allocatedSinceSize >= allocatedSinceMaxSize) {
       Slot **newAllocatedSince;
       allocatedSinceMaxSize += 10;
-      BEFORE_MALLOC_CALL;
-      newAllocatedSince = (Slot**)mm_malloc((allocatedSinceMaxSize)*sizeof(Slot*));
+      newAllocatedSince = (Slot**)mm_impl_malloc((allocatedSinceMaxSize)*sizeof(Slot*));
       memcpy(newAllocatedSince, allocatedSince, allocatedSinceSize*sizeof(Slot*));
-      mm_free(allocatedSince);
-      AFTER_MALLOC_CALL;
+      mm_impl_free(allocatedSince);
       allocatedSince = newAllocatedSince;
     }
     allocatedSince[allocatedSinceSize++] = s;
@@ -1460,16 +1435,15 @@ static void meta_init(char **argv) {
 
 static void *meta_malloc(size_t size) {
   void *user = NULL;
+  CmiMemLock();
   if (memory_charmdebug_internal==0) {
     Slot *s;
     dumpStackFrames();
-    BEFORE_MALLOC_CALL;
 #if CPD_USE_MMAP
     s=(Slot *)mmap(NULL, SLOTSPACE+size+numStackFrames*sizeof(void*), PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
 #else
-    s=(Slot *)mm_malloc(SLOTSPACE+size+numStackFrames*sizeof(void*));
+    s=(Slot *)mm_impl_malloc(SLOTSPACE+size+numStackFrames*sizeof(void*));
 #endif
-    AFTER_MALLOC_CALL;
     if (s!=NULL) {
       user = (char*)setSlot(&s,size);
       memory_allocated_user_total += size;
@@ -1483,10 +1457,9 @@ static void *meta_malloc(size_t size) {
       disableVerbosity = 0;
     }
   } else {
-    BEFORE_MALLOC_CALL;
-    user = mm_malloc(size);
-    AFTER_MALLOC_CALL;
+    user = mm_impl_malloc(size);
   }
+  CmiMemUnlock();
   if (cpdInitializeMemory) {
     memset(user, 0, size); // for Record-Replay must initialize all memory otherwise paddings may differ (screwing up the CRC)
   }
@@ -1494,19 +1467,20 @@ static void *meta_malloc(size_t size) {
 }
 
 static void meta_free(void *mem) {
+  if (mem==NULL) return; /*Legal, but misleading*/
+  CmiMemLock();
   if (memory_charmdebug_internal==0) {
     int memSize;
     Slot *s;
-    if (mem==NULL) return; /*Legal, but misleading*/
+
     s=UserToSlot(mem);
 #if CMK_MEMORY_BUILD_OS
     /* In this situation, we can have frees that were not allocated by our malloc...
      * for now simply skip over them. */
     if (s == NULL || ((s->magic&~FLAGS_MASK) != SLOTMAGIC_VALLOC &&
         (s->magic&~FLAGS_MASK) != SLOTMAGIC)) {
-      BEFORE_MALLOC_CALL;
-      mm_free(mem);
-      AFTER_MALLOC_CALL;
+      mm_impl_free(mem);
+      CmiMemUnlock();
       return;
     }
 #endif
@@ -1546,10 +1520,8 @@ static void meta_free(void *mem) {
     { /*Allocated with special alignment*/
       void *ptr = s->extraStack;
       freeSlot(s);
-      BEFORE_MALLOC_CALL;
-      mm_free(ptr);
-      /*mm_free(((char *)mem)-CmiGetPageSize());*/
-      AFTER_MALLOC_CALL;
+      mm_impl_free(ptr);
+      /*mm_impl_free(((char *)mem)-CmiGetPageSize());*/
     }
     else if ((s->magic&~FLAGS_MASK)==SLOTMAGIC)
     { /*Ordinary allocated block */
@@ -1561,23 +1533,20 @@ static void meta_free(void *mem) {
 #else
       ptr = s;
 #endif
-      BEFORE_MALLOC_CALL;
 #if CPD_USE_MMAP
       munmap(ptr, freeSize);
 #else
-      mm_free(ptr);
+      mm_impl_free(ptr);
 #endif
-      AFTER_MALLOC_CALL;
     }
     else if (s->magic==SLOTMAGIC_FREED)
       CmiAbort("Free'd block twice");
     else /*Unknown magic number*/
       CmiAbort("Free'd non-malloc'd block");
   } else {
-    BEFORE_MALLOC_CALL;
-    mm_free(mem);
-    AFTER_MALLOC_CALL;
+    mm_impl_free(mem);
   }
+  CmiMemUnlock();
 }
 
 static void *meta_calloc(size_t nelem, size_t size) {
@@ -1594,8 +1563,10 @@ static void *meta_realloc(void *oldBuffer, size_t newSize) {
   void *newBuffer = meta_malloc(newSize);
   if ( newBuffer && oldBuffer ) {
     /*Preserve old buffer contents*/
+    CmiMemLock();
     Slot *o=UserToSlot(oldBuffer);
     size_t size=o->userSize;
+    CmiMemUnlock();
     if (size>newSize) size=newSize;
     if (size > 0)
       memcpy(newBuffer, oldBuffer, size);
@@ -1612,12 +1583,12 @@ static void *meta_memalign(size_t align, size_t size) {
   void *user;
 
   while (overhead < SLOTSPACE+sizeof(SlotStack)) overhead += align;
+
+  CmiMemLock();
   /* Allocate the required size + the overhead needed to keep the user alignment */
   dumpStackFrames();
 
-  BEFORE_MALLOC_CALL;
-  alloc=(char *)mm_memalign(align,overhead+size+numStackFrames*sizeof(void*));
-  AFTER_MALLOC_CALL;
+  alloc=(char *)mm_impl_memalign(align,overhead+size+numStackFrames*sizeof(void*));
   s=(Slot*)(alloc+overhead-SLOTSPACE);
   user=setSlot(&s,size);
   s->magic = SLOTMAGIC_VALLOC + (s->magic&0xF);
@@ -1625,6 +1596,7 @@ static void *meta_memalign(size_t align, size_t size) {
   s->extraStack->protectedMemory = NULL;
   s->extraStack->protectedMemoryLength = 0;
   memory_allocated_user_total += size;
+  CmiMemUnlock();
 #if ! CMK_BIGSIM_CHARM
   traceMalloc_c(user, size, s->from, s->stackLen);
 #endif
@@ -1639,15 +1611,18 @@ static int meta_posix_memalign(void **outptr, size_t align, size_t size) {
   void *user;
 
   while (overhead < SLOTSPACE+sizeof(SlotStack)) overhead += align;
+
+  CmiMemLock();
   /* Allocate the required size + the overhead needed to keep the user alignment */
   dumpStackFrames();
 
-  BEFORE_MALLOC_CALL;
-  ret = mm_posix_memalign(outptr,align,overhead+size+numStackFrames*sizeof(void*));
+  ret = mm_impl_posix_memalign(outptr,align,overhead+size+numStackFrames*sizeof(void*));
   alloc=(char *)*outptr;
-  AFTER_MALLOC_CALL;
   if (ret != 0)
+  {
+    CmiMemUnlock();
     return ret;
+  }
   s=(Slot*)(alloc+overhead-SLOTSPACE);
   user=setSlot(&s,size);
   s->magic = SLOTMAGIC_VALLOC + (s->magic&0xF);
@@ -1655,6 +1630,7 @@ static int meta_posix_memalign(void **outptr, size_t align, size_t size) {
   s->extraStack->protectedMemory = NULL;
   s->extraStack->protectedMemoryLength = 0;
   memory_allocated_user_total += size;
+  CmiMemUnlock();
 #if ! CMK_BIGSIM_CHARM
   traceMalloc_c(user, size, s->from, s->stackLen);
 #endif
@@ -1669,12 +1645,12 @@ static void *meta_aligned_alloc(size_t align, size_t size) {
   void *user;
 
   while (overhead < SLOTSPACE+sizeof(SlotStack)) overhead += align;
+
+  CmiMemLock();
   /* Allocate the required size + the overhead needed to keep the user alignment */
   dumpStackFrames();
 
-  BEFORE_MALLOC_CALL;
-  alloc=(char *)mm_aligned_alloc(align,overhead+size+numStackFrames*sizeof(void*));
-  AFTER_MALLOC_CALL;
+  alloc=(char *)mm_impl_aligned_alloc(align,overhead+size+numStackFrames*sizeof(void*));
   s=(Slot*)(alloc+overhead-SLOTSPACE);
   user=setSlot(&s,size);
   s->magic = SLOTMAGIC_VALLOC + (s->magic&0xF);
@@ -1682,6 +1658,7 @@ static void *meta_aligned_alloc(size_t align, size_t size) {
   s->extraStack->protectedMemory = NULL;
   s->extraStack->protectedMemoryLength = 0;
   memory_allocated_user_total += size;
+  CmiMemUnlock();
 #if ! CMK_BIGSIM_CHARM
   traceMalloc_c(user, size, s->from, s->stackLen);
 #endif
@@ -1698,6 +1675,7 @@ static void *meta_pvalloc(size_t size) {
 }
 
 void setProtection(char* mem, char *ptr, int len, int flag) {
+  CmiMemLock();
   Slot *sl = UserToSlot(mem);
   if (sl->extraStack == NULL) CmiAbort("Tried to protect memory not memaligned\n");
   if (flag != 0) {
@@ -1707,70 +1685,84 @@ void setProtection(char* mem, char *ptr, int len, int flag) {
     sl->extraStack->protectedMemory = NULL;
     sl->extraStack->protectedMemoryLength = 0;
   }
+  CmiMemUnlock();
 }
 
 void **chareObjectMemory = NULL;
 int chareObjectMemorySize = 0;
 
 void setMemoryTypeChare(void *ptr) {
+  CmiMemLock();
   Slot *sl = UserToSlot(ptr);
   sl->magic = (sl->magic & ~FLAGS_MASK) | CHARE_TYPE;
   sl->chareID = nextChareID;
   if (nextChareID >= chareObjectMemorySize) {
     void **newChare;
-    BEFORE_MALLOC_CALL;
-    newChare = (void**)mm_malloc((nextChareID+100) * sizeof(void*));
-    AFTER_MALLOC_CALL;
+    newChare = (void**)mm_impl_malloc((nextChareID+100) * sizeof(void*));
     memcpy(newChare, chareObjectMemory, chareObjectMemorySize*sizeof(void*));
     chareObjectMemorySize = nextChareID+100;
-    BEFORE_MALLOC_CALL;
-    mm_free(chareObjectMemory);
-    AFTER_MALLOC_CALL;
+    mm_impl_free(chareObjectMemory);
     chareObjectMemory = newChare;
   }
   chareObjectMemory[nextChareID] = ptr;
   nextChareID ++;
+  CmiMemUnlock();
 }
 
 /* The input parameter is the pointer to the envelope, after the CmiChunkHeader */
 void setMemoryTypeMessage(void *ptr) {
+  CmiMemLock();
   void *realptr = (char*)ptr - sizeof(CmiChunkHeader);
   Slot *sl = UserToSlot(realptr);
   if ((sl->magic&~FLAGS_MASK) == SLOTMAGIC || (sl->magic&~FLAGS_MASK) == SLOTMAGIC_VALLOC) {
     sl->magic = (sl->magic & ~FLAGS_MASK) | MESSAGE_TYPE;
   }
+  CmiMemUnlock();
 }
 
 int setMemoryChareIDFromPtr(void *ptr) {
+  CmiMemLock();
   int tmp = memory_chare_id;
   if (ptr == NULL || ptr == 0) memory_chare_id = 0;
   else memory_chare_id = UserToSlot(ptr)->chareID;
+  CmiMemUnlock();
   return tmp;
 }
 
 void setMemoryChareID(int chareID) {
+  CmiMemLock();
   memory_chare_id = chareID;
+  CmiMemUnlock();
 }
 
 void setMemoryOwnedBy(void *ptr, int chareID) {
+  CmiMemLock();
   Slot *sl = UserToSlot(ptr);
   sl->chareID = chareID;
+  CmiMemUnlock();
 }
 
 void * MemoryToSlot(void *ptr) {
   Slot *sl;
   int i;
 #if defined(CPD_USE_MMAP) && defined(CMK_SEPARATE_SLOT)
+  CmiMemLock();
   for (i=0; i<1000; ++i) {
     sl = UserToSlot((void*)(intptr_t)(((CmiUInt8)(intptr_t)ptr)-i*CmiGetPageSize() & ~(CmiGetPageSize()-1)));
-    if (sl != NULL) return sl;
+    if (sl != NULL)
+    {
+      CmiMemUnlock();
+      return sl;
+    }
   }
+  CmiMemUnlock();
 #endif
   return NULL;
 }
 
 /*void PrintDebugStackTrace(void *ptr) {
   int i;
+  CmiMemLock();
   Slot *sl = UserToSlot((void*)(((CmiUInt8)ptr) & ~(CmiGetPageSize()-1)));
   if (sl != NULL) {
     CmiPrintf("%d %d ",sl->chareID,sl->stackLen);
@@ -1778,6 +1770,7 @@ void * MemoryToSlot(void *ptr) {
   } else {
     CmiPrintf("%d 0 ",sl->chareID);
   }
+  CmiMemUnlock();
 }*/
 
 

--- a/src/conv-core/memory-gnu.C
+++ b/src/conv-core/memory-gnu.C
@@ -1,7 +1,7 @@
 /*
 This version of ptmalloc3 is hacked in following ways:
    - Renamed to file memory-gnu.C
-   - Use mm_* routine names, as defined below.
+   - Use mm_impl_* routine names, as defined below.
    - Add UPDATE_MEMUSAGE
    - Add definitions for ONLY_MSPACES, MSPACES, USE_LOCKS
    - Rename malloc.c to memory-gnu-internal.C and include here
@@ -10,16 +10,16 @@ This version of ptmalloc3 is hacked in following ways:
 
 #define CMI_MEMORY_GNU
 
-#define malloc   mm_malloc
-#define free	 mm_free
-#define calloc   mm_calloc
-#define cfree	 mm_cfree
-#define realloc  mm_realloc
-#define memalign mm_memalign
-#define posix_memalign mm_posix_memalign
-#define aligned_alloc mm_aligned_alloc
-#define valloc   mm_valloc
-#define pvalloc  mm_pvalloc
+#define malloc   mm_impl_malloc
+#define free	 mm_impl_free
+#define calloc   mm_impl_calloc
+#define cfree	 mm_impl_cfree
+#define realloc  mm_impl_realloc
+#define memalign mm_impl_memalign
+#define posix_memalign mm_impl_posix_memalign
+#define aligned_alloc mm_impl_aligned_alloc
+#define valloc   mm_impl_valloc
+#define pvalloc  mm_impl_pvalloc
 
 extern CMK_TYPEDEF_UINT8 _memory_allocated;
 extern CMK_TYPEDEF_UINT8 _memory_allocated_max;

--- a/src/conv-core/memory-isomalloc.C
+++ b/src/conv-core/memory-isomalloc.C
@@ -8,11 +8,6 @@ NOTE: isomalloc is threadsafe, so the isomallocs are not wrapped in CmiMemLock.
 
 #define CMK_ISOMALLOC_EXCLUDE_FORTRAN_CALLS   0
 
-#if ! CMK_MEMORY_BUILD_OS
-/* Use Gnumalloc as meta-meta malloc fallbacks (mm_*) */
-#include "memory-gnu.C"
-#endif
-
 #include "memory-isomalloc.h"
 
 struct CmiMemoryIsomallocState {
@@ -224,18 +219,12 @@ static void *meta_pvalloc(size_t size)
 #define CMK_MEMORY_HAS_NOMIGRATE
 /*Allocate non-migratable memory:*/
 void *malloc_nomigrate(size_t size) { 
-  void *result;
-  CmiMemLock();
-  result = mm_malloc(size);
-  CmiMemUnlock();
-  return result;
+  return mm_malloc(size);
 }
 
 void free_nomigrate(void *mem)
 {
-  CmiMemLock();
   mm_free(mem);
-  CmiMemUnlock();
 }
 
 #define CMK_MEMORY_HAS_ISOMALLOC

--- a/src/conv-core/memory-lock.C
+++ b/src/conv-core/memory-lock.C
@@ -1,10 +1,4 @@
 
-/* Wrap a CmiMemLock around this code */
-#define MEM_LOCK_AROUND(code) \
-  CmiMemLock(); \
-  code; \
-  CmiMemUnlock();
-
 static void meta_init(char **argv)
 {
 /*   if (CmiMyRank()==0) CmiMemoryIs_flag|=CMI_MEMORY_IS_OSLOCK;   */
@@ -13,40 +7,40 @@ static void meta_init(char **argv)
 void *meta_malloc(size_t size)
 {
   void *result;
-  MEM_LOCK_AROUND( result = mm_malloc(size); )
+  MEM_LOCK_AROUND( result = mm_impl_malloc(size); )
   if (result==NULL) CmiOutOfMemory(size);
   return result;
 }
 
 void meta_free(void *mem)
 {
-  MEM_LOCK_AROUND( mm_free(mem); )
+  MEM_LOCK_AROUND( mm_impl_free(mem); )
 }
 
 void *meta_calloc(size_t nelem, size_t size)
 {
   void *result;
-  MEM_LOCK_AROUND( result = mm_calloc(nelem, size); )
+  MEM_LOCK_AROUND( result = mm_impl_calloc(nelem, size); )
   if (result==NULL) CmiOutOfMemory(size);
   return result;
 }
 
 void meta_cfree(void *mem)
 {
-  MEM_LOCK_AROUND( mm_cfree(mem); )
+  MEM_LOCK_AROUND( mm_impl_cfree(mem); )
 }
 
 void *meta_realloc(void *mem, size_t size)
 {
   void *result;
-  MEM_LOCK_AROUND( result = mm_realloc(mem, size); )
+  MEM_LOCK_AROUND( result = mm_impl_realloc(mem, size); )
   return result;
 }
 
 void *meta_memalign(size_t align, size_t size)
 {
   void *result;
-  MEM_LOCK_AROUND( result = mm_memalign(align, size); )
+  MEM_LOCK_AROUND( result = mm_impl_memalign(align, size); )
   if (result==NULL) CmiOutOfMemory(align*size);
   return result;    
 }
@@ -54,7 +48,7 @@ void *meta_memalign(size_t align, size_t size)
 int meta_posix_memalign(void **outptr, size_t align, size_t size)
 {
   int result;
-  MEM_LOCK_AROUND( result = mm_posix_memalign(outptr, align, size); )
+  MEM_LOCK_AROUND( result = mm_impl_posix_memalign(outptr, align, size); )
   if (result!=0) CmiOutOfMemory(align*size);
   return result;
 }
@@ -62,7 +56,7 @@ int meta_posix_memalign(void **outptr, size_t align, size_t size)
 void *meta_aligned_alloc(size_t align, size_t size)
 {
   void *result;
-  MEM_LOCK_AROUND( result = mm_aligned_alloc(align, size); )
+  MEM_LOCK_AROUND( result = mm_impl_aligned_alloc(align, size); )
   if (result==NULL) CmiOutOfMemory(align*size);
   return result;
 }
@@ -70,7 +64,7 @@ void *meta_aligned_alloc(size_t align, size_t size)
 void *meta_valloc(size_t size)
 {
   void *result;
-  MEM_LOCK_AROUND( result = mm_valloc(size); )
+  MEM_LOCK_AROUND( result = mm_impl_valloc(size); )
   if (result==NULL) CmiOutOfMemory(size);
   return result;
 }
@@ -78,7 +72,7 @@ void *meta_valloc(size_t size)
 void *meta_pvalloc(size_t size)
 {
   void *result;
-  MEM_LOCK_AROUND( result = mm_pvalloc(size); )
+  MEM_LOCK_AROUND( result = mm_impl_pvalloc(size); )
   if (result==NULL) CmiOutOfMemory(size);
   return result;
 }

--- a/src/conv-core/memory-os-wrapper.C
+++ b/src/conv-core/memory-os-wrapper.C
@@ -17,17 +17,17 @@
 
 struct mallinfo;
 
-extern void * (*mm_malloc)(size_t);
-extern void * (*mm_calloc)(size_t,size_t);
-extern void * (*mm_realloc)(void*,size_t);
-extern void * (*mm_memalign)(size_t,size_t);
-extern int (*mm_posix_memalign)(void **,size_t,size_t);
-extern void * (*mm_aligned_alloc)(size_t,size_t);
-extern void * (*mm_valloc)(size_t);
-extern void * (*mm_pvalloc)(size_t);
-extern void (*mm_free)(void*);
-extern void (*mm_cfree)(void*);
-extern struct mallinfo (*mm_mallinfo)(void);
+extern void * (*mm_impl_malloc)(size_t);
+extern void * (*mm_impl_calloc)(size_t,size_t);
+extern void * (*mm_impl_realloc)(void*,size_t);
+extern void * (*mm_impl_memalign)(size_t,size_t);
+extern int (*mm_impl_posix_memalign)(void **,size_t,size_t);
+extern void * (*mm_impl_aligned_alloc)(size_t,size_t);
+extern void * (*mm_impl_valloc)(size_t);
+extern void * (*mm_impl_pvalloc)(size_t);
+extern void (*mm_impl_free)(void*);
+extern void (*mm_impl_cfree)(void*);
+extern struct mallinfo (*mm_impl_mallinfo)(void);
 
   
 extern char initialize_memory_wrapper_status;
@@ -41,18 +41,18 @@ void initialize_memory_wrapper() {
   void * (*os_calloc)(size_t,size_t) = (void *(*)(size_t,size_t)) dlsym(RTLD_NEXT, "calloc");
   void (*os_free)(void*) = (void (*)(void*)) dlsym(RTLD_NEXT, "free");
 
-  mm_malloc = os_malloc;
-  mm_calloc = os_calloc;
-  mm_free = os_free;
+  mm_impl_malloc = os_malloc;
+  mm_impl_calloc = os_calloc;
+  mm_impl_free = os_free;
 
-  mm_realloc = (void *(*)(void*,size_t)) dlsym(RTLD_NEXT, "realloc");
-  mm_memalign = (void *(*)(size_t,size_t)) dlsym(RTLD_NEXT, "memalign");
-  mm_posix_memalign = (int (*)(void **,size_t,size_t)) dlsym(RTLD_NEXT, "posix_memalign");
-  mm_aligned_alloc = (void *(*)(size_t,size_t)) dlsym(RTLD_NEXT, "aligned_alloc");
-  mm_valloc = (void *(*)(size_t)) dlsym(RTLD_NEXT, "valloc");
-  mm_pvalloc = (void *(*)(size_t)) dlsym(RTLD_NEXT, "pvalloc");
-  mm_cfree = (void (*)(void*)) dlsym(RTLD_NEXT, "cfree");
-  mm_mallinfo = (struct mallinfo (*)(void)) dlsym(RTLD_NEXT, "mallinfo");
+  mm_impl_realloc = (void *(*)(void*,size_t)) dlsym(RTLD_NEXT, "realloc");
+  mm_impl_memalign = (void *(*)(size_t,size_t)) dlsym(RTLD_NEXT, "memalign");
+  mm_impl_posix_memalign = (int (*)(void **,size_t,size_t)) dlsym(RTLD_NEXT, "posix_memalign");
+  mm_impl_aligned_alloc = (void *(*)(size_t,size_t)) dlsym(RTLD_NEXT, "aligned_alloc");
+  mm_impl_valloc = (void *(*)(size_t)) dlsym(RTLD_NEXT, "valloc");
+  mm_impl_pvalloc = (void *(*)(size_t)) dlsym(RTLD_NEXT, "pvalloc");
+  mm_impl_cfree = (void (*)(void*)) dlsym(RTLD_NEXT, "cfree");
+  mm_impl_mallinfo = (struct mallinfo (*)(void)) dlsym(RTLD_NEXT, "mallinfo");
 }
 
 #endif

--- a/src/conv-core/memory-verbose.C
+++ b/src/conv-core/memory-verbose.C
@@ -6,16 +6,12 @@ Orion Sky Lawlor, olawlor@acm.org, 6/22/2001
 
 *****************************************************************************/
 
-#if ! CMK_MEMORY_BUILD_OS
-/* Use Gnumalloc as meta-meta malloc fallbacks (mm_*) */
-#include "memory-gnu.C"
-#endif
-
 static int memInit=0;
-static int inMemVerbose=0;
+CpvStaticDeclare(int, inMemVerbose);
 
 static void meta_init(char **argv)
 {
+  CpvInitialize(int, inMemVerbose);
   if (CmiMyRank()==0) memInit=1;
   CmiNodeAllBarrier();
   if (memInit) CmiPrintf("CMI_MEMORY(%d)> Called meta_init\n", CmiMyPe());
@@ -32,10 +28,10 @@ static void *meta_malloc(size_t size)
 
 static void meta_free(void *mem)
 {
-  if (memInit && !inMemVerbose) {
-    inMemVerbose = 1;
+  if (memInit && !CpvAccess(inMemVerbose)) {
+    CpvAccess(inMemVerbose) = 1;
     CmiPrintf("CMI_MEMORY(%d)> free(%p)\n", CmiMyPe(),mem);
-    inMemVerbose = 0;
+    CpvAccess(inMemVerbose) = 0;
   }
   if (memInit>1) {int memBack=memInit; memInit=0; CmiPrintStackTrace(0); memInit=memBack;}
   mm_free(mem);


### PR DESCRIPTION
- Use of the ptmalloc3 "gnu" allocator has been made more modular so that it is now easier to add new malloc backends besides it and the OS allocator, as well as to allow further work toward using it as a memory pool for Isomalloc, HAPI, or more, if desired.
- Underlying malloc implementations are now exposed in two ways: `mm_*` symbols lock if the implementation requires it (such as ptmalloc3), while `mm_impl_*` symbols do no locking (unless the implementation, such as the OS, does its own). This allows our memory layers to handle locking as efficiently as possible.
- `-memory leak`, `-memory paranoid`, and `-memory verbose` are now thread-safe in all circumstances, including the default `-memory os-*`, by handling locking as part of their implementations. `-memory charmdebug` is also closer to being thread-safe, but it would require more changes outside of this PR's scope.
- Previously, `-memory gnu-*` always locked around the calls into our Converse memory layers, which allowed thread-safe usage of most memory modes, but also added unnecessary locking to ones that do not need it. This has been eliminated.
- The hook approach to intercepting malloc has been modularized so it does not require manual placement of `BEFORE`/`AFTER_MALLOC_CALL` at call sites. With this in place, in theory it may not require much work to add `libmemory-hooks-` variants of modes besides `charmdebug` to `src/scripts/Makefile`, though this is likely of interest to no one, especially since the hook method is not thread-safe.