### PR TITLE
AMPI: fix MPI_Waitsome by creating valid requests for eager msgs

### DIFF
--- a/src/libs/ck-libs/ampi/ampi.C
+++ b/src/libs/ck-libs/ampi/ampi.C
@@ -3180,9 +3180,9 @@ MPI_Request ampi::delesend(int t, int sRank, const void* buf, int count, MPI_Dat
                                                      getDDT(), AMPI_REQ_COMPLETED));
   }
   else { // Persistent request
-    CkAssert(sreq.isPersistent());
     AmpiRequestList& reqList = parent->ampiReqs;
     AmpiRequest& sreq = (*reqList[reqIdx]);
+    CkAssert(sreq.isPersistent());
     sreq.complete = true;
   }
 

--- a/src/libs/ck-libs/ampi/ampi.C
+++ b/src/libs/ck-libs/ampi/ampi.C
@@ -3088,7 +3088,11 @@ MPI_Request ampi::sendLocalMsg(int tag, int srcRank, const void* buf, int size, 
                CkMyPe(), parent->thisIndex, destPtr->parent->thisIndex);
     )
     destPtr->generic(makeAmpiMsg(destRank, tag, srcRank, buf, count, type, destComm, seq));
-    return MPI_REQUEST_NULL;
+    if (reqIdx == MPI_REQUEST_NULL) {
+      reqIdx = postReq(parent->reqPool.newReq<SendReq>((void*)buf, count, type, destRank, tag, destComm, getDDT(),
+                                                        AMPI_REQ_COMPLETED));
+    }
+    return reqIdx;
   }
 }
 
@@ -3171,14 +3175,18 @@ MPI_Request ampi::delesend(int t, int sRank, const void* buf, int count, MPI_Dat
   // Send via normal Charm++ message with copies on both sender- and receiver-sides
   arrProxy[destIdx].generic(makeAmpiMsg(rank, t, sRank, buf, count, type, destcomm, seq));
 
-  if (reqIdx != MPI_REQUEST_NULL) { // Persistent send request
+  if (reqIdx == MPI_REQUEST_NULL) { // Sends via generic() get a pre-completed send request
+    reqIdx = postReq(parent->reqPool.newReq<SendReq>((void*)buf, count, type, rank, t, destcomm,
+                                                     getDDT(), AMPI_REQ_COMPLETED));
+  }
+  else { // Persistent request
+    CkAssert(sreq.isPersistent());
     AmpiRequestList& reqList = parent->ampiReqs;
     AmpiRequest& sreq = (*reqList[reqIdx]);
-    CkAssert(sreq.isPersistent());
     sreq.complete = true;
-    return reqIdx;
   }
-  return MPI_REQUEST_NULL;
+
+  return reqIdx;
 }
 
 // Invoked by recv'er when not co-located in the same process as sender.
@@ -6142,10 +6150,10 @@ AMPI_API_IMPL(int, MPI_Waitsome, int incount, MPI_Request *array_of_requests, in
     if (req.test()) {
       pptr = req.wait(pptr, &sts);
       array_of_indices[(*outcount)] = i;
-      (*outcount)++;
       if (array_of_statuses != MPI_STATUSES_IGNORE)
         array_of_statuses[(*outcount)] = sts;
       reqs.freeNonPersReq(pptr, array_of_requests[i]);
+      (*outcount)++;
     }
     else {
       req.setBlocked(true);
@@ -6175,11 +6183,11 @@ AMPI_API_IMPL(int, MPI_Waitsome, int incount, MPI_Request *array_of_requests, in
       if (req.test()) {
         pptr = req.wait(pptr, &sts);
         array_of_indices[(*outcount)] = i;
-        (*outcount)++;
         if (array_of_statuses != MPI_STATUSES_IGNORE)
           array_of_statuses[(*outcount)] = sts;
         reqs.unblockReqs(&array_of_requests[i], incount-i);
         reqs.freeNonPersReq(pptr, array_of_requests[i]);
+        *outcount = 1;
         CkAssert(pptr->numBlockedReqs == 0);
         return MPI_SUCCESS;
       }
@@ -6451,9 +6459,9 @@ AMPI_API_IMPL(int, MPI_Testsome, int incount, MPI_Request *array_of_requests, in
     testRequest(pptr, &array_of_requests[i], &flag, &sts);
     if (flag) {
       array_of_indices[(*outcount)] = i;
-      (*outcount)++;
       if (array_of_statuses != MPI_STATUSES_IGNORE)
         array_of_statuses[(*outcount)] = sts;
+      (*outcount)++;
     }
   }
 


### PR DESCRIPTION
MPI_Waitsome and Testsome require users to be aware of the difference between NULL and
valid requests. AMPI used to return MPI_REQUEST_NULL for eagerly sent messages, in order
to avoid the overhead of request creation. Now we pool requests anyways, so just make the
real requests. Also fix an indexing error in Waitsome and Testsome.