### PR TITLE
Darwin: Use uFcontext threads by default

### DIFF
--- a/src/arch/mpi-darwin-x86_64/conv-mach-smp.h
+++ b/src/arch/mpi-darwin-x86_64/conv-mach-smp.h
@@ -6,9 +6,6 @@
 #define CMK_SHARED_VARS_UNAVAILABLE                        0
 #define CMK_SHARED_VARS_POSIX_THREADS_SMP                  1
 
-#undef CMK_THREADS_USE_JCONTEXT
-#define CMK_THREADS_USE_JCONTEXT                           1
-
 #undef CMK_USE_POLL
 #define CMK_USE_POLL                                       1
 #undef CMK_USE_KQUEUE

--- a/src/arch/mpi-darwin-x86_64/conv-mach.h
+++ b/src/arch/mpi-darwin-x86_64/conv-mach.h
@@ -37,7 +37,8 @@
 #define CMK_THREADS_USE_PTHREADS                           0
 #define CMK_THREADS_ARE_WIN32_FIBERS                       0
 #define CMK_THREADS_USE_CONTEXT                            0
-#define CMK_THREADS_USE_JCONTEXT                           1
+#define CMK_THREADS_USE_JCONTEXT                           0
+#define CMK_THREADS_USE_FCONTEXT                           1
 
 #define CMK_SIGNAL_NOT_NEEDED                              0
 #define CMK_SIGNAL_USE_SIGACTION                           0

--- a/src/arch/multicore-darwin-x86_64/conv-mach.h
+++ b/src/arch/multicore-darwin-x86_64/conv-mach.h
@@ -32,7 +32,9 @@
 #define CMK_SHARED_VARS_UNIPROCESSOR                       0
 #define CMK_SHARED_VARS_POSIX_THREADS_SMP                  1
 
-#define CMK_THREADS_USE_JCONTEXT                           1
+#define CMK_THREADS_USE_CONTEXT                            0
+#define CMK_THREADS_USE_JCONTEXT                           0
+#define CMK_THREADS_USE_FCONTEXT                           1
 #define CMK_THREADS_USE_PTHREADS                           0
 #define CMK_THREADS_ARE_WIN32_FIBERS                       0
 

--- a/src/arch/netlrts-darwin-x86_64/conv-mach-smp.h
+++ b/src/arch/netlrts-darwin-x86_64/conv-mach-smp.h
@@ -7,9 +7,6 @@
 #define CMK_SHARED_VARS_UNAVAILABLE                        0
 #define CMK_SHARED_VARS_POSIX_THREADS_SMP                  1
 
-#undef CMK_THREADS_USE_JCONTEXT
-#define CMK_THREADS_USE_JCONTEXT                           1
-
 #undef CMK_USE_POLL
 #define CMK_USE_POLL                                       1
 #undef CMK_USE_KQUEUE

--- a/src/arch/netlrts-darwin-x86_64/conv-mach.h
+++ b/src/arch/netlrts-darwin-x86_64/conv-mach.h
@@ -33,7 +33,8 @@
 #define CMK_THREADS_USE_PTHREADS                           0
 #define CMK_THREADS_ARE_WIN32_FIBERS                       0
 #define CMK_THREADS_USE_CONTEXT                            0
-#define CMK_THREADS_USE_JCONTEXT                           1
+#define CMK_THREADS_USE_JCONTEXT                           0
+#define CMK_THREADS_USE_FCONTEXT                           1
 
 #define CMK_SIGNAL_NOT_NEEDED                              0
 #define CMK_SIGNAL_USE_SIGACTION                           0


### PR DESCRIPTION
This replaces uJcontext as the default threading implementation. Its use of setjmp/longjmp causes failures on Darwin during checkpoint restart.