### PR TITLE
charmrun: fix syntax error in mpi win

### DIFF
--- a/src/arch/mpi-win64/charmrun
+++ b/src/arch/mpi-win64/charmrun
@@ -79,7 +79,7 @@ do
 	++debugger)
 		DEBUGGER=$2
 		shift
-        ;;
+		;;
 	*) 
 	    args=$args" "$1
 	    ;;

--- a/src/arch/mpi-win64/charmrun
+++ b/src/arch/mpi-win64/charmrun
@@ -79,6 +79,7 @@ do
 	++debugger)
 		DEBUGGER=$2
 		shift
+        ;;
 	*) 
 	    args=$args" "$1
 	    ;;


### PR DESCRIPTION
Fixes #2674.
Followup from #2394.
Could be cherry-picked to 6.10.