### PR TITLE
Improve portability of CmiMemoryAtomic*/ReadFence/WriteFence

### DIFF
--- a/src/arch/util/machine-smp.C
+++ b/src/arch/util/machine-smp.C
@@ -93,8 +93,8 @@ static struct CmiStateStruct Cmi_default_state; /* State structure to return dur
 
 #if CMK_SHARED_VARS_NT_THREADS
 
-CmiNodeLock CmiMemLock_lock;
-CmiNodeLock cmiMemoryLock;
+CmiNodeLock CmiMemLock_lock; // used by CmiMemLock during heap interception (charmc -memory)
+CmiNodeLock cmiMemoryLock; // used by CmiMemoryAtomic*/ReadFence/WriteFence and CMK_PCQUEUE_LOCK
 static CmiNodeLock comm_mutex;
 #define CmiCommLockOrElse(x) /*empty*/
 #define CmiCommLock() (CmiLock(comm_mutex))
@@ -239,8 +239,8 @@ static void CmiDestroyLocks(void)
 /***************** Pthreads kernel SMP threads ******************/
 #elif CMK_SHARED_VARS_POSIX_THREADS_SMP
 
-CmiNodeLock CmiMemLock_lock;
-CmiNodeLock cmiMemoryLock;
+CmiNodeLock CmiMemLock_lock; // used by CmiMemLock during heap interception (charmc -memory)
+CmiNodeLock cmiMemoryLock; // used by CmiMemoryAtomic*/ReadFence/WriteFence and CMK_PCQUEUE_LOCK
 int _Cmi_sleepOnIdle=0;
 int _Cmi_forceSpinOnIdle=0;
 extern std::atomic<int> _cleanUp;

--- a/src/arch/util/machine-smp.C
+++ b/src/arch/util/machine-smp.C
@@ -94,9 +94,7 @@ static struct CmiStateStruct Cmi_default_state; /* State structure to return dur
 #if CMK_SHARED_VARS_NT_THREADS
 
 CmiNodeLock CmiMemLock_lock;
-#if defined CMK_NEED_MEMORY_LOCK || CMK_PCQUEUE_LOCK
 CmiNodeLock cmiMemoryLock;
-#endif
 static CmiNodeLock comm_mutex;
 #define CmiCommLockOrElse(x) /*empty*/
 #define CmiCommLock() (CmiLock(comm_mutex))
@@ -199,9 +197,7 @@ static void CmiStartThreads(char **argv)
 
   CmiMemLock_lock=CmiCreateLock();
   comm_mutex = CmiCreateLock();
-#if defined CMK_NEED_MEMORY_LOCK || CMK_PCQUEUE_LOCK
   cmiMemoryLock = CmiCreateLock();
-#endif
 
   Cmi_state_key = TlsAlloc();
   if(Cmi_state_key == 0xFFFFFFFF) PerrorExit("TlsAlloc main");
@@ -237,18 +233,14 @@ static void CmiDestroyLocks(void)
   comm_mutex = 0;
   CmiDestroyLock(CmiMemLock_lock);
   CmiMemLock_lock = 0;
-#if defined CMK_NEED_MEMORY_LOCK || CMK_PCQUEUE_LOCK
   CmiDestroyLock(cmiMemoryLock);
-#endif
 }
 
 /***************** Pthreads kernel SMP threads ******************/
 #elif CMK_SHARED_VARS_POSIX_THREADS_SMP
 
 CmiNodeLock CmiMemLock_lock;
-#if defined CMK_NEED_MEMORY_LOCK || CMK_PCQUEUE_LOCK
 CmiNodeLock cmiMemoryLock;
-#endif
 int _Cmi_sleepOnIdle=0;
 int _Cmi_forceSpinOnIdle=0;
 extern std::atomic<int> _cleanUp;
@@ -428,9 +420,7 @@ static void CmiStartThreads(char **argv)
   MACHSTATE(4,"CmiStartThreads")
   CmiMemLock_lock=CmiCreateLock();
   _smp_mutex = CmiCreateLock();
-#if defined CMK_NEED_MEMORY_LOCK || CMK_PCQUEUE_LOCK
   cmiMemoryLock = CmiCreateLock();
-#endif
 
 #if ! (CMK_HAS_TLS_VARIABLES && !CMK_NOT_USE_TLS_THREAD)
   pthread_key_create(&Cmi_state_key, 0);
@@ -512,9 +502,7 @@ static void CmiDestroyLocks(void)
   comm_mutex = 0;
   CmiDestroyLock(CmiMemLock_lock);
   CmiMemLock_lock = 0;
-#if defined CMK_NEED_MEMORY_LOCK || CMK_PCQUEUE_LOCK
   CmiDestroyLock(cmiMemoryLock);
-#endif
 }
 
 #endif


### PR DESCRIPTION
* Disable C11 stdatomic.h support with GCC < 7.1 when OpenMP or
Objective-C are in use

* Add MSVC intrinsics for memory fences

* Always create cmiMemoryLock: it won't be obvious to the runtime, which
compiles as C++, if C user code such as the Converse tests need it, e.g.
for CpvInitialize