### PR TITLE
AMPI: Include accessory implementation files directly from ampi.C

### DIFF
--- a/src/libs/ck-libs/ampi/CMakeLists.txt
+++ b/src/libs/ck-libs/ampi/CMakeLists.txt
@@ -1,4 +1,4 @@
-set(ampi-cxx-sources ampi.C ampiMisc.C ampiOneSided.C ampif.C ddt.C mpich-alltoall.C ampi_mpix.C)
+set(ampi-cxx-sources ampi.C ampif.C ddt.C)
 
 set(ampi-f90-sources ampifimpl.f90 ampimod.f90)
 

--- a/src/libs/ck-libs/ampi/Makefile
+++ b/src/libs/ck-libs/ampi/Makefile
@@ -11,8 +11,7 @@ HEADDEP=$(HEADERS) ampiimpl.h ddt.h \
 COMPAT=compat_ampi.o \
        compat_ampim.o compat_ampifm.o compat_ampicm.o \
 	   compat_ampicpp.o
-OBJS=ampi.o ampif.o ampiOneSided.o \
-     ampiMisc.o ddt.o mpich-alltoall.o ampi_mpix.o ampi_noimpl.o
+OBJS=ampi.o ampif.o ddt.o
 
 AMPI_LIB=libmoduleampi
 AMPI_LIBDIR=$(CDIR)/lib
@@ -160,27 +159,14 @@ compat_ampicm.o: compat_ampicm.C
 compat_ampi.o: compat_ampi.c
 	$(CHARMC) -c compat_ampi.c
 
-ampi_mpix.o: ampi_mpix.C $(HEADDEP)
-
-ampi_noimpl.o: ampi_noimpl.C $(HEADDEP)
-
 compat_ampicpp.o: compat_ampicpp.C
 	$(CHARMC) -c compat_ampicpp.C
 
-ampi.o: ampi.C $(HEADDEP)
-	$(CHARMC) -c ampi.C
+ampi.o: ampi.C ampiMisc.C mpich-alltoall.C ampiOneSided.C ampi_noimpl.C ampi_mpix.C $(HEADDEP)
+	$(CHARMC) -c $<
 
 ampif.o: ampif.C $(HEADDEP)
 	$(CHARMC) -c ampif.C
-
-ampiOneSided.o: ampiOneSided.C ampiimpl.h $(HEADDEP)
-	$(CHARMC) -c ampiOneSided.C
-
-ampiMisc.o: ampiMisc.C ampiimpl.h $(HEADDEP)
-	$(CHARMC) -c ampiMisc.C
-
-mpich-alltoall.o: mpich-alltoall.C $(HEADDEP)
-	$(CHARMC) -c mpich-alltoall.C
 
 ampi.decl.h ampi.def.h: ampi.ci
 	$(CHARMC) ampi.ci
@@ -193,13 +179,13 @@ $(FUNCPTR_SHIM_OBJ): ampi_funcptr_shim.C $(HEADDEP)
 $(FUNCPTR_FORTRAN_OBJ): ampif.C $(HEADDEP)
 	-$(CHARMC) -ampi-funcptr-shim -c $< -o $@
 
-$(FUNCPTR_LOADER_OBJ): ampi_funcptr_loader.C $(HEADDEP)
+$(FUNCPTR_LOADER_OBJ): ampi_funcptr_loader.C ampi_funcptr_loader.h $(HEADDEP)
 	$(CHARMC) -c $< -o $@
 
-$(FUNCPTR_FSGLOBALS_OBJ): ampi_funcptr_fsglobals.C $(HEADDEP)
+$(FUNCPTR_FSGLOBALS_OBJ): ampi_funcptr_fsglobals.C ampi_funcptr_loader.h $(HEADDEP)
 	$(CHARMC) -c $< -o $@
 
-$(FUNCPTR_PIPGLOBALS_OBJ): ampi_funcptr_pipglobals.C $(HEADDEP)
+$(FUNCPTR_PIPGLOBALS_OBJ): ampi_funcptr_pipglobals.C ampi_funcptr_loader.h $(HEADDEP)
 	$(CHARMC) -c $< -o $@
 
 clean:

--- a/src/libs/ck-libs/ampi/ampi.C
+++ b/src/libs/ck-libs/ampi/ampi.C
@@ -11996,3 +11996,9 @@ int AMPI_GPU_Invoke(cudaStream_t stream)
 #endif // CMK_CUDA
 
 #include "ampi.def.h"
+
+#include "ampiMisc.C"
+#include "mpich-alltoall.C"
+#include "ampiOneSided.C"
+#include "ampi_noimpl.C"
+#include "ampi_mpix.C"

--- a/src/libs/ck-libs/ampi/ampiMisc.C
+++ b/src/libs/ck-libs/ampi/ampiMisc.C
@@ -380,7 +380,7 @@ AMPI_API_IMPL(int, MPI_Info_free, MPI_Info *info)
   return ampiErrhandler("AMPI_Info_free", ret);
 }
 
-#ifdef AMPIMSGLOG
+#if AMPIMSGLOG
 #if CMK_USE_ZLIB
 /*zDisk PUP::er's*/
 void PUP::tozDisk::bytes(void *p,int n,size_t itemSize,dataType /*t*/)

--- a/src/libs/ck-libs/ampi/ampi_funcptr_loader.h
+++ b/src/libs/ck-libs/ampi/ampi_funcptr_loader.h
@@ -10,7 +10,10 @@
 #include <inttypes.h>
 #include <limits.h>
 
-#include "ampiimpl.h"
+/* avoid including ampiimpl.h */
+#include "charm.h"
+extern char * ampi_binary_path;
+
 #include "ampi_funcptr.h"
 
 #define STRINGIZE_INTERNAL(x) #x


### PR DESCRIPTION
This includes:
ampiMisc.C
mpich-alltoall.C
ampiOneSided.C
ampi_noimpl.C
ampi_mpix.C

This allows these files to better share the inline functions in ampiimpl.h without requiring link-time optimization. It also should eliminate time spent redundantly compiling ampiimpl.h.