### PR TITLE
Clean up gfortran build system details

### DIFF
--- a/src/arch/common/cc-gcc.sh
+++ b/src/arch/common/cc-gcc.sh
@@ -16,7 +16,7 @@ CMK_PIC='-fPIC'
 if [ "$CMK_MACOSX" ]; then
   if [ -z "$CMK_COMPILER_SUFFIX" ]; then
     # find real gcc (not Apple's clang) in $PATH on darwin, works with homebrew/macports
-    candidates=$(which gcc gcc-{4..19} gcc-mp-{4..19} 2>/dev/null)
+    candidates=$(command -v gcc gcc-{19..4} gcc-mp-{19..4} 2>/dev/null)
     for cand in $candidates; do
       $cand -v 2>&1 | grep -q clang
       if [ $? -eq 1 ]; then
@@ -26,6 +26,7 @@ if [ "$CMK_MACOSX" ]; then
         CMK_LD="$cand "
         CMK_CXX="$cppcand "
         CMK_LDXX="$cppcand "
+        CMK_COMPILER_SUFFIX="${cand#gcc}"
 
         found=1
         break
@@ -56,3 +57,38 @@ if [ "$CMK_COMPILER" = "msvc" ]; then
 fi
 
 CMK_COMPILER='gcc'
+
+if command -v "gfortran$CMK_COMPILER_SUFFIX" 'gfortran' 'f95' >/dev/null 2>&1
+then
+  . $CHARMINC/conv-mach-gfortran.sh
+else
+  if command -v 'g77' >/dev/null 2>&1
+  then
+    CMK_CF77='g77'
+  elif command -v 'f77' >/dev/null 2>&1
+  then
+    CMK_CF77='f77'
+  fi
+  CMK_F77LIBS='-lg2c'
+
+  if command -v 'xlf90_r' >/dev/null 2>&1
+  then
+    # xlf
+    CMK_CF90='xlf90_r'
+    bindir=`dirname $(command -v $CMK_CF90)`
+    libdir="$bindir/../lib"
+    CMK_CF90="$CMK_CF90 -qpic=large -qthreaded -qlanglvl=90std -qwarn64 -qspill=32648 -qsuppress=1513-029:1518-012:1518-059 -qsuffix=f=f90:cpp=F90 "
+    CMK_CF90_FIXED="$CMK_CF90 -qsuffix=f=f:cpp=F -qfixed=132 "
+    CMK_F90LIBS="-L/opt/ibmcmp/xlf/11.1/bin/../../../xlsmp/1.7/lib -L$libdir -lxl -lxlf90 -lxlfmath -lxlopt -lxlsmp"
+    CMK_F90_USE_MODDIR=1
+    CMK_F90_MODINC='-I'
+  elif command -v 'f90' >/dev/null 2>&1
+  then
+    # absoft
+    CMK_CF90='f90'
+    CMK_CF90_FIXED="$CMK_CF90 -W132"
+    CMK_F90LIBS='-L/usr/absoft/lib -L/opt/absoft/lib -lf90math -lfio -lU77 -lf77math'
+    CMK_F90_USE_MODDIR=1
+    CMK_F90_MODINC='-p'
+  fi
+fi

--- a/src/arch/common/cc-icc.sh
+++ b/src/arch/common/cc-icc.sh
@@ -14,7 +14,7 @@ CMK_CF90="ifort -auto -fPIC "
 #CMK_CF90_FIXED="$CMK_CF90 -132 -FI "
 #FOR 64 bit machine
 CMK_CF90_FIXED="$CMK_CF90 -164 -FI "
-F90DIR=`which ifort 2> /dev/null`
+F90DIR=`command -v ifort 2> /dev/null`
 if test -x "$F90DIR"
 then
   MYDIR="$PWD"

--- a/src/arch/common/cc-pgcc.sh
+++ b/src/arch/common/cc-pgcc.sh
@@ -32,7 +32,7 @@ CMK_CF77="pgf77 "
 CMK_CF90="pgf90 "
 CMK_CF90_FIXED="$CMK_CF90 -Mfixed "
 f90libdir="."
-f90bindir=`which pgf90 2>/dev/null`
+f90bindir=`command -v pgf90 2>/dev/null`
 if test -n "$f90bindir"
 then
   f90libdir="$f90bindir/../lib"

--- a/src/arch/common/conv-mach-craype.sh
+++ b/src/arch/common/conv-mach-craype.sh
@@ -76,7 +76,7 @@ then
 CMK_CF77="ftn -auto "
 CMK_CF90="ftn -auto "
 
-F90DIR=`which ifort 2> /dev/null`
+F90DIR=`command -v ifort 2> /dev/null`
 if test -x "$F90DIR"
 then
   MYDIR="$PWD"

--- a/src/arch/common/conv-mach-gfortran.sh
+++ b/src/arch/common/conv-mach-gfortran.sh
@@ -4,16 +4,21 @@ CMK_CXX_FLAGS="$CMK_CXX_FLAGS -DCMK_GFORTRAN"
 if test -n "$CMK_MACOSX"
 then
 CMK_F90FLAGS="$CMK_F90FLAGS -fno-common"
-CMK_F77FLAGS="$CMK_F90FLAGS -fno-common"
+CMK_F77FLAGS="$CMK_F77FLAGS -fno-common"
 fi
 
 CMK_FPP="$CMK_CPP_C -P -CC"
 
-# Find common gfortran binary names, and choose the last one found
-# (presumably the most modern).
-CMK_CF90=$(which gfortran gfortran-{4..19} gfortran-mp-{4..19} 2>/dev/null | tail -1)
+CMK_CF90=''
 
-[ -z $CMK_CF90 ] && { echo 'No gfortran found, exiting'; exit 1; }
+# If using gcc, try to find the matching gfortran version
+[ "$CMK_COMPILER" = 'gcc' ] && command -v "gfortran$CMK_COMPILER_SUFFIX" >/dev/null 2>&1 && CMK_CF90="gfortran$CMK_COMPILER_SUFFIX"
+
+# Find common gfortran binary names, and choose the first one found
+# (presumably the most modern).
+[ -z "$CMK_CF90" ] && CMK_CF90=$(command -v gfortran f95 gfortran-{19..4} gfortran-mp-{19..4} 2>/dev/null | head -1)
+
+[ -z "$CMK_CF90" ] && { echo 'No gfortran found, exiting'; exit 1; }
 
 # Find libgfortran, which we need to link to manually as the C++ compiler does
 # the linking.

--- a/src/arch/common/conv-mach-ifort.sh
+++ b/src/arch/common/conv-mach-ifort.sh
@@ -3,7 +3,7 @@
 CMK_CF77="ifort -auto -fpic "
 CMK_CF90="ifort -auto -fpic "
 CMK_CF90_FIXED="$CMK_CF90 -132 -FI "
-F90DIR=`which ifort 2> /dev/null`
+F90DIR=`command -v ifort 2> /dev/null`
 if test -x "$F90DIR" 
 then
   MYDIR="$PWD"

--- a/src/arch/common/conv-mach-pgf90.sh
+++ b/src/arch/common/conv-mach-pgf90.sh
@@ -1,5 +1,5 @@
 COMMENT="Use pgf90 fortran compiler in $PG_DIR"
-PG_DIR=`which pgf90`
+PG_DIR=`command -v pgf90`
 if test x$PG_DIR = x 
 then
   echo charmc> Fatal error: pgf90 not found!

--- a/src/arch/mpi-linux-ppc/cc-mpicxx.sh
+++ b/src/arch/mpi-linux-ppc/cc-mpicxx.sh
@@ -30,7 +30,7 @@ CMK_LDXX="$CMK_CXX "
 CMK_CF77="mpif77 -auto -fPIC "
 CMK_CF90="mpif90 -auto -fPIC "
 CMK_CF90_FIXED="$CMK_CF90 -132 -FI "
-F90DIR=`which ifort 2> /dev/null`
+F90DIR=`command -v ifort 2> /dev/null`
 if test -x "$F90DIR"
 then
   MYDIR="$PWD"

--- a/src/arch/mpi-linux-x86_64/cc-mpicxx.sh
+++ b/src/arch/mpi-linux-x86_64/cc-mpicxx.sh
@@ -48,7 +48,7 @@ esac
 CMK_CF77="mpif77 -auto -fPIC "
 CMK_CF90="mpif90 -auto -fPIC "
 CMK_CF90_FIXED="$CMK_CF90 -132 -FI "
-F90DIR=`which ifort 2> /dev/null`
+F90DIR=`command -v ifort 2> /dev/null`
 if test -x "$F90DIR"
 then
   MYDIR="$PWD"

--- a/src/arch/multicore-arm7/conv-mach.sh
+++ b/src/arch/multicore-arm7/conv-mach.sh
@@ -10,26 +10,5 @@ CMK_CXX_OPTIMIZE="-O3"
 CMK_NO_PARTITIONS="1"
 
 CMK_QT='generic64-light'
-CMK_CF90=`which f95 2>/dev/null`
-if test -n "$CMK_CF90"
-then
-#    CMK_FPP="cpp -P -CC"
-#    CMK_CF90="$CMK_CF90 -fpic -fautomatic -fdollar-ok "
-#    CMK_CF90_FIXED="$CMK_CF90 -ffixed-form "
-#    CMK_F90LIBS="-lgfortran "
-#    CMK_F90_USE_MODDIR=1
-#    CMK_F90_MODINC="-I"
-#    CMK_MOD_NAME_ALLCAPS=
-#    CMK_MOD_EXT="mod"
-    . $CHARMINC/conv-mach-gfortran.sh
-else
-    CMK_CF77="g77 "
-    CMK_CF90="f90 "
-    CMK_CF90_FIXED="$CMK_CF90 -W132 "
-    CMK_F90LIBS="-L/usr/absoft/lib -L/opt/absoft/lib -lf90math -lfio -lU77 -lf77math "
-    CMK_F77LIBS="-lg2c "
-    CMK_F90_USE_MODDIR=1
-    CMK_F90_MODINC="-p"
-fi
 
 CMK_MULTICORE='1'

--- a/src/arch/multicore-arm8/conv-mach.sh
+++ b/src/arch/multicore-arm8/conv-mach.sh
@@ -10,26 +10,5 @@ CMK_CXX_OPTIMIZE="-O3"
 CMK_NO_PARTITIONS="1"
 
 CMK_QT='generic64-light'
-CMK_CF90=`which f95 2>/dev/null`
-if test -n "$CMK_CF90"
-then
-#    CMK_FPP="cpp -P -CC"
-#    CMK_CF90="$CMK_CF90 -fpic -fautomatic -fdollar-ok "
-#    CMK_CF90_FIXED="$CMK_CF90 -ffixed-form "
-#    CMK_F90LIBS="-lgfortran "
-#    CMK_F90_USE_MODDIR=1
-#    CMK_F90_MODINC="-I"
-#    CMK_MOD_NAME_ALLCAPS=
-#    CMK_MOD_EXT="mod"
-    . $CHARMINC/conv-mach-gfortran.sh
-else
-    CMK_CF77="g77 "
-    CMK_CF90="f90 "
-    CMK_CF90_FIXED="$CMK_CF90 -W132 "
-    CMK_F90LIBS="-L/usr/absoft/lib -L/opt/absoft/lib -lf90math -lfio -lU77 -lf77math "
-    CMK_F77LIBS="-lg2c "
-    CMK_F90_USE_MODDIR=1
-    CMK_F90_MODINC="-p"
-fi
 
 CMK_MULTICORE='1'

--- a/src/arch/multicore-linux-ppc/conv-mach.sh
+++ b/src/arch/multicore-linux-ppc/conv-mach.sh
@@ -5,34 +5,6 @@ CMK_LIBS="$CMK_LIBS -lpthread"
 CMK_XIOPTS=''
 CMK_QT='generic64-light'
 
-# fortran compiler Absoft or gnu f95
-CMK_CF77='g77 '
-CMK_F77LIBS='-lg2c '
-CMK_CF90=`which xlf90_r 2>/dev/null`
-if test -n "$CMK_CF90"
-then
-# xlf
-  bindir=`dirname $CMK_CF90`
-  libdir="$bindir/../lib"
-  CMK_CF90="$CMK_CF90 -qpic=large -qthreaded -qlanglvl=90std -qwarn64 -qspill=32648 -qsuppress=1513-029:1518-012:1518-059 -qsuffix=f=f90:cpp=F90 "
-  CMK_CF90_FIXED="$CMK_CF90 -qsuffix=f=f:cpp=F -qfixed=132 "
-  CMK_F90LIBS="-L/opt/ibmcmp/xlf/11.1/bin/../../../xlsmp/1.7/lib -L$libdir -lxl -lxlf90 -lxlfmath -lxlopt -lxlsmp"
-  CMK_F90_USE_MODDIR=1
-  CMK_F90_MODINC='-I'
-else
-# gnu f95
-  CMK_CF90=`which f95 2>/dev/null`
-  if test -n "$CMK_CF90"
-  then
-    CMK_FPP='cpp -P -CC'
-    CMK_CF90="$CMK_CF90 -fpic -fautomatic -fdollar-ok "
-    CMK_CF90_FIXED="$CMK_CF90 -ffixed-form "
-    CMK_F90LIBS='-lgfortran '
-    CMK_F90_USE_MODDIR=1
-    CMK_F90_MODINC='-I'
-  fi
-fi
-
 CMK_MULTICORE='1'
 CMK_SMP='1'
 CMK_NO_PARTITIONS="1"

--- a/src/arch/multicore-linux32/conv-mach.sh
+++ b/src/arch/multicore-linux32/conv-mach.sh
@@ -5,14 +5,6 @@ CMK_DEFS="$CMK_DEFS -D_REENTRANT -m32"
 CMK_XIOPTS=''
 CMK_LIBS="-lpthread $CMK_LIBS"
 
-CMK_CF77='g77 '
-CMK_CF90='f90 '
-CMK_CF90_FIXED="$CMK_CF90 -W132 "
-CMK_F90LIBS='-L/usr/absoft/lib -L/opt/absoft/lib -lf90math -lfio -lU77 -lf77math '
-CMK_F77LIBS='-lg2c '
-CMK_F90_USE_MODDIR=1
-CMK_F90_MODINC='-p'
-
 CMK_QT='generic64-light'
 
 CMK_MULTICORE='1'

--- a/src/arch/multicore-linux64/conv-mach.sh
+++ b/src/arch/multicore-linux64/conv-mach.sh
@@ -5,20 +5,6 @@ CMK_DEFS="$CMK_DEFS -D_REENTRANT"
 CMK_XIOPTS=''
 CMK_LIBS="-lpthread $CMK_LIBS"
 
-CMK_CF90=`which f95 2>/dev/null`
-if test -n "$CMK_CF90"
-then
-    . $CHARMINC/conv-mach-gfortran.sh
-else
-    CMK_CF77='g77 '
-    CMK_CF90='f90 '
-    CMK_CF90_FIXED="$CMK_CF90 -W132 "
-    CMK_F90LIBS='-lf90math -lfio -lU77 -lf77math '
-    CMK_F77LIBS='-lg2c '
-    CMK_F90_USE_MODDIR=1
-    CMK_F90_MODINC='-p'
-fi
-
 CMK_QT='generic64-light'
 
 CMK_MULTICORE='1'

--- a/src/arch/netlrts-linux-arm7/conv-mach.sh
+++ b/src/arch/netlrts-linux-arm7/conv-mach.sh
@@ -7,24 +7,3 @@ CMK_WARNINGS_ARE_ERRORS='-Werror'
 CMK_CXX_OPTIMIZE='-O3'
 
 CMK_QT='generic64-light'
-CMK_CF90=`which f95 2>/dev/null`
-if test -n "$CMK_CF90"
-then
-#    CMK_FPP="cpp -P -CC"
-#    CMK_CF90="$CMK_CF90 -fpic -fautomatic -fdollar-ok "
-#    CMK_CF90_FIXED="$CMK_CF90 -ffixed-form "
-#    CMK_F90LIBS="-lgfortran "
-#    CMK_F90_USE_MODDIR=1
-#    CMK_F90_MODINC="-I"
-#    CMK_MOD_NAME_ALLCAPS=
-#    CMK_MOD_EXT="mod"
-    . $CHARMINC/conv-mach-gfortran.sh
-else
-    CMK_CF77='g77 '
-    CMK_CF90='f90 '
-    CMK_CF90_FIXED="$CMK_CF90 -W132 "
-    CMK_F90LIBS='-L/usr/absoft/lib -L/opt/absoft/lib -lf90math -lfio -lU77 -lf77math '
-    CMK_F77LIBS='-lg2c '
-    CMK_F90_USE_MODDIR=1
-    CMK_F90_MODINC='-p'
-fi

--- a/src/arch/netlrts-linux-arm8/conv-mach.sh
+++ b/src/arch/netlrts-linux-arm8/conv-mach.sh
@@ -7,24 +7,3 @@ CMK_WARNINGS_ARE_ERRORS='-Werror'
 CMK_CXX_OPTIMIZE='-O3'
 
 CMK_QT='generic64-light'
-CMK_CF90=`which f95 2>/dev/null`
-if test -n "$CMK_CF90"
-then
-#    CMK_FPP="cpp -P -CC"
-#    CMK_CF90="$CMK_CF90 -fpic -fautomatic -fdollar-ok "
-#    CMK_CF90_FIXED="$CMK_CF90 -ffixed-form "
-#    CMK_F90LIBS="-lgfortran "
-#    CMK_F90_USE_MODDIR=1
-#    CMK_F90_MODINC="-I"
-#    CMK_MOD_NAME_ALLCAPS=
-#    CMK_MOD_EXT="mod"
-    . $CHARMINC/conv-mach-gfortran.sh
-else
-    CMK_CF77='g77 '
-    CMK_CF90='f90 '
-    CMK_CF90_FIXED="$CMK_CF90 -W132 "
-    CMK_F90LIBS='-L/usr/absoft/lib -L/opt/absoft/lib -lf90math -lfio -lU77 -lf77math '
-    CMK_F77LIBS='-lg2c '
-    CMK_F90_USE_MODDIR=1
-    CMK_F90_MODINC='-p'
-fi

--- a/src/arch/netlrts-linux-ppc/conv-mach.sh
+++ b/src/arch/netlrts-linux-ppc/conv-mach.sh
@@ -6,25 +6,3 @@ CMK_WARNINGS_ARE_ERRORS='-Werror'
 CMK_CXX_OPTIMIZE='-O3'
 
 CMK_QT='generic64-light'
-
-CMK_CF90=`which f95 2>/dev/null`
-if test -n "$CMK_CF90"
-then
-#    CMK_FPP="cpp -P -CC"
-#    CMK_CF90="$CMK_CF90 -fpic -fautomatic -fdollar-ok "
-#    CMK_CF90_FIXED="$CMK_CF90 -ffixed-form "
-#    CMK_F90LIBS="-lgfortran "
-#    CMK_F90_USE_MODDIR=1
-#    CMK_F90_MODINC="-I"
-#    CMK_MOD_NAME_ALLCAPS=
-#    CMK_MOD_EXT="mod"
-    . $CHARMINC/conv-mach-gfortran.sh
-else
-    CMK_CF77='g77 '
-    CMK_CF90='f90 '
-    CMK_CF90_FIXED="$CMK_CF90 -W132 "
-    CMK_F90LIBS='-L/usr/absoft/lib -L/opt/absoft/lib -lf90math -lfio -lU77 -lf77math '
-    CMK_F77LIBS='-lg2c '
-    CMK_F90_USE_MODDIR=1
-    CMK_F90_MODINC='-p'
-fi

--- a/src/arch/netlrts-linux-x86_64/conv-mach.sh
+++ b/src/arch/netlrts-linux-x86_64/conv-mach.sh
@@ -6,25 +6,3 @@ CMK_WARNINGS_ARE_ERRORS='-Werror'
 CMK_CXX_OPTIMIZE='-O3'
 
 CMK_QT='generic64-light'
-
-CMK_CF90=`which f95 2>/dev/null`
-if test -n "$CMK_CF90"
-then
-#    CMK_FPP="cpp -P -CC"
-#    CMK_CF90="$CMK_CF90 -fpic -fautomatic -fdollar-ok "
-#    CMK_CF90_FIXED="$CMK_CF90 -ffixed-form "
-#    CMK_F90LIBS="-lgfortran "
-#    CMK_F90_USE_MODDIR=1
-#    CMK_F90_MODINC="-I"
-#    CMK_MOD_NAME_ALLCAPS=
-#    CMK_MOD_EXT="mod"
-    . $CHARMINC/conv-mach-gfortran.sh
-else
-    CMK_CF77='g77 '
-    CMK_CF90='f90 '
-    CMK_CF90_FIXED="$CMK_CF90 -W132 "
-    CMK_F90LIBS='-L/usr/absoft/lib -L/opt/absoft/lib -lf90math -lfio -lU77 -lf77math '
-    CMK_F77LIBS='-lg2c '
-    CMK_F90_USE_MODDIR=1
-    CMK_F90_MODINC='-p'
-fi

--- a/src/arch/netlrts-linux/conv-mach.sh
+++ b/src/arch/netlrts-linux/conv-mach.sh
@@ -10,47 +10,6 @@ CMK_LDXX_FLAGS="$CMK_CXX_FLAGS "
 CMK_XIOPTS=''
 CMK_QT='i386-gcc'
 
-CMK_CF90=`which f95 2>/dev/null`
-if test -n "$CMK_CF90"
-then
-    . $CHARMINC/conv-mach-gfortran.sh
-else
-
-# fortran compiler f77 or gnu f95
-CMK_CF77=`which g77 2>/dev/null`
-if test -z "$CMK_CF77"
-then
-  CMK_CF77=`which f77 2>/dev/null`
-fi
-if test -n "$CMK_CF77"
-then
-  CMK_F77LIBS='-lg2c '
-fi
-
-CMK_CF90=`which f90 2>/dev/null`
-if test -n "$CMK_CF90"
-then
-# absoft
-  CMK_CF90_FIXED="$CMK_CF90 -W132 "
-  CMK_F90LIBS='-L/usr/absoft/lib -L/opt/absoft/lib -lf90math -lfio -lU77 -lf77math '
-  CMK_F90_USE_MODDIR=1
-  CMK_F90_MODINC='-p'
-else
-# gnu f95
-  CMK_CF90=`which f95 2>/dev/null`
-  if test -n "$CMK_CF90"
-  then
-    CMK_FPP='cpp -P -CC'
-    CMK_CF90="$CMK_CF90 -fpic -fautomatic -fdollar-ok "
-    CMK_CF90_FIXED="$CMK_CF90 -ffixed-form "
-    CMK_F90LIBS='-lgfortran '
-    CMK_F90_USE_MODDIR=1
-    CMK_F90_MODINC='-I'
-  fi
-fi
-
-fi
-
 CMK_CF77="$CMK_CF77 -m32"
 CMK_CF90="$CMK_CF90 -m32"
 CMK_CF90_FIXED="$CMK_CF90_FIXED -m32"

--- a/src/arch/ofi-linux-x86_64/conv-mach.sh
+++ b/src/arch/ofi-linux-x86_64/conv-mach.sh
@@ -1,19 +1,5 @@
 . $CHARMINC/cc-gcc.sh
 
-CMK_CF90=`which f95 2>/dev/null`
-if test -n "$CMK_CF90"
-then
-    . $CHARMINC/conv-mach-gfortran.sh
-else
-    CMK_CF77='g77 '
-    CMK_CF90='f90 '
-    CMK_CF90_FIXED="$CMK_CF90 -W132 "
-    CMK_F90LIBS='-L/usr/absoft/lib -L/opt/absoft/lib -lf90math -lfio -lU77 -lf77math '
-    CMK_F77LIBS='-lg2c '
-    CMK_F90_USE_MODDIR=1
-    CMK_F90_MODINC='-p'
-fi
-
 # For libfabric
 #If the user doesn't pass --basedir, use defaults for libfabric headers and library
 if test -z "$USER_OPTS_LD"

--- a/src/arch/pami-linux-ppc64le/conv-mach.sh
+++ b/src/arch/pami-linux-ppc64le/conv-mach.sh
@@ -40,7 +40,7 @@ CMK_MOD_EXT='mod'
 CMK_F90_MODINC='-p'
 CMK_F90_USE_MODDIR=''
 
-F90DIR=`which ifort 2> /dev/null`
+F90DIR=`command -v ifort 2> /dev/null`
 if test -x "$F90DIR"
 then
   MYDIR="$PWD"

--- a/src/arch/ucx-linux-arm8/conv-mach.sh
+++ b/src/arch/ucx-linux-arm8/conv-mach.sh
@@ -1,19 +1,5 @@
 . $CHARMINC/cc-gcc.sh
 
-CMK_CF90=`which f95 2>/dev/null`
-if test -n "$CMK_CF90"
-then
-    . $CHARMINC/conv-mach-gfortran.sh
-else
-    CMK_CF77='g77 '
-    CMK_CF90='f90 '
-    CMK_CF90_FIXED="$CMK_CF90 -W132 "
-    CMK_F90LIBS='-L/usr/absoft/lib -L/opt/absoft/lib -lf90math -lfio -lU77 -lf77math '
-    CMK_F77LIBS='-lg2c '
-    CMK_F90_USE_MODDIR=1
-    CMK_F90_MODINC='-p'
-fi
-
 if test -z "$USER_OPTS_LD"
 then
     CMK_INCDIR="-I/usr/include/"

--- a/src/arch/ucx-linux-x86_64/conv-mach.sh
+++ b/src/arch/ucx-linux-x86_64/conv-mach.sh
@@ -1,19 +1,5 @@
 . $CHARMINC/cc-gcc.sh
 
-CMK_CF90=`which f95 2>/dev/null`
-if test -n "$CMK_CF90"
-then
-    . $CHARMINC/conv-mach-gfortran.sh
-else
-    CMK_CF77='g77 '
-    CMK_CF90='f90 '
-    CMK_CF90_FIXED="$CMK_CF90 -W132 "
-    CMK_F90LIBS='-L/usr/absoft/lib -L/opt/absoft/lib -lf90math -lfio -lU77 -lf77math '
-    CMK_F77LIBS='-lg2c '
-    CMK_F90_USE_MODDIR=1
-    CMK_F90_MODINC='-p'
-fi
-
 if test -z "$USER_OPTS_LD"
 then
     CMK_INCDIR="-I/usr/include/"

--- a/src/arch/uth-linux-x86_64/conv-mach.sh
+++ b/src/arch/uth-linux-x86_64/conv-mach.sh
@@ -1,10 +1,5 @@
 . $CHARMINC/cc-gcc.sh
 
-if command -v gfortran >/dev/null 2>&1
-then
-  . $CHARMINC/conv-mach-gfortran.sh
-fi
-
 CMK_CXX_FLAGS="$CMK_CXX_FLAGS -Wno-deprecated"
 CMK_QT='generic64-light'
 CMK_XIOPTS=''

--- a/src/arch/uth-linux/conv-mach.sh
+++ b/src/arch/uth-linux/conv-mach.sh
@@ -1,10 +1,5 @@
 . $CHARMINC/cc-gcc.sh
 
-if command -v gfortran >/dev/null 2>&1
-then
-  . $CHARMINC/conv-mach-gfortran.sh
-fi
-
 CMK_CXX_FLAGS="$CMK_CXX_FLAGS -Wno-deprecated"
 CMK_QT='generic'
 CMK_XIOPTS=''

--- a/src/arch/verbs-linux-ppc64le/conv-mach.sh
+++ b/src/arch/verbs-linux-ppc64le/conv-mach.sh
@@ -8,28 +8,6 @@ CMK_CXX_OPTIMIZE='-O3'
 
 CMK_QT='generic64-light'
 
-CMK_CF90=`which f95 2>/dev/null`
-if test -n "$CMK_CF90"
-then
-#    CMK_FPP="cpp -P -CC"
-#    CMK_CF90="$CMK_CF90 -fpic -fautomatic -fdollar-ok "
-#    CMK_CF90_FIXED="$CMK_CF90 -ffixed-form "
-#    CMK_F90LIBS="-lgfortran "
-#    CMK_F90_USE_MODDIR=1
-#    CMK_F90_MODINC="-I"
-#    CMK_MOD_NAME_ALLCAPS=
-#    CMK_MOD_EXT="mod"
-    . $CHARMINC/conv-mach-gfortran.sh
-else
-    CMK_CF77='g77 '
-    CMK_CF90='f90 '
-    CMK_CF90_FIXED="$CMK_CF90 -W132 "
-    CMK_F90LIBS='-L/usr/absoft/lib -L/opt/absoft/lib -lf90math -lfio -lU77 -lf77math '
-    CMK_F77LIBS='-lg2c '
-    CMK_F90_USE_MODDIR=1
-    CMK_F90_MODINC='-p'
-fi
-
 #default ibverbs path for openib
 if test -z "$CMK_INCDIR"
 then

--- a/src/arch/verbs-linux-x86_64/conv-mach.sh
+++ b/src/arch/verbs-linux-x86_64/conv-mach.sh
@@ -8,28 +8,6 @@ CMK_CXX_OPTIMIZE='-O3'
 
 CMK_QT='generic64-light'
 
-CMK_CF90=`which f95 2>/dev/null`
-if test -n "$CMK_CF90"
-then
-#    CMK_FPP="cpp -P -CC"
-#    CMK_CF90="$CMK_CF90 -fpic -fautomatic -fdollar-ok "
-#    CMK_CF90_FIXED="$CMK_CF90 -ffixed-form "
-#    CMK_F90LIBS="-lgfortran "
-#    CMK_F90_USE_MODDIR=1
-#    CMK_F90_MODINC="-I"
-#    CMK_MOD_NAME_ALLCAPS=
-#    CMK_MOD_EXT="mod"
-    . $CHARMINC/conv-mach-gfortran.sh
-else
-    CMK_CF77='g77 '
-    CMK_CF90='f90 '
-    CMK_CF90_FIXED="$CMK_CF90 -W132 "
-    CMK_F90LIBS='-L/usr/absoft/lib -L/opt/absoft/lib -lf90math -lfio -lU77 -lf77math '
-    CMK_F77LIBS='-lg2c '
-    CMK_F90_USE_MODDIR=1
-    CMK_F90_MODINC='-p'
-fi
-
 #default ibverbs path for openib
 if test -z "$CMK_INCDIR"
 then

--- a/src/scripts/conv-config.sh
+++ b/src/scripts/conv-config.sh
@@ -53,8 +53,7 @@ CMK_LD_SHARED="-shared"
 [ -z "$CMK_CF90_FIXED" ] && CMK_CF90_FIXED="$CMK_CF90"
 [ -z "$CMK_CC_RELIABLE" ] && CMK_CC_RELIABLE="$CMK_CC"
 [ -z "$CMK_CC_FASTEST" ] && CMK_CC_FASTEST="$CMK_CC"
-[ -z "$CMK_CC_RELIABLE" ] && CMK_CC_RELIABLE="$CMK_CC"
-[ -z "$CMK_CF77" ] && CMK_CF77_FIXED="$CMK_CF90"
+[ -z "$CMK_CF77" ] && CMK_CF77="$CMK_CF90"
 [ -z "$CMK_CF77_FIXED" ] && CMK_CF77_FIXED="$CMK_CF77"
 
 # set CMK_NATIVE defaults before adding potentially target-specific build-line args


### PR DESCRIPTION
Also tries to match gfortran version to gcc version if specified. For
example: `./build netlrts-linux-x86_64 gcc-8` will use gfortran-8.