### PR TITLE
Ensure a PE that is initially underloaded never tries to transfer load.

### DIFF
--- a/src/ck-ldb/DistributedLB.C
+++ b/src/ck-ldb/DistributedLB.C
@@ -156,11 +156,14 @@ void DistributedLB::LoadReduction(CkReductionMsg* redn_msg) {
   // can receive more work. So assuming there exists an overloaded PE that can
   // donate work, I will start gossipping my load information.
   if (my_load < transfer_threshold) {
+    underloaded = true;
 		double r_loads[1];
 		int r_pe_no[1];
     r_loads[0] = my_load;
     r_pe_no[0] = CkMyPe();
     GossipLoadInfo(CkMyPe(), 1, r_pe_no, r_loads);
+  } else {
+    underloaded = false;
   }
 
   // Start quiescence detection at PE 0.
@@ -289,7 +292,7 @@ void DistributedLB::DoneGossip() {
 }
 
 void DistributedLB::StartNextLBPhase() {
-  if (underloaded_pe_count == 0 || my_load <= transfer_threshold) {
+  if (underloaded_pe_count == 0 || my_load <= transfer_threshold || underloaded) {
     // If this PE has no information about underloaded processors, or it has
     // no objects to donate to underloaded processors then do nothing.
     DoneWithLBPhase();

--- a/src/ck-ldb/DistributedLB.h
+++ b/src/ck-ldb/DistributedLB.h
@@ -47,6 +47,7 @@ private:
   std::vector<int> pe_no;
   std::vector<double> loads;
   std::vector<double> distribution;
+  bool underloaded;
 
   minHeap* objs;
 


### PR DESCRIPTION
With the new multiphase approach, as load thresholds change, it was possible
before that a PE which had accepted load became "overloaded" at a certain
threshold and would try to transfer load. This behavior could cause crashes
and/or hangs under the right circumstances and was never intended.