### PR TITLE
cdash/ctest: Fix test directories on Windows

### DIFF
--- a/cdash/CTestTestfile.cmake
+++ b/cdash/CTestTestfile.cmake
@@ -1,12 +1,17 @@
+# Determine where the tests/ examples/ benchmarks/ directories are.
+# Necessary for Windows, which does not have the usual tmp etc. symlinks.
+file(GLOB_RECURSE mydir FOLLOW_SYMLINKS  ../*/include/VERSION) # The '*' is the dir we want.
+get_filename_component(mydir ${mydir} DIRECTORY)
+
 # Build the tests using parallel make
-add_test(build-tests      "make" "-C" "../tests"      "-j4"  "OPTS=\"-g\"")
-add_test(build-examples   "make" "-C" "../examples"   "-j4"  "OPTS=\"-g\"")
-add_test(build-benchmarks "make" "-C" "../benchmarks" "-j4"  "OPTS=\"-g\"")
+add_test(build-tests      "make" "-C" "${mydir}/../tests"      "-j4"  "OPTS=\"-g\"")
+add_test(build-examples   "make" "-C" "${mydir}/../examples"   "-j4"  "OPTS=\"-g\"")
+add_test(build-benchmarks "make" "-C" "${mydir}/../benchmarks" "-j4"  "OPTS=\"-g\"")
 
 # Run the tests
-add_test(tests/ "make" "-C" "../tests" "test" "TESTOPTS=$ENV{AUTOBUILD_TEST_OPTS}")
+add_test(tests/ "make" "-C" "${mydir}/../tests" "test" "TESTOPTS=$ENV{AUTOBUILD_TEST_OPTS}")
 set_tests_properties(tests/ PROPERTIES  TIMEOUT "2400")
-add_test(examples/ "make" "-C" "../examples" "test" "TESTOPTS=$ENV{AUTOBUILD_TEST_OPTS}")
+add_test(examples/ "make" "-C" "${mydir}/../examples" "test" "TESTOPTS=$ENV{AUTOBUILD_TEST_OPTS}")
 set_tests_properties(examples/ PROPERTIES  TIMEOUT "2400")
-add_test(benchmarks/ "make" "-C" "../benchmarks" "test" "TESTOPTS=$ENV{AUTOBUILD_TEST_OPTS}")
+add_test(benchmarks/ "make" "-C" "${mydir}/../benchmarks" "test" "TESTOPTS=$ENV{AUTOBUILD_TEST_OPTS}")
 set_tests_properties(benchmarks/ PROPERTIES  TIMEOUT "2400")


### PR DESCRIPTION
On Windows systems, `./build` does not create the usual top-level `bin`, `tmp`, etc. symlinks, which ctest used to find the directory of tests to run. This patch changes this to determine the name of the directory where the `include/VERSION` file is located, and use that directory to locate the `tests/`, `examples/`, and `benchmarks/` directories. 

Note that this might fail when there are multiple builds within the same charm directory, as there will be multiple `include/VERSION` files. Since this is meant just for automated test builds, we can ignore this limitation for now.