### PR TITLE
Various cleanup relating to fsglobals work

### DIFF
--- a/build
+++ b/build
@@ -225,7 +225,6 @@ LIBDIR=
 INCDIR=
 ARCH=
 BUILD_SHARED=""             # default no shared lib
-WITH_ROMIO="true"           # default to building ROMIO on AMPI
 WITH_PRODUCTION=
 DESTINATION=""
 DESTINATION_SUFFIX=""
@@ -275,6 +274,16 @@ shift
 #echo $ARCH
 
 OPT_DIRS="$src/$BASEVERSION $src/$ARCH $src/common"
+
+# default to building ROMIO on AMPI where supported
+case "$BASEVERSION" in
+  *-win64*|*-win-*)
+    WITH_ROMIO=''
+    ;;
+  *)
+    WITH_ROMIO='true'
+    ;;
+esac
 
 # process remainder of version argument as options, copied from below
 for w in $VERSOPTS; do

--- a/buildcmake
+++ b/buildcmake
@@ -71,7 +71,6 @@ opt_qlogic=0
 opt_randomized_msgq=0
 opt_refnum_type="unsigned short"
 opt_replay=0
-opt_romio=1
 opt_shrinkexpand=0
 opt_smp=0
 opt_stats=0
@@ -81,6 +80,16 @@ opt_tcp=0
 opt_tracing=0
 opt_tracing_commthread=0
 opt_zlib=1
+
+# default to building ROMIO on AMPI where supported
+case "$triplet" in
+  *-win64*|*-win-*)
+    opt_romio=0
+    ;;
+  *)
+    opt_romio=1
+    ;;
+esac
 
 opt_CC= #undef
 opt_CXX= #undef

--- a/src/arch/common/cc-clang.sh
+++ b/src/arch/common/cc-clang.sh
@@ -19,6 +19,7 @@ if [ "$CMK_COMPILER" = "msvc" ]; then
   CMK_NATIVE_LDXX="$CMK_LDXX"
 fi
 
+CMK_PIC='' # empty string: will be reset to default by conv-config.sh
 CMK_PIE='-fPIE'
 
 CMK_COMPILER='clang'

--- a/src/arch/common/cc-gcc.sh
+++ b/src/arch/common/cc-gcc.sh
@@ -12,6 +12,7 @@ CMK_LD_LIBRARY_PATH="-Wl,-rpath,$CHARMLIBSO/"
 CMK_RANLIB='ranlib'
 CMK_LIBS="$CMK_LIBS -lckqt"
 CMK_PIC='-fPIC'
+CMK_PIE='' # empty string: will be reset to default by conv-config.sh
 
 if [ "$CMK_MACOSX" ]; then
   if [ -z "$CMK_COMPILER_SUFFIX" ]; then

--- a/src/arch/common/cc-msvc.sh
+++ b/src/arch/common/cc-msvc.sh
@@ -15,4 +15,8 @@ CMK_RANLIB="echo "
 CMK_LIBS=""
 CMK_MOD_EXT="vo"
 
+# space character: avoid reset to default by conv-config.sh
+CMK_PIC=' '
+CMK_PIE=' '
+
 CMK_COMPILER='msvc'

--- a/src/arch/win/unix2nt_cc
+++ b/src/arch/win/unix2nt_cc
@@ -160,6 +160,7 @@ DOCOMPILE=''
 DOASSEMBLE=''
 DOLINK=''
 DODEPS=''
+SHARED=''
 OUTPUT=''
 CL_OPTS="$CL_COMMON"
 ML_OPTS="$ML_COMMON"
@@ -182,6 +183,9 @@ do
 	case "$arg" in
 	-verbose)
 		VERBOSE='1'
+		;;
+	-shared)
+		SHARED='1'
 		;;
 	-E)
 		CL+=' -E'
@@ -211,6 +215,7 @@ do
 		ML_OPTS+=' -Zi -Zd'
 		LINK_OPTS+=' -DEBUG'
 		CL_MT='-MTd'
+		CL_DLL='-LDd'
 		;;
 	-c) 
 		CL+=' -c'
@@ -301,6 +306,11 @@ do
 		elif [[ "x`getExtension $out`" = "x.so" ]]
 		then
 			OUTPUT="-Fo`cygpath -w $out`"
+		elif [[ "x`getExtension $out`" = "x.dll" ]]
+		then
+			OUTPUT="-Fo`cygpath -w $out`"
+			LINK+=" -dll -out:$out"
+			DOLINK='1'
 		elif [[ "x`getExtension $out`" = "x.exe" ]]
 		then
 			LINK+=" -out:$out"
@@ -361,7 +371,7 @@ do
 	esac
 done
 
-CL_OPTS+=" $CL_MT"
+[[ -n "$SHARED" ]] && CL_OPTS+=" $CL_DLL" || CL_OPTS+=" $CL_MT"
 
 if [[ -n "$DODEPS" ]]
 then

--- a/src/arch/win/unix2nt_cc
+++ b/src/arch/win/unix2nt_cc
@@ -211,7 +211,7 @@ do
 		CL_OPTS+=' -DNDEBUG -Ox'
 		ML_OPTS+=' -DNDEBUG'
 		;;
-	-g)
+	-g|-g[123456789]|-ggdb|-ggdb[123])
 		CL_OPTS+=' -Z7'
 		ML_OPTS+=' -Zi -Zd'
 		LINK_OPTS+=' -DEBUG'

--- a/src/arch/win/unix2nt_cc
+++ b/src/arch/win/unix2nt_cc
@@ -56,13 +56,14 @@ ML_COMMON='-nologo -W1 -D_WINDOWS -DNOMINMAX'
 #Here, the full path to "link.exe" has to be added because, in cygwin, there
 #is a file "/usr/bin/link" which has the same name, and takes higher precedence
 #than the microsoft one.
+cl_path=`command -v cl`
 if [[ "`command -v link`" != '/usr/bin/link' ]]
 then
 LINK_CMD='link.exe'
-elif [[ -d "`cygpath -u \"$VCC_DIR/bin/HostX64/x64\"`" ]]
+elif [[ -d "`cygpath -u "${cl_path%cl}"`" ]]
 then
-LINK_CMD="$VCC_DIR/bin/HostX64/x64/link.exe"
-elif [[ -d "`cygpath -u \"$VCC_DIR/BIN/amd64\"`" ]]
+LINK_CMD="${cl_path%cl}link.exe"
+elif [[ -d "`cygpath -u "$VCC_DIR/BIN/amd64"`" ]]
 then
 LINK_CMD="$VCC_DIR/BIN/amd64/LINK.EXE"
 else

--- a/src/libs/ck-libs/ampi/pathstub.sh
+++ b/src/libs/ck-libs/ampi/pathstub.sh
@@ -2,6 +2,9 @@
 DIR=$(dirname $0)
 FN=$(basename $0)
 
+# protect rpath arguments from disappearing due to variable expansion
+ORIGIN='\$ORIGIN'
+
 # detect and handle circular calls when:
 # * building with the MPI machine layer
 # * using Charmrun's ++mpiexec

--- a/src/libs/conv-libs/openmp_llvm/runtime/src/kmp.h
+++ b/src/libs/conv-libs/openmp_llvm/runtime/src/kmp.h
@@ -230,6 +230,10 @@ typedef union kmp_team kmp_team_p;
 typedef union kmp_info kmp_info_p;
 typedef union kmp_root kmp_root_p;
 
+#if CHARM_OMP
+#include "ompcharm.h"
+#endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -1162,7 +1166,6 @@ typedef DWORD kmp_key_t;
 typedef pthread_t kmp_thread_t;
 typedef pthread_key_t kmp_key_t;
 #elif CHARM_OMP
-#include "ompcharm.h"
 typedef CthThread kmp_thread_t;
 typedef pthread_key_t kmp_key_t;
 #endif

--- a/src/scripts/configure.ac
+++ b/src/scripts/configure.ac
@@ -2360,7 +2360,7 @@ EOT
 TRACE_LINK_FLAG=''
 CAN_EXPORT_SYMBOLS='0'
 for i in '-rdynamic' '-Wl,--export-dynamic'; do
-  test_link "whether has $i" "yes" "no" "$i"
+  test_link "whether has $i" "yes" "no" "" "$i"
   if test "$strictpass" = '1'; then
     TRACE_LINK_FLAG="$i"
     CAN_EXPORT_SYMBOLS='1'


### PR DESCRIPTION
- Charmrun: Fix buffer overflow in local process launch on Windows
- unix2nt_cc: Recognize additional variants of -g
- Windows: Fix /usr/bin/link workaround with VS 2017 and newer
- Windows: Don't try to build ROMIO by default
- Windows: Avoid -fPIC and -fPIE unknown argument warnings
- unix2nt_cc: Add support for creating DLLs
- AMPI: Add $ORIGIN safeguard to pathstub.sh
- configure: Fix -rdynamic test when using clang
- src/libs/conv-libs/openmp_llvm: Fix "error: template with C linkage"

(Please rebase as a merge strategy.)