### PR TITLE
Add Heap Record-Replay, -memory record

### DIFF
--- a/src/conv-core/CMakeLists.txt
+++ b/src/conv-core/CMakeLists.txt
@@ -44,6 +44,9 @@ target_compile_definitions(memory-os PRIVATE -DCMK_MEMORY_BUILD_OS)
 add_library(memory-os-verbose memory.C)
 target_compile_definitions(memory-os-verbose PRIVATE -DCMK_MEMORY_BUILD_OS_WRAPPED -DCMK_MEMORY_BUILD_VERBOSE)
 
+add_library(memory-os-record memory.C)
+target_compile_definitions(memory-os-record PRIVATE -DCMK_MEMORY_BUILD_OS_WRAPPED -DCMK_MEMORY_BUILD_RECORD)
+
 add_library(memory-os-paranoid memory.C)
 target_compile_definitions(memory-os-paranoid PRIVATE -DCMK_MEMORY_BUILD_OS_WRAPPED -DCMK_MEMORY_BUILD_PARANOID)
 
@@ -64,6 +67,9 @@ if(${CMK_HAS_MMAP})
 
     add_library(memory-verbose memory.C)
     target_compile_definitions(memory-verbose PRIVATE -DCMK_MEMORY_BUILD_VERBOSE)
+
+    add_library(memory-record memory.C)
+    target_compile_definitions(memory-record PRIVATE -DCMK_MEMORY_BUILD_RECORD)
 
     add_library(memory-paranoid memory.C)
     target_compile_definitions(memory-paranoid PRIVATE -DCMK_MEMORY_BUILD_PARANOID)

--- a/src/conv-core/memory-record.C
+++ b/src/conv-core/memory-record.C
@@ -1,0 +1,329 @@
+// Heap Record-Replay
+// By Evan Ramos
+// Generates an MPI program that repeats the exact sequence of heap operations observed on each PE.
+
+#include <cstdint>
+#include <cstdio>
+#include <unordered_map>
+
+// raw string literals containing the output program
+
+static const char prologue[] =
+R"code(
+#include <stdlib.h>
+#include <stdio.h>
+#include "mpi.h"
+
+int main(int argc, char ** argv)
+{
+  MPI_Init(&argc, &argv);
+
+  int p;
+  MPI_Comm_size(MPI_COMM_WORLD, &p);
+
+  if (%d != p)
+    puts("This recording was intended for %d ranks.");
+
+  int rank;
+  MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+
+  switch (rank)
+  {
+)code";
+
+static const char body[] =
+R"code(
+    case %d:
+    {
+#include "heap-replay-%d.cpp"
+      break;
+    }
+)code";
+
+static const char epilogue[] =
+R"code(
+    default:
+      break;
+  }
+
+  MPI_Finalize();
+  return 0;
+}
+)code";
+
+// end raw string literals
+
+static char initialized;
+struct MemoryRecord {
+  std::unordered_map<uintptr_t, unsigned long long> ptrs;
+  FILE * output;
+  unsigned long long count;
+  char guard;
+};
+CpvStaticDeclare(MemoryRecord, state);
+
+static void meta_init(char **argv)
+{
+  CpvInitialize(MemoryRecord, state);
+
+  const int mype = CmiMyPe();
+
+  char outputname[64];
+  sprintf(outputname, "heap-replay-%d.cpp", mype);
+  FILE * output = fopen(outputname, "wb");
+  if (output == nullptr)
+    CmiAbort("Could not open heap-replay-%d.cpp!", mype);
+  CpvAccess(state).output = output;
+
+  if (CmiMyRank() == 0)
+    initialized = 1;
+
+  CmiNodeAllBarrier();
+
+  if (mype == 0)
+  {
+    const int numpes = CmiNumPes();
+
+    FILE * mainsrc = fopen("heap-replay.cpp", "wb");
+    if (mainsrc == nullptr)
+      CmiAbort("Could not open heap-replay.cpp!");
+    fprintf(mainsrc, prologue, numpes, numpes);
+    for (int pe = 0; pe < numpes; ++pe)
+      fprintf(mainsrc, body, pe, pe);
+    fprintf(mainsrc, epilogue);
+    fclose(mainsrc);
+  }
+}
+
+static void *meta_malloc(size_t size)
+{
+  void *ret = mm_malloc(size);
+
+  if (initialized && !CpvAccess(state).guard)
+  {
+    MemoryRecord & data = CpvAccess(state);
+    data.guard = 1;
+
+    fprintf(data.output, "void * ptr_%llu = malloc(%zu);\n", data.count, size);
+    data.ptrs.emplace((uintptr_t)ret, data.count);
+    ++data.count;
+
+    data.guard = 0;
+  }
+
+  return ret;
+}
+
+static void meta_free(void *mem)
+{
+  if (initialized && !CpvAccess(state).guard)
+  {
+    MemoryRecord & data = CpvAccess(state);
+    data.guard = 1;
+
+    if (mem == nullptr)
+      fprintf(data.output, "free(nullptr);\n");
+    else
+    {
+      auto iter = data.ptrs.find((uintptr_t)mem);
+      if (iter != data.ptrs.end())
+      {
+        fprintf(data.output, "free(ptr_%llu);\n", iter->second);
+        data.ptrs.erase(iter);
+      }
+#if 0
+      else // causes an abort during global variable destructors
+        CmiAbort("Got free(%p) without recording a matching allocation!", mem);
+#endif
+    }
+
+    data.guard = 0;
+  }
+
+  mm_free(mem);
+}
+
+static void *meta_calloc(size_t nelem, size_t size)
+{
+  void *ret = mm_calloc(nelem, size);
+
+  if (initialized && !CpvAccess(state).guard)
+  {
+    MemoryRecord & data = CpvAccess(state);
+    data.guard = 1;
+
+    fprintf(data.output, "void * ptr_%llu = calloc(%zu, %zu);\n", data.count, nelem, size);
+    data.ptrs.emplace((uintptr_t)ret, data.count);
+    ++data.count;
+
+    data.guard = 0;
+  }
+
+  return ret;
+}
+
+static void meta_cfree(void *mem)
+{
+  if (initialized && !CpvAccess(state).guard)
+  {
+    MemoryRecord & data = CpvAccess(state);
+    data.guard = 1;
+
+    if (mem == nullptr)
+      fprintf(data.output, "cfree(nullptr);\n");
+    else
+    {
+      auto iter = data.ptrs.find((uintptr_t)mem);
+      if (iter != data.ptrs.end())
+      {
+        fprintf(data.output, "cfree(ptr_%llu);\n", iter->second);
+        data.ptrs.erase(iter);
+      }
+#if 0
+      else
+        CmiAbort("Got cfree(%p) without recording a matching allocation!", mem);
+#endif
+    }
+
+    data.guard = 0;
+  }
+  mm_cfree(mem);
+}
+
+static void *meta_realloc(void *mem, size_t size)
+{
+  void *ret = mm_realloc(mem, size);
+
+  if (initialized && !CpvAccess(state).guard)
+  {
+    MemoryRecord & data = CpvAccess(state);
+    data.guard = 1;
+
+    if (mem == nullptr)
+      fprintf(data.output, "void * ptr_%llu = realloc(nullptr, %zu);\n", data.count, size);
+    else
+    {
+      auto iter = data.ptrs.find((uintptr_t)mem);
+      if (iter != data.ptrs.end())
+      {
+        fprintf(data.output, "void * ptr_%llu = realloc(ptr_%llu, %zu);\n", data.count, iter->second, size);
+        data.ptrs.erase(iter);
+      }
+#if 0
+      else
+        CmiAbort("Got realloc(%p, %zu) without recording a matching allocation!", mem, size);
+#endif
+    }
+    ++data.count;
+
+    data.guard = 0;
+  }
+
+  return ret;
+}
+
+static void *meta_memalign(size_t align, size_t size)
+{
+  void *ret = mm_memalign(align, size);
+
+  if (initialized && !CpvAccess(state).guard)
+  {
+    MemoryRecord & data = CpvAccess(state);
+    data.guard = 1;
+
+    fprintf(data.output, "void * ptr_%llu = memalign(%zu, %zu);\n", data.count, align, size);
+    data.ptrs.emplace((uintptr_t)ret, data.count);
+    ++data.count;
+
+    data.guard = 0;
+  }
+
+  return ret;
+}
+
+static int meta_posix_memalign(void **outptr, size_t align, size_t size)
+{
+  int ret = mm_posix_memalign(outptr, align, size);
+
+  if (initialized && !CpvAccess(state).guard)
+  {
+    MemoryRecord & data = CpvAccess(state);
+    data.guard = 1;
+
+    fprintf(data.output, "void * ptr_%llu;\nposix_memalign(&ptr_%llu, %zu, %zu);\n", data.count, data.count, align, size);
+    data.ptrs.emplace((uintptr_t)*outptr, data.count);
+    ++data.count;
+
+    data.guard = 0;
+  }
+
+  return ret;
+}
+
+static void *meta_aligned_alloc(size_t align, size_t size)
+{
+  void *ret = mm_aligned_alloc(align, size);
+
+  if (initialized && !CpvAccess(state).guard)
+  {
+    MemoryRecord & data = CpvAccess(state);
+    data.guard = 1;
+
+    fprintf(data.output, "void * ptr_%llu = aligned_alloc(%zu, %zu);\n", data.count, align, size);
+    data.ptrs.emplace((uintptr_t)ret, data.count);
+    ++data.count;
+
+    data.guard = 0;
+  }
+
+  return ret;
+}
+
+static void *meta_valloc(size_t size)
+{
+  void *ret = mm_valloc(size);
+
+  if (initialized && !CpvAccess(state).guard)
+  {
+    MemoryRecord & data = CpvAccess(state);
+    data.guard = 1;
+
+    fprintf(data.output, "void * ptr_%llu = valloc(%zu);\n", data.count, size);
+    data.ptrs.emplace((uintptr_t)ret, data.count);
+    ++data.count;
+
+    data.guard = 0;
+  }
+
+  return ret;
+}
+
+static void *meta_pvalloc(size_t size)
+{
+  void *ret = mm_pvalloc(size);
+
+  if (initialized && !CpvAccess(state).guard)
+  {
+    MemoryRecord & data = CpvAccess(state);
+    data.guard = 1;
+
+    fprintf(data.output, "void * ptr_%llu = pvalloc(%zu);\n", data.count, size);
+    data.ptrs.emplace((uintptr_t)ret, data.count);
+    ++data.count;
+
+    data.guard = 0;
+  }
+
+  return ret;
+}
+
+// Filter out RTS allocations which can be freed from PEs other than their originator.
+#define CMK_MEMORY_HAS_NOMIGRATE
+void *malloc_nomigrate(size_t size)
+{
+  return mm_malloc(size);
+}
+void free_nomigrate(void *mem)
+{
+  mm_free(mem);
+}

--- a/src/conv-core/memory-record.C
+++ b/src/conv-core/memory-record.C
@@ -70,7 +70,7 @@ static void meta_init(char **argv)
 
   char outputname[64];
   sprintf(outputname, "heap-replay-%d.cpp", mype);
-  FILE * output = fopen(outputname, "wb");
+  FILE * output = fopen(outputname, "w");
   if (output == nullptr)
     CmiAbort("Could not open heap-replay-%d.cpp!", mype);
   CpvAccess(state).output = output;
@@ -84,7 +84,7 @@ static void meta_init(char **argv)
   {
     const int numpes = CmiNumPes();
 
-    FILE * mainsrc = fopen("heap-replay.cpp", "wb");
+    FILE * mainsrc = fopen("heap-replay.cpp", "w");
     if (mainsrc == nullptr)
       CmiAbort("Could not open heap-replay.cpp!");
     fprintf(mainsrc, prologue, numpes, numpes);

--- a/src/conv-core/memory-record.C
+++ b/src/conv-core/memory-record.C
@@ -1,6 +1,11 @@
-// Heap Record-Replay
-// By Evan Ramos
-// Generates an MPI program that repeats the exact sequence of heap operations observed on each PE.
+/*
+ * Heap Record-Replay
+ * By Evan Ramos
+ *
+ * Generates an MPI program that repeats the exact sequence of heap operations observed
+ * on each PE. Can be used for debugging and performance analysis of memory allocators
+ * as well as heap behavior of user codes.
+ */
 
 #include <cstdint>
 #include <cstdio>

--- a/src/conv-core/memory.C
+++ b/src/conv-core/memory.C
@@ -444,6 +444,10 @@ static inline void *mm_impl_pvalloc(size_t size)
 #include "memory-verbose.C"
 #endif
 
+#if CMK_MEMORY_BUILD_RECORD
+#include "memory-record.C"
+#endif
+
 #if CMK_MEMORY_BUILD_PARANOID
 #include "memory-paranoid.C"
 #endif
@@ -797,6 +801,10 @@ static void meta_init(char **argv) {
 
 #if CMK_MEMORY_BUILD_VERBOSE
 #include "memory-verbose.C"
+#endif
+
+#if CMK_MEMORY_BUILD_RECORD
+#include "memory-record.C"
 #endif
 
 #if CMK_MEMORY_BUILD_PARANOID

--- a/src/scripts/Makefile
+++ b/src/scripts/Makefile
@@ -454,6 +454,7 @@ MEMLIBS = \
   $(L)/libmemory-default.a \
   $(L)/libmemory-os.a \
   $(L)/libmemory-os-verbose.a \
+  $(L)/libmemory-os-record.a \
   $(L)/libmemory-os-isomalloc.a \
   $(L)/libmemory-os-leak.a \
   $(L)/libmemory-os-paranoid.a \
@@ -465,6 +466,7 @@ ifneq ($(CMK_HAS_MMAP),0)
 MEMLIBS += \
   $(L)/libmemory-gnu.a \
   $(L)/libmemory-gnu-verbose.a \
+  $(L)/libmemory-gnu-record.a \
   $(L)/libmemory-gnu-paranoid.a \
   $(L)/libmemory-gnu-leak.a \
   $(L)/libmemory-gnu-isomalloc.a \
@@ -668,6 +670,7 @@ endef
 $(eval $(call libmem,default,                           ,-DCMK_MEMORY_BUILD_DEFAULT))
 $(eval $(call libmem,os,                                ,-DCMK_MEMORY_BUILD_OS))
 $(eval $(call libmem,os-verbose,    memory-verbose.C,    -DCMK_MEMORY_BUILD_OS_WRAPPED -DCMK_MEMORY_BUILD_VERBOSE    -touch-on-failure))
+$(eval $(call libmem,os-record,     memory-record.C,     -DCMK_MEMORY_BUILD_OS_WRAPPED -DCMK_MEMORY_BUILD_RECORD     -touch-on-failure))
 $(eval $(call libmem,os-paranoid,   memory-paranoid.C,   -DCMK_MEMORY_BUILD_OS_WRAPPED -DCMK_MEMORY_BUILD_PARANOID   -touch-on-failure))
 $(eval $(call libmem,os-leak,       memory-leak.C,       -DCMK_MEMORY_BUILD_OS_WRAPPED -DCMK_MEMORY_BUILD_LEAK       -touch-on-failure))
 $(eval $(call libmem,os-isomalloc,  memory-isomalloc.C,  -DCMK_MEMORY_BUILD_OS_WRAPPED -DCMK_MEMORY_BUILD_ISOMALLOC  -touch-on-failure))
@@ -682,6 +685,7 @@ $(eval $(call libmem,hooks-charmdebug,,-DCMK_MEMORY_BUILD_GNU_HOOKS -DCMK_MEMORY
 #  This is OK, but then we can't use "-memory gnu" or friends.
 $(eval $(call libmem,gnu,                                        ,-DCMK_MEMORY_BUILD_GNU -touch-on-failure))
 $(eval $(call libmem,gnu-verbose,             memory-verbose.C   ,-DCMK_MEMORY_BUILD_VERBOSE -touch-on-failure))
+$(eval $(call libmem,gnu-record,              memory-record.C    ,-DCMK_MEMORY_BUILD_RECORD -touch-on-failure))
 $(eval $(call libmem,gnu-paranoid,            memory-paranoid.C  ,-DCMK_MEMORY_BUILD_PARANOID -touch-on-failure))
 $(eval $(call libmem,gnu-leak,                memory-leak.C      ,-DCMK_MEMORY_BUILD_LEAK -touch-on-failure))
 $(eval $(call libmem,gnu-isomalloc,           memory-isomalloc.C ,-DCMK_MEMORY_BUILD_ISOMALLOC -touch-on-failure))

--- a/src/scripts/charmc
+++ b/src/scripts/charmc
@@ -1531,7 +1531,7 @@ BAL_OBJ="-lldb-$BALANCE -lconv-ldb"
 
 # Set the default expansions of unprefixed variants
 case "$MEMORY" in
-  'verbose'|'paranoid'|'leak'|'isomalloc')
+  'verbose'|'record'|'paranoid'|'leak'|'isomalloc')
     MEMORY="os-$MEMORY"
     ;;
   charmdebug*)


### PR DESCRIPTION
Generates an MPI program that repeats the exact sequence of heap operations observed on each PE. Can be used for debugging and performance analysis of memory allocators as well as heap behavior of user codes.