### PR TITLE
Fix verbs on new InfiniBand hardware/drivers

### DIFF
--- a/src/arch/verbs/machine-ibverbs.C
+++ b/src/arch/verbs/machine-ibverbs.C
@@ -976,11 +976,10 @@ struct infiOtherNodeData *initInfiOtherNodeData(int node,int addr[3]){
 	attr.qp_state 	    = IBV_QPS_RTS;
 #if ! QLOGIC
 	attr.timeout 	    = 26;
-	attr.retry_cnt 	    = 20;
 #else
 	attr.timeout 	    = 14;
-	attr.retry_cnt 	    = 7;
 #endif
+	attr.retry_cnt 	    = 7;
 	attr.rnr_retry 	    = 7;
 	attr.sq_psn 	    = context->localAddr[node].psn;
 	attr.max_rd_atomic  = 1;
@@ -999,15 +998,9 @@ struct infiOtherNodeData *initInfiOtherNodeData(int node,int addr[3]){
         if(err == 22) {
           //use inverted logic
 #if QLOGIC
-          mtu = IBV_MTU_2048;
-          attr.path_mtu             = mtu;
           attr.timeout              = 26;
-          attr.retry_cnt            = 20;
 #else
-          mtu = IBV_MTU_4096;
-          attr.path_mtu             = mtu;
           attr.timeout              = 14;
-          attr.retry_cnt            = 7;
 #endif
 
           MACHSTATE3(3,"Retry:dlid 0x%x qp 0x%x psn 0x%x",attr.ah_attr.dlid,attr.dest_qp_num,attr.sq_psn);


### PR DESCRIPTION
Verbs started rejecting setting retry_cnt to 20 because this is only
a 3-bit field, so the maximum legal value is 7.  This caused a
retry using "QLOGIC" values, which attempted to modify the mtu,
but the mtu flag was not set and mtu could not be modified at this
point of setup anyway, so the value was only changed for future
nodes attempting to connect and was in general inconsistent,
resulting in "Work completion error in sendCq" Charm++ aborts
along with mlx5 driver "got completion with error" messages.

Fix is to always set retry_cnt to 7 and don't try to change mtu.