### PR TITLE
allows msa programs to build with std::move, as added by xlat-i

### DIFF
--- a/src/libs/ck-libs/multiphaseSharedArrays/msa-DistPageMgr.ci
+++ b/src/libs/ck-libs/multiphaseSharedArrays/msa-DistPageMgr.ci
@@ -10,7 +10,7 @@ module msa
                          unsigned int max_bytes, unsigned int nEntries, unsigned int numberOfWorkerThreads);
         entry void AckPage(unsigned int page);
         entry void ReceivePage(unsigned int page, ENTRY_TYPE pageData[size], int size);
-        entry void ReceivePageWithPUP(unsigned int page, MSA_PageT<ENTRY_TYPE, ENTRY_OPS_CLASS, ENTRIES_PER_PAGE> pageData, int size);
+        entry void ReceivePageWithPUP(unsigned int page, const MSA_PageT<ENTRY_TYPE, ENTRY_OPS_CLASS, ENTRIES_PER_PAGE> &pageData, int size);
         entry void enroll();
         entry void enroll(unsigned int numberOfWorkerThreads);
         entry void enrollAck(int originator);  // internal method
@@ -30,12 +30,12 @@ module msa
     template<class ENTRY_TYPE, class ENTRY_OPS_CLASS,unsigned int ENTRIES_PER_PAGE> array[1D] MSA_PageArray
     {
         entry MSA_PageArray(void);
-	entry void setCacheProxy(CProxy_MSA_CacheGroup<ENTRY_TYPE, ENTRY_OPS_CLASS, ENTRIES_PER_PAGE> cache);
+	entry void setCacheProxy(const CProxy_MSA_CacheGroup<ENTRY_TYPE, ENTRY_OPS_CLASS, ENTRIES_PER_PAGE> &cache);
 	
         entry void GetPage(int pe);
         entry void PAReceivePage(ENTRY_TYPE page[ENTRIES_PER_PAGE], int pe, MSA_Page_Fault_t pageState);
         entry void PAReceiveRLEPage(MSA_WriteSpan_t spans[nSpans], unsigned int nSpans, ENTRY_TYPE entries[nEntries], unsigned int nEntries, int pe, MSA_Page_Fault_t pageState);
-        entry void PAReceiveRLEPageWithPup(MSA_WriteSpan_t spans[nSpans], unsigned int nSpans, MSA_PageT<ENTRY_TYPE, ENTRY_OPS_CLASS, ENTRIES_PER_PAGE> entries, unsigned int nEntries, int pe, MSA_Page_Fault_t pageState);
+        entry void PAReceiveRLEPageWithPup(MSA_WriteSpan_t spans[nSpans], unsigned int nSpans, const MSA_PageT<ENTRY_TYPE, ENTRY_OPS_CLASS, ENTRIES_PER_PAGE> &entries, unsigned int nEntries, int pe, MSA_Page_Fault_t pageState);
         entry void Sync(bool clear);
 	
         // for debugging purposes only

--- a/src/libs/ck-libs/multiphaseSharedArrays/msa-DistPageMgr.h
+++ b/src/libs/ck-libs/multiphaseSharedArrays/msa-DistPageMgr.h
@@ -453,6 +453,7 @@ public:
  	inline ENTRY &operator[](int i) {return data[i];}
  	inline const ENTRY &operator[](int i) const {return data[i];}
     inline ENTRY *getData() { return data; }
+	inline const ENTRY *getData() const { return (const ENTRY*) data; }
 };
 
 //=============================== Cache Manager =================================
@@ -838,12 +839,12 @@ public:
 
     /// A requested page has arrived from the network.
     ///  nEntriesInPage_ = num entries being sent (0 for empty page, num entries otherwise)
-    inline void ReceivePageWithPUP(unsigned int page, page_t &pageData, int size)
+    inline void ReceivePageWithPUP(unsigned int page, const page_t &pageData, int size)
 		{
 			ReceivePage(page, pageData.getData(), size);
 		}
 
-    inline void ReceivePage(unsigned int page, ENTRY_TYPE* pageData, int size)
+    inline void ReceivePage(unsigned int page, const ENTRY_TYPE* pageData, int size)
 		{
 			CkAssert(0==size || ENTRIES_PER_PAGE == size);
 			// the page we requested has been received
@@ -1308,7 +1309,7 @@ public:
     inline MSA_PageArray() : epage(NULL) { }
     inline MSA_PageArray(CkMigrateMessage* m) { delete m; }
     
-    void setCacheProxy(CProxy_CacheGroup_t &cache_)
+    void setCacheProxy(const CProxy_CacheGroup_t &cache_)
 		{
 			cache=cache_;
 		}
@@ -1369,7 +1370,7 @@ public:
     /// Receive a runlength encoded page from the network:
     inline void PAReceiveRLEPageWithPup(
     	const MSA_WriteSpan_t *spans, unsigned int nSpans, 
-        page_t &entries, unsigned int nEntries, 
+        const page_t &entries, unsigned int nEntries,
         int pe, MSA_Page_Fault_t pageState)
 		{
 			PAReceiveRLEPage(spans, nSpans, entries.getData(), nEntries, pe, pageState);


### PR DESCRIPTION
Xlat-i adds `std::move` to function arguments while unmarshalling for zero-copy support. This did not preclude compilation of the MSA library, but anything trying to use its headers will fail to build. This patch allows MSA programs to build again.