### PR TITLE
hwloc #2679: Disable GL and Cairo at configure time

### DIFF
--- a/src/scripts/configure.ac
+++ b/src/scripts/configure.ac
@@ -2980,6 +2980,8 @@ enable_libxml2='no'
 enable_visibility='no'
 enable_nvml='no'
 enable_opencl='no'
+enable_gl='no'
+enable_cairo='no'
 . hwloc/VERSION
 export libhwloc_so_version
 AC_SUBST(libhwloc_so_version)


### PR DESCRIPTION
CMakeLists.txt already disables these options.
Please verify that this resolves the issue.

Closes #2679 