### PR TITLE
Fix causality issue in examples/charm++/reductions/allReduce

### DIFF
--- a/examples/charm++/reductions/allReduce/AllReduce.C
+++ b/examples/charm++/reductions/allReduce/AllReduce.C
@@ -3,9 +3,6 @@
 #include <math.h>
 
 
-/*readonly*/ CProxy_main mainProxy;
-/*readonly*/ int units;
-/*readonly*/ int allredSize;
 #include "AllReduce.h"
 
 /*mainchare*/
@@ -15,21 +12,19 @@ main::main(CkArgMsg* m)
     //Process command-line arguments
     //Start the computation
 
-    mainProxy = thishandle;
     if(m->argc<2)
       {
 	      CkPrintf("Needs number of array elements and allreduce data size\n");
 	CkExit();
       }
     units=atoi(m->argv[1]);
-    allredSize=atoi(m->argv[2]);
+    int allredSize=atoi(m->argv[2]);
     
-    arr = CProxy_AllReduce::ckNew(thisProxy, units);
+    arr = CProxy_AllReduce::ckNew(thisProxy, allredSize, units, units);
 
     CkPrintf("AllReduce for %d pes on %d units for %d size\n",
 	     CkNumPes(),units,allredSize);
 
-    arr.init();
     startTime = CkWallTimer();
     arr.dowork();
   }

--- a/examples/charm++/reductions/allReduce/AllReduce.C
+++ b/examples/charm++/reductions/allReduce/AllReduce.C
@@ -19,7 +19,9 @@ main::main(CkArgMsg* m)
       }
     units=atoi(m->argv[1]);
     int allredSize=atoi(m->argv[2]);
-    
+
+    delete m;
+
     arr = CProxy_AllReduce::ckNew(thisProxy, allredSize, units, units);
 
     CkPrintf("AllReduce for %d pes on %d units for %d size\n",

--- a/examples/charm++/reductions/allReduce/AllReduce.ci
+++ b/examples/charm++/reductions/allReduce/AllReduce.ci
@@ -1,15 +1,11 @@
 mainmodule AllReduce {
-  readonly int units;
-  readonly int allredSize;
-
   mainchare main {
     entry main(CkArgMsg *m);
     entry void done();
   };
 
   array [1D] AllReduce {
-    entry AllReduce(CProxy_main);
-    entry void init();
+    entry AllReduce(CProxy_main, int, int);
     entry void dowork(void);	
     entry void report(CkReductionMsg *msg);
   };        	

--- a/examples/charm++/reductions/allReduce/AllReduce.h
+++ b/examples/charm++/reductions/allReduce/AllReduce.h
@@ -6,6 +6,7 @@ class main : public CBase_main
 private:
   CProxy_AllReduce arr;
 	double startTime;
+	int units;
 public:
 
   main(CkArgMsg* m);
@@ -30,14 +31,14 @@ class AllReduce : public CBase_AllReduce
 {
  private:
 	CProxy_main mainProxy;
+	int allredSize, units;
 	double* myData;
  public:
 
-	AllReduce(CProxy_main ma)   { mainProxy=ma;  }
-
   AllReduce(CkMigrateMessage *m) {};
 
-	void init()
+	AllReduce(CProxy_main ma, int s, int u)
+		: mainProxy{ma}, allredSize{s}, units{u}
 	{
 		                myData = new double[allredSize/(sizeof(double))];
 				                for (int i=0; i<allredSize/sizeof(double); i++) {


### PR DESCRIPTION
Fixes failure seen in http://charm.cs.illinois.edu/autobuild/old.2020_02_03__01_02/multicore-darwin-x86_64.txt