### PR TITLE
Increase UCX CI build timeout to 60 minutes

### DIFF
--- a/.github/workflows/ucx.yml
+++ b/.github/workflows/ucx.yml
@@ -4,7 +4,7 @@ on: [push]
 
 jobs:
   build:
-    timeout-minutes: 45
+    timeout-minutes: 60
 
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
Validation sometimes fails in the middle of testing due to the timeout.