### PR TITLE
CDash updates

### DIFF
--- a/cdash/CTestTestfile.cmake
+++ b/cdash/CTestTestfile.cmake
@@ -1,4 +1,4 @@
-# Disable since that won't work in the cmake build:
+# Disabled since that won't work in the cmake build:
 # add_test(build-tests "make" "-C" "../tmp" "-j4" "all-test-tests" "all-test-examples" "all-test-benchmarks" "OPTS=\"-g\"")
 
 add_test(tests/ "make" "-C" "../tests" "test" "TESTOPTS=$ENV{AUTOBUILD_TEST_OPTS}")

--- a/cdash/CTestTestfile.cmake
+++ b/cdash/CTestTestfile.cmake
@@ -1,6 +1,9 @@
-# Disabled since that won't work in the cmake build:
-# add_test(build-tests "make" "-C" "../tmp" "-j4" "all-test-tests" "all-test-examples" "all-test-benchmarks" "OPTS=\"-g\"")
+# Build the tests using parallel make
+add_test(build-tests      "make" "-C" "../tests"      "-j4"  "OPTS=\"-g\"")
+add_test(build-examples   "make" "-C" "../examples"   "-j4"  "OPTS=\"-g\"")
+add_test(build-benchmarks "make" "-C" "../benchmarks" "-j4"  "OPTS=\"-g\"")
 
+# Run the tests
 add_test(tests/ "make" "-C" "../tests" "test" "TESTOPTS=$ENV{AUTOBUILD_TEST_OPTS}")
 set_tests_properties(tests/ PROPERTIES  TIMEOUT "2400")
 add_test(examples/ "make" "-C" "../examples" "test" "TESTOPTS=$ENV{AUTOBUILD_TEST_OPTS}")

--- a/cdash/CTestTestfile.cmake
+++ b/cdash/CTestTestfile.cmake
@@ -1,7 +1,9 @@
-add_test(build-tests "make" "-C" "../tmp" "-j4" "all-test-tests" "all-test-examples" "all-test-benchmarks" "OPTS=\"-g\"")
+# Disable since that won't work in the cmake build:
+# add_test(build-tests "make" "-C" "../tmp" "-j4" "all-test-tests" "all-test-examples" "all-test-benchmarks" "OPTS=\"-g\"")
+
 add_test(tests/ "make" "-C" "../tests" "test" "TESTOPTS=$ENV{AUTOBUILD_TEST_OPTS}")
-set_tests_properties(tests/ PROPERTIES  TIMEOUT "1200")
+set_tests_properties(tests/ PROPERTIES  TIMEOUT "2400")
 add_test(examples/ "make" "-C" "../examples" "test" "TESTOPTS=$ENV{AUTOBUILD_TEST_OPTS}")
-set_tests_properties(examples/ PROPERTIES  TIMEOUT "1200")
+set_tests_properties(examples/ PROPERTIES  TIMEOUT "2400")
 add_test(benchmarks/ "make" "-C" "../benchmarks" "test" "TESTOPTS=$ENV{AUTOBUILD_TEST_OPTS}")
-set_tests_properties(benchmarks/ PROPERTIES  TIMEOUT "1200")
+set_tests_properties(benchmarks/ PROPERTIES  TIMEOUT "2400")

--- a/cdash/run_autobuild.sh
+++ b/cdash/run_autobuild.sh
@@ -1,7 +1,7 @@
 #!/bin/bash --login
 # Use a --login shell to make sure modules etc. get loaded.
 
-set -o errexit -o nounset
+set -o nounset
 
 # Configuration starts here
 

--- a/cdash/run_autobuild.sh
+++ b/cdash/run_autobuild.sh
@@ -18,11 +18,9 @@ AUTOBUILD_TEST_OPTS=${AUTOBUILD_TEST_OPTS:-++local}
 ############################
 ############################
 
-# Check if we were started by cron
-PPPID=$(ps h -o ppid= $PPID)
-P_COMMAND=$(basename $(ps h -o comm= $PPPID))
-
-if [[ $P_COMMAND != "cron" && $P_COMMAND != "systemd" ]]; then
+# Check if we were started by cron or not
+# -t 1 => stdout is on a terminal
+if [[ -t 1 ]]; then
         # Interactive shell, run Experimental
         AUTOBUILD_CTEST_MODEL="Experimental"
 else


### PR DESCRIPTION
- Increase timeout for each test to 40 minutes.
- Split up building tests into tests/ examples/ benchmarks/ for better support with the cmake build system.
- Don't exit immediately on error in run_autobuild.sh (to make sure
  the build directory is cleaned up).
- More robust detection of whether the script was started by cron or not.