### PR TITLE
AMPI: increase objid collection bits for AMPI-only builds

### DIFF
--- a/build
+++ b/build
@@ -863,7 +863,10 @@ then
       # strip "-only" suffix from AMPI target
       PROGRAM="${PROGRAM%-only}"
     fi
-    OPTS="-DCMK_NO_INTEROP=1 -DCMK_NO_MSG_PRIOS=1 $OPTS "
+    # AMPI doesn't use Charm-MPI interop or msg priorities of any kind.
+    # AMPI creates O(NumVirtualRanks) chare arrays by default (for MPI_COMM_SELF),
+    # so we bump up the number of bits reserved for the collection in the objid.
+    OPTS="-DCMK_NO_INTEROP=1 -DCMK_NO_MSG_PRIOS=1 -DCMK_OBJID_COLLECTION_BITS=29 $OPTS "
     CONFIG_OPTS="--with-prio-type=char $CONFIG_OPTS "
 else
     echo "CMK_AMPI_ONLY=\"0\"" >> $ConvSh

--- a/buildcmake
+++ b/buildcmake
@@ -271,8 +271,11 @@ if [[ "$target" = "${target%AMPI-only}AMPI-only" ]]; then
     # strip "-only" suffix from AMPI target
     target="${target%AMPI-only}AMPI"
 
+    # AMPI doesn't use Charm-MPI interop or msg priorities of any kind.
+    # AMPI creates O(NumVirtualRanks) chare arrays by default (for MPI_COMM_SELF),
+    # so we bump up the number of bits reserved for the collection in the objid.
     opt_prio_type="char"
-    opt_extra_opts="-DCMK_NO_INTEROP=1 -DCMK_NO_MSG_PRIOS=1 $opt_extra_opts "
+    opt_extra_opts="-DCMK_NO_INTEROP=1 -DCMK_NO_MSG_PRIOS=1 -DCMK_OBJID_COLLECTION_BITS=29 $opt_extra_opts "
 fi
 
 opt_network=$(echo $triplet | cut -d '-' -f1)


### PR DESCRIPTION
This leaves 32 bits for the element id, 29 for the collection id, and 3 for the tag bits.