### PR TITLE
Fix tlsglobals migration on macOS

### DIFF
--- a/src/conv-core/threads.C
+++ b/src/conv-core/threads.C
@@ -622,7 +622,7 @@ static void CthInterceptionsCreate(CthThread th)
       tlsptr = CmiIsomallocContextMallocAlign(base->isomallocContext, tlsdesc.align, tlsdesc.size);
     else
       tlsptr = CmiAlignedAlloc(tlsdesc.align, tlsdesc.size);
-    base->tlsseg = CmiTLSCreateSegUsingPtr(tlsptr);
+    CmiTLSCreateSegUsingPtr(&CpvAccess(Cth_PE_TLS), &base->tlsseg, tlsptr);
   }
   else
   {
@@ -656,11 +656,9 @@ static void CthBaseInit(char **argv)
   CpvAccess(Cth_serialNo) = 1;
 
 #if CMK_THREADS_BUILD_TLS
-  CmiTLSInit();
-  CmiThreadIs_flag |= CMI_THREAD_IS_TLS;
-
   CpvInitialize(tlsseg_t, Cth_PE_TLS);
-  CmiTLSSegmentGet(&CpvAccess(Cth_PE_TLS));
+  CmiTLSInit(&CpvAccess(Cth_PE_TLS));
+  CmiThreadIs_flag |= CMI_THREAD_IS_TLS;
 #endif
 }
 

--- a/src/util/cmitls.C
+++ b/src/util/cmitls.C
@@ -35,11 +35,6 @@ extern int quietModeRequested;
  * Of note are sections 3.4.2 (IA-32, a.k.a. x86) and 3.4.6 (x86-64).
  */
 
-extern "C" {
-void* getTLS();
-void setTLS(void*);
-}
-
 #if CMK_TLS_SWITCHING_X86_64
 # define CMK_TLS_X86_MOV "movq"
 # ifdef __APPLE__
@@ -47,12 +42,50 @@ void setTLS(void*);
 # else
 #  define CMK_TLS_X86_REG "fs"
 # endif
+# define CMK_TLS_X86_WIDTH "8"
 #elif CMK_TLS_SWITCHING_X86
 # define CMK_TLS_X86_MOV "movl"
 # define CMK_TLS_X86_REG "gs"
+# define CMK_TLS_X86_WIDTH "4"
 #else
 # define CMK_TLS_SWITCHING_UNAVAILABLE
 #endif
+
+#ifdef __APPLE__
+
+extern "C" {
+void* getTLSForKey(size_t);
+void setTLSForKey(size_t, void*);
+}
+
+void* getTLSForKey(size_t key)
+{
+#ifdef CMK_TLS_X86_MOV
+  void* ptr;
+  asm volatile (CMK_TLS_X86_MOV " %%" CMK_TLS_X86_REG ":0x0(,%1," CMK_TLS_X86_WIDTH "), %0\n"
+                : "=&r"(ptr)
+                : "r"(key));
+  return ptr;
+#else
+  return nullptr;
+#endif
+}
+
+void setTLSForKey(size_t key, void* newptr)
+{
+#ifdef CMK_TLS_X86_MOV
+  asm volatile (CMK_TLS_X86_MOV " %0, %%" CMK_TLS_X86_REG ":0x0(,%1," CMK_TLS_X86_WIDTH ")\n"
+                :
+                : "r"(newptr), "r"(key));
+#endif
+}
+
+#else
+
+extern "C" {
+void* getTLS();
+void setTLS(void*);
+}
 
 void* getTLS()
 {
@@ -69,17 +102,18 @@ void* getTLS()
 void setTLS(void* newptr)
 {
 #ifdef CMK_TLS_X86_MOV
-  asm volatile (CMK_TLS_X86_MOV " %0, %%" CMK_TLS_X86_REG ":0x0\n\t"
+  asm volatile (CMK_TLS_X86_MOV " %0, %%" CMK_TLS_X86_REG ":0x0\n"
                 :
                 : "r"(newptr));
 #endif
 }
 
+#endif
+
 
 // ----- TLS segment size determination -----
 
 static tlsdesc_t CmiTLSDescription;
-static tlsseg_t CmiTLSPrimarySegment;
 
 #if CMK_HAS_DL_ITERATE_PHDR
 
@@ -114,7 +148,45 @@ static inline void CmiTLSStatsInit(void)
 
 #elif defined __APPLE__
 
-// parts adapted from threadLocalVariables.c in dyld
+static constexpr size_t global_align = 16; // Apple uses alignment by 16
+
+# include <map>
+
+struct CmiTLSSegment
+{
+  const void * ptr;
+  size_t size;
+};
+static std::map<unsigned long, CmiTLSSegment> CmiTLSSegments;
+
+
+// things needed for GNU emutls
+
+# include <vector>
+# include <pthread.h>
+
+struct CmiTLSEmuTLSObject
+{
+  size_t size;
+  size_t align;
+  uintptr_t offset;
+  const void * initial;
+};
+
+static size_t CmiTLSSizeWithoutEmuTLS;
+static size_t CmiTLSEmuTLSNumObjects;
+static constexpr size_t CmiTLSEmuTLSArbitraryExtra = 32;
+static unsigned long CmiTLSEmuTLSKey;
+static std::vector<CmiTLSEmuTLSObject *> CmiTLSEmuTLSObjects;
+
+static inline size_t CmiTLSEmuTLSGetAlignedSize(size_t numobjects)
+{
+  const size_t size = sizeof(void *) * (2 /* emutls_array */ + numobjects + CmiTLSEmuTLSArbitraryExtra);
+  return CMIALIGN(size, global_align);
+}
+
+
+// things needed for TLV sections
 
 # include <mach-o/dyld.h>
 # include <mach-o/nlist.h>
@@ -135,9 +207,21 @@ static inline void CmiTLSStatsInit(void)
   typedef struct nlist macho_nlist;
 #endif
 
-static size_t GetTLVSizeFromMachOHeader()
+struct TLVDescriptor
+{
+  void * (*thunk)(struct TLVDescriptor *);
+  unsigned long key;
+  unsigned long offset;
+};
+
+
+static inline void CmiTLSStatsInit()
 {
   size_t totalsize = 0;
+  size_t total_emutls_num = 0;
+
+  // Parse all Mach-O headers to get TLS/TLV information.
+  // Adapted from threadLocalVariables.c in dyld.
 
   for (uint32_t c = 0; c < _dyld_image_count(); ++c)
   {
@@ -148,13 +232,16 @@ static size_t GetTLVSizeFromMachOHeader()
     CmiEnforce(mh_orig->magic == MACHO_HEADER_MAGIC);
     const auto mh = (const macho_header *)mh_orig;
     const auto mh_addr = (const char *)mh;
+    // const char * const name = _dyld_get_image_name(c);
 
-    const uint8_t * start = nullptr;
-    unsigned long size = 0;
+    uint64_t text_vmaddr = 0, linkedit_vmaddr = 0, linkedit_fileoff = 0;
     intptr_t slide = 0;
     bool slideComputed = false;
 
-    uint64_t text_vmaddr = 0, linkedit_vmaddr = 0, linkedit_fileoff = 0;
+    const uint8_t * start = nullptr;
+    unsigned long size = 0;
+    unsigned long key = 0;
+    bool haveKey = false;
 
     const uint32_t cmd_count = mh->ncmds;
     const auto cmds = (const struct load_command *)(mh_addr + sizeof(macho_header));
@@ -202,6 +289,23 @@ static size_t GetTLVSizeFromMachOHeader()
               size = newEnd - start;
             }
           }
+          else if (section_type == S_THREAD_LOCAL_VARIABLES)
+          {
+            const auto tlvstart = (const TLVDescriptor *)(sect->addr + slide);
+            const auto tlvend = (const TLVDescriptor *)(sect->addr + slide + sect->size);
+            for (const TLVDescriptor * d = tlvstart; d < tlvend; ++d)
+            {
+              if (haveKey)
+              {
+                CmiEnforce(d->key == key);
+              }
+              else
+              {
+                key = d->key;
+                haveKey = true;
+              }
+            }
+          }
         }
       }
       else if (lc_type == LC_SYMTAB && text_vmaddr)
@@ -218,12 +322,19 @@ static size_t GetTLVSizeFromMachOHeader()
             continue;
 
           static const char emutls_prefix[] = "___emutls_v.";
+          static constexpr size_t emutls_prefix_len = sizeof(emutls_prefix)-1;
           const char * const symname = strtab + nl->n_un.n_strx;
-          if (strncmp(symname, emutls_prefix, sizeof(emutls_prefix)-1) == 0)
+          if (strncmp(symname, emutls_prefix, emutls_prefix_len) == 0)
           {
-            const auto addr = (const size_t *)(nl->n_value + slide);
-            const size_t symsize = *addr;
-            totalsize += symsize;
+            const auto obj = (CmiTLSEmuTLSObject *)(nl->n_value + slide);
+
+            // Save this object pointer for later. We need all fields in the struct.
+            // Don't consider the placeholders for migration, since we need emutls to allocate them itself.
+            static const char CmiTLSPlaceholder_prefix[] = "CmiTLSPlaceholder";
+            if (strncmp(symname + emutls_prefix_len, CmiTLSPlaceholder_prefix, sizeof(CmiTLSPlaceholder_prefix)-1) != 0)
+              CmiTLSEmuTLSObjects.emplace_back(obj);
+
+            ++total_emutls_num;
           }
         }
       }
@@ -231,16 +342,47 @@ static size_t GetTLVSizeFromMachOHeader()
       cmd = (const struct load_command *)(((const char *)cmd) + cmd->cmdsize);
     }
 
-    totalsize += size;
+    // Add any TLV section found in this image.
+    CmiEnforce(haveKey == (size > 0));
+    if (size > 0)
+    {
+      const size_t alignedsize = CMIALIGN(size, global_align);
+
+      const bool didInsert = CmiTLSSegments.emplace(key, CmiTLSSegment{start, alignedsize}).second;
+      CmiEnforce(didInsert);
+
+      totalsize += alignedsize;
+    }
   }
 
-  return totalsize;
-}
+  // Tabulate the results.
 
-static inline void CmiTLSStatsInit(void)
-{
-  CmiTLSDescription.size = GetTLVSizeFromMachOHeader();
-  CmiTLSDescription.align = 16; // Apple uses alignment by 16
+  CmiTLSSizeWithoutEmuTLS = totalsize;
+
+  if (total_emutls_num > 0)
+  {
+    // Predict the value that emutls_key will be after emutls_init is called.
+    pthread_key_t fakekey;
+    pthread_key_create(&fakekey, nullptr);
+    CmiTLSEmuTLSKey = fakekey + 1;
+    CmiTLSEmuTLSNumObjects = total_emutls_num;
+
+    totalsize += CmiTLSEmuTLSGetAlignedSize(total_emutls_num);
+
+    // Assign emutls offsets.
+    // Leave room for the placeholders to take the first indexes so that the first one calls emutls_init.
+    size_t migratable_emutls_idx = total_emutls_num - CmiTLSEmuTLSObjects.size();
+    for (CmiTLSEmuTLSObject * obj : CmiTLSEmuTLSObjects)
+    {
+      obj->offset = ++migratable_emutls_idx;
+      size_t size = CMIALIGN(obj->size, obj->align);
+      size = CMIALIGN(size, global_align);
+      totalsize += size;
+    }
+  }
+
+  CmiTLSDescription.size = totalsize;
+  CmiTLSDescription.align = global_align;
 }
 
 #elif CMK_HAS_ELF_H && CMK_DLL_USE_DLOPEN && CMK_HAS_RTLD_DEFAULT
@@ -324,7 +466,22 @@ static inline void CmiTLSStatsInit()
 
 // ----- CmiTLS implementation -----
 
-void CmiTLSInit()
+extern thread_local int CmiTLSPlaceholderInt;
+thread_local int CmiTLSPlaceholderInt = -1;
+
+struct CmiTLSPlaceholderWithConstructor
+{
+  CmiTLSPlaceholderWithConstructor()
+  {
+    data = -1;
+  }
+  int data;
+};
+
+extern thread_local CmiTLSPlaceholderWithConstructor CmiTLSPlaceholderStruct;
+thread_local CmiTLSPlaceholderWithConstructor CmiTLSPlaceholderStruct{};
+
+void CmiTLSInit(tlsseg_t * newThreadParent)
 {
 #ifdef CMK_TLS_SWITCHING_UNAVAILABLE
   CmiAbort("TLS globals are not supported.");
@@ -340,8 +497,74 @@ void CmiTLSInit()
     }
 
     CmiTLSStatsInit();
-    CmiTLSPrimarySegment.memseg = (Addr)getTLS();
   }
+
+#ifdef __APPLE__
+  // Allocate our own thread-local storage for each PE's parent so that CmiTLSSegmentSet
+  // is simple and tlsseg_t does not need to contain a std::map of keys to pointers.
+
+  CmiNodeAllBarrier();
+
+  void * memseg = CmiAlignedAlloc(CmiTLSDescription.align, CmiTLSDescription.size);
+  memset(memseg, 0, CmiTLSDescription.size);
+
+  auto data = (char *)memseg;
+  for (const auto & tlv : CmiTLSSegments)
+  {
+    const void * const ptr = tlv.second.ptr;
+    const size_t size = tlv.second.size;
+
+    memcpy(data, ptr, size);
+
+    data += size;
+  }
+
+  const size_t total_emutls_num = CmiTLSEmuTLSNumObjects;
+  if (total_emutls_num > 0)
+  {
+    *(size_t *)data = total_emutls_num + CmiTLSEmuTLSArbitraryExtra;
+    auto ptrs = (void **)data;
+    size_t my_emutls_size = CmiTLSEmuTLSGetAlignedSize(total_emutls_num);
+    data += my_emutls_size;
+
+    // Fill in emutls pointers and copy initial values.
+    for (CmiTLSEmuTLSObject * obj : CmiTLSEmuTLSObjects)
+    {
+      size_t size = CMIALIGN(obj->size, obj->align);
+      size = CMIALIGN(size, global_align);
+
+      ptrs[obj->offset] = data;
+
+      if (obj->initial != nullptr)
+        memcpy(data, obj->initial, obj->size);
+
+      data += size;
+      my_emutls_size += size;
+    }
+
+    CmiNodeAllBarrier();
+
+    if (CmiMyRank() == 0)
+    {
+      // Add this entry for CmiTLSSegmentSet.
+      const bool didInsert = CmiTLSSegments.emplace(CmiTLSEmuTLSKey, CmiTLSSegment{nullptr, my_emutls_size}).second;
+      CmiEnforce(didInsert);
+    }
+
+    CmiNodeAllBarrier();
+  }
+
+  newThreadParent->memseg = memseg;
+
+  // Replace the default key values with our custom ones packed into a single buffer.
+  CmiTLSSegmentSet(newThreadParent);
+#else
+  newThreadParent->memseg = (Addr)getTLS();
+#endif
+
+  // If emutls is active, setting these will eventually call emutls_init, which we need.
+  CmiTLSPlaceholderInt = CmiMyPe();
+  CmiTLSPlaceholderStruct.data = CmiMyRank();
 #endif
 }
 
@@ -350,29 +573,59 @@ tlsdesc_t CmiTLSGetDescription()
   return CmiTLSDescription;
 }
 
-tlsseg_t CmiTLSCreateSegUsingPtr(void * ptr)
+void CmiTLSCreateSegUsingPtr(const tlsseg_t * threadParent, tlsseg_t * t, void * ptr)
 {
-  tlsseg_t t{};
   auto memseg = (char *)ptr;
-  memcpy(memseg, (char *)CmiTLSPrimarySegment.memseg - CmiTLSDescription.size, CmiTLSDescription.size);
-  t.memseg = (Addr)(memseg + CmiTLSDescription.size);
-  /* printf("[%d] 2 ALIGN %d MEM %p SIZE %d\n", CmiMyPe(), CmiTLSDescription.align, t.memseg, CmiTLSDescription.size); */
-  return t;
+
+#ifdef __APPLE__
+  memcpy(memseg, threadParent->memseg, CmiTLSDescription.size);
+
+  // Fill in emutls pointers.
+  auto ptrs = (void **)((char *)memseg + CmiTLSSizeWithoutEmuTLS);
+  auto data = (char *)ptrs + CmiTLSEmuTLSGetAlignedSize(CmiTLSEmuTLSNumObjects);
+  for (CmiTLSEmuTLSObject * obj : CmiTLSEmuTLSObjects)
+  {
+    size_t size = CMIALIGN(obj->size, obj->align);
+    size = CMIALIGN(size, global_align);
+
+    ptrs[obj->offset] = data;
+
+    data += size;
+  }
+
+  t->memseg = memseg;
+#else
+  memcpy(memseg, (const char *)threadParent->memseg - CmiTLSDescription.size, CmiTLSDescription.size);
+
+  t->memseg = (Addr)(memseg + CmiTLSDescription.size);
+  /* printf("[%d] 2 ALIGN %d MEM %p SIZE %d\n", CmiMyPe(), CmiTLSDescription.align, t->memseg, CmiTLSDescription.size); */
+#endif
 }
 
 void * CmiTLSGetBuffer(tlsseg_t * t)
 {
+#ifdef __APPLE__
+  return t->memseg;
+#else
   return (char *)t->memseg - CmiTLSDescription.size;
-}
-
-void CmiTLSSegmentGet(tlsseg_t * cur)
-{
-  cur->memseg = (Addr)getTLS();
+#endif
 }
 
 void CmiTLSSegmentSet(tlsseg_t * next)
 {
+#ifdef __APPLE__
+  auto data = (char *)next->memseg;
+  for (const auto & tlv : CmiTLSSegments)
+  {
+    const unsigned long key = tlv.first;
+    const size_t size = tlv.second.size;
+
+    setTLSForKey(key, data);
+    data += size;
+  }
+#else
   setTLS((void*)next->memseg);
+#endif
 }
 
 #endif

--- a/src/util/cmitls.h
+++ b/src/util/cmitls.h
@@ -45,13 +45,12 @@ typedef struct tlsseg {
 extern "C" {
 #endif
 
-void CmiTLSInit(void);
+void CmiTLSInit(tlsseg_t * newThreadParent);
 
 tlsdesc_t CmiTLSGetDescription(void);
-tlsseg_t CmiTLSCreateSegUsingPtr(void *);
+void CmiTLSCreateSegUsingPtr(const tlsseg_t * threadParent, tlsseg_t * t, void * ptr);
 void * CmiTLSGetBuffer(tlsseg_t *);
 
-void CmiTLSSegmentGet(tlsseg_t *);
 void CmiTLSSegmentSet(tlsseg_t *);
 
 #ifdef __cplusplus


### PR DESCRIPTION
This commit implements the bookkeeping necessary for macOS to use
thread-local storage buffers as allocated by Isomalloc instead of
allocating and maintaining its own non-migratable buffers.