### PR TITLE
GitHub CI: limit jobs to 45 minutes

### DIFF
--- a/.github/workflows/bigsim.yml
+++ b/.github/workflows/bigsim.yml
@@ -4,6 +4,7 @@ on: [push]
 
 jobs:
   build:
+    timeout-minutes: 45
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -4,6 +4,7 @@ on: [push]
 
 jobs:
   build:
+    timeout-minutes: 45
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/uth.yml
+++ b/.github/workflows/uth.yml
@@ -3,9 +3,9 @@ name: UTH Linux
 on: [push]
 
 jobs:
-  timeout-minutes: 45
 
   build:
+    timeout-minutes: 45
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/uth.yml
+++ b/.github/workflows/uth.yml
@@ -3,7 +3,6 @@ name: UTH Linux
 on: [push]
 
 jobs:
-
   build:
     timeout-minutes: 45
 

--- a/.github/workflows/uth.yml
+++ b/.github/workflows/uth.yml
@@ -3,6 +3,8 @@ name: UTH Linux
 on: [push]
 
 jobs:
+  timeout-minutes: 45
+
   build:
 
     runs-on: ubuntu-latest

--- a/.github/workflows/verbs.yml
+++ b/.github/workflows/verbs.yml
@@ -6,6 +6,7 @@ on: [push]
 
 jobs:
   build:
+    timeout-minutes: 45
 
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
Should prevent long-running CI hangs (default timeout is 360 mins) such as the one seen in #2458.