### PR TITLE
Revert CmiAbort segfaults in production builds

### DIFF
--- a/src/arch/mpi/machine.C
+++ b/src/arch/mpi/machine.C
@@ -1464,8 +1464,8 @@ void LrtsInit(int *argc, char ***argv, int *numNodes, int *myNodeID) {
         Cmi_truecrash = 1;
 #endif
         int debug = CmiGetArgFlag(largv,"++debug");
-        if (CmiGetArgFlagDesc(*argv,"+truecrash","Do not install signal handlers") || debug ||
-            CmiNumNodes()<=32) Cmi_truecrash = 1;
+        if (CmiGetArgFlagDesc(*argv,"+truecrash","Do not install signal handlers") ||
+            debug ) Cmi_truecrash = 1;
         int debug_no_pause = CmiGetArgFlag(largv,"++debug-no-pause");
         if (debug || debug_no_pause) {  /*Pause so user has a chance to start and attach debugger*/
 #if CMK_HAS_GETPID

--- a/src/arch/netlrts/machine.C
+++ b/src/arch/netlrts/machine.C
@@ -2156,8 +2156,7 @@ void LrtsInit(int *argc, char ***argv, int *numNodes, int *myNodeID)
   Cmi_truecrash = 1;
 #endif
   if (CmiGetArgFlagDesc(*argv,"+truecrash","Do not install signal handlers") ||
-      CmiGetArgFlagDesc(*argv,"++debug",NULL /*meaning: don't show this*/) ||
-      CmiNumNodes()<=32) Cmi_truecrash = 1;
+      CmiGetArgFlagDesc(*argv,"++debug",NULL /*meaning: don't show this*/) ) Cmi_truecrash = 1;
     /* netpoll disable signal */
   if (CmiGetArgFlagDesc(*argv,"+netpoll","Do not use SIGIO--poll instead")) Cmi_netpoll = 1;
   if (CmiGetArgFlagDesc(*argv,"+netint","Use SIGIO")) Cmi_netpoll = 0;

--- a/src/arch/verbs/machine.C
+++ b/src/arch/verbs/machine.C
@@ -2007,8 +2007,7 @@ void LrtsInit(int *argc, char ***argv, int *numNodes, int *myNodeID)
   Cmi_truecrash = 1;
 #endif
   if (CmiGetArgFlagDesc(*argv,"+truecrash","Do not install signal handlers") ||
-      CmiGetArgFlagDesc(*argv,"++debug",NULL /*meaning: don't show this*/) ||
-      CmiNumNodes()<=32) Cmi_truecrash = 1;
+      CmiGetArgFlagDesc(*argv,"++debug",NULL /*meaning: don't show this*/) ) Cmi_truecrash = 1;
     /* netpoll disable signal */
   if (CmiGetArgFlagDesc(*argv,"+netpoll","Do not use SIGIO--poll instead")) Cmi_netpoll = 1;
   if (CmiGetArgFlagDesc(*argv,"+netint","Use SIGIO")) Cmi_netpoll = 0;


### PR DESCRIPTION
Partial revert of 8c85a3debc2254d68f8aa50c6ec0b1e302c86131, which
had set Cmi_truecrash=1 whenever CmiNumNodes()<=32.  This would
cause users to see a segfault when CmiAbort() was called due to
input errors, safety checks, etc., which they would interpret as
a bug in the application.  Now builds with CMK_OPTIMIZE=1 will
only segfault in CmiAbort() if ++debug or +truecrash are specified
by the user on the command line at run time.