### PR TITLE
Remove thread_local with constructor from cmitls.C

### DIFF
--- a/src/util/cmitls.C
+++ b/src/util/cmitls.C
@@ -469,18 +469,6 @@ static inline void CmiTLSStatsInit()
 extern thread_local int CmiTLSPlaceholderInt;
 thread_local int CmiTLSPlaceholderInt = -1;
 
-struct CmiTLSPlaceholderWithConstructor
-{
-  CmiTLSPlaceholderWithConstructor()
-  {
-    data = -1;
-  }
-  int data;
-};
-
-extern thread_local CmiTLSPlaceholderWithConstructor CmiTLSPlaceholderStruct;
-thread_local CmiTLSPlaceholderWithConstructor CmiTLSPlaceholderStruct{};
-
 void CmiTLSInit(tlsseg_t * newThreadParent)
 {
 #ifdef CMK_TLS_SWITCHING_UNAVAILABLE
@@ -564,7 +552,6 @@ void CmiTLSInit(tlsseg_t * newThreadParent)
 
   // If emutls is active, setting these will eventually call emutls_init, which we need.
   CmiTLSPlaceholderInt = CmiMyPe();
-  CmiTLSPlaceholderStruct.data = CmiMyRank();
 #endif
 }
 


### PR DESCRIPTION
Should solve the following:

```
../bin/charmc  -optimize -production   -I.   -c -o cmitls.o cmitls.C
cmitls.C: In function â€˜void __tls_init()â€™:
cmitls.C:482:47: internal compiler error: Segmentation fault
 thread_local CmiTLSPlaceholderWithConstructor CmiTLSPlaceholderStruct{};
                                               ^
Please submit a full bug report,
with preprocessed source if appropriate.
See <file:///usr/share/doc/gcc-4.8/README.Bugs> for instructions.
Preprocessed source stored into /tmp/cckhEghy.out file, please attach this to your bugreport.
Fatal Error by charmc in directory /scratch/autobuild/netlrts-linux-x86_64-syncft/charm/netlrts-linux-x86_64-syncft/tmp
   Command g++ -DCMK_GFORTRAN -I../bin/../include -D__CHARMC__=1 -I. -O3 -fno-stack-protector -std=c++11 -c cmitls.C -o cmitls.o returned error code 1
charmc exiting...
```

If this passes verification then we should be able to do without this variable.