### PR TITLE
Iterative LB example to demonstrate hang with CMK_GLOBAL_LOCATION_UPDATE

### DIFF
--- a/examples/charm++/load_balancing/iterative/Makefile
+++ b/examples/charm++/load_balancing/iterative/Makefile
@@ -1,0 +1,24 @@
+OPTS = -O0 -g
+
+CHARM_DIR = ../../../..
+CHARMC = $(CHARM_DIR)/bin/charmc $(OPTS)
+CHARM_INC = -I$(CHARM_DIR)/include
+
+LD_LIBS =
+
+TARGET = iterative
+all: $(TARGET)
+
+OBJS = $(TARGET).o
+
+$(TARGET): $(OBJS)
+		$(CHARMC) -language charm++ -module CommonLBs -o $@ $(OBJS) $(LD_LIBS)
+
+$(TARGET).decl.h: $(TARGET).ci
+		$(CHARMC) $<
+
+$(TARGET).o: $(TARGET).C $(TARGET).decl.h $(TARGET).def.h
+		$(CHARMC) -c $<
+
+clean:
+		rm -f *.decl.h *.def.h conv-host *.o $(TARGET) charmrun

--- a/examples/charm++/load_balancing/iterative/iterative.C
+++ b/examples/charm++/load_balancing/iterative/iterative.C
@@ -1,0 +1,100 @@
+#include "iterative.decl.h"
+
+/* readonly */ CProxy_Main main_proxy;
+/* readonly */ CProxy_Test test_proxy;
+/* readonly */ int n_iters;
+/* readonly */ int data_size;
+
+class Main : public CBase_Main {
+  double start_time;
+
+public:
+  Main(CkArgMsg* m) {
+    main_proxy = thisProxy;
+    n_iters = 1;
+    data_size = 128;
+
+    // Check if there are 2 PEs
+    if (CkNumPes() != 2) {
+      CkAbort("Should be run with 2 PEs");
+    }
+
+    // Process command line arguments
+    int c;
+    while ((c = getopt(m->argc, m->argv, "i:s:")) != -1) {
+      switch (c) {
+        case 'i':
+          n_iters = atoi(optarg);
+          break;
+        case 's':
+          data_size = atoi(optarg);
+          break;
+        default:
+          CkAbort("Unknown command line argument detected");
+      }
+    }
+    delete m;
+
+    // Print info
+    CkPrintf("[Load balancing itertions test]\n"
+        "Iters: %d, Data size: %d bytes\n", n_iters, data_size);
+
+    // Create chares
+    test_proxy = CProxy_Test::ckNew(CkNumPes());
+
+    // Begin testing
+    thisProxy.test();
+  }
+
+  void test() {
+    start_time = CkWallTimer();
+
+    CkPrintf("Testing chare array... ");
+    for (int i = 0; i < n_iters; i++) {
+      // XXX: Hangs after 1st LB with CkCallbackResumeThread.
+      //      With CkWaitQD, LB is performed only once.
+      test_proxy[0].send(CkCallbackResumeThread());
+      //CkWaitQD();
+    }
+    CkPrintf("PASS\n");
+
+    CkPrintf("Elapsed: %.6lf s\n", CkWallTimer() - start_time);
+    CkExit();
+  }
+};
+
+class Test : public CBase_Test {
+  int pe;
+  CkCallback cb;
+
+public:
+  Test() {
+    usesAtSync = true;
+  }
+
+  Test(CkMigrateMessage* m) {}
+
+  void pup(PUP::er& p) {
+    p|pe;
+    p|cb;
+  }
+
+  void send(CkCallback cb) {
+    char data[data_size];
+    thisProxy[1].recv(cb, data_size, data);
+    pe = CkMyPe();
+    AtSync();
+  }
+
+  void recv(CkCallback cb, int size, char* data) {
+    this->cb = cb;
+    pe = CkMyPe();
+    AtSync();
+  }
+
+  void ResumeFromSync() {
+    if (thisIndex == 1) cb.send();
+  }
+};
+
+#include "iterative.def.h"

--- a/examples/charm++/load_balancing/iterative/iterative.ci
+++ b/examples/charm++/load_balancing/iterative/iterative.ci
@@ -1,0 +1,17 @@
+mainmodule iterative {
+  readonly CProxy_Main main_proxy;
+  readonly CProxy_Test test_proxy;
+  readonly int n_iters;
+  readonly int data_size;
+
+  mainchare Main {
+    entry Main(CkArgMsg* m);
+    entry [threaded] void test();
+  };
+
+  array [1D] Test {
+    entry Test();
+    entry void send(CkCallback cb);
+    entry void recv(CkCallback cb, int size, char data[size]);
+  };
+};


### PR DESCRIPTION
The added example (`examples/charm++/load_balancing/iterative`) demonstrates a hang with LB when Charm++ is compiled with `CMK_GLOBAL_LOCATION_UPDATE`. Also confirmed that it doesn't hang without `CMK_GLOBAL_LOCATION_UPDATE`. Tested on LLNL Lassen.

Charm++ build command: `./build charm++ ucx-linux-ppc64le smp ompipmix -j -g -O0 --basedir=$HOME/openmpi-4.0.1/install -DCMK_GLOBAL_LOCATION_UPDATE`

Test command: `jsrun -n2 -a1 -c2 -g1 -K1 -r2 ./iterative -i 100 +ppn 1 +pemap L0,80 +commap L4,84 +balancer RotateLB +LBDebug 1`

Output:
```
Charm++> Running in SMP mode: 2 processes, 1 worker threads (PEs) + 1 comm threads per process, 2 PEs total
Charm++> The comm. thread both sends and receives messages
Converse/Charm++ Commit ID: v6.11.0-devel-208-g4ad39a43d
Isomalloc> Synchronized global address space.
CharmLB> Verbose level 1, load balancing period: -1 seconds
CharmLB> Load balancer assumes all CPUs are same.
Charm++> cpu affinity enabled.
Charm++> cpuaffinity PE-core map (logical indices): 0,80
HWLOC> [0] Thread 0x200001331640 bound to cpuset: 0x00000100
Charm++> Running on 1 hosts (2 sockets x 20 cores x 4 PUs = 160-way SMP)
Charm++> cpu topology info is gathered in 0.003 seconds.
CharmLB> RotateLB created.
[Load balancing itertions test]
Iters: 100, Data size: 128 bytes
Testing chare array...
CharmLB> RotateLB: PE [0] step 0 starting at 0.012207 Memory: 236.687500 MB
CharmLB> RotateLB: PE [0] strategy starting at 0.012472
CharmLB> RotateLB: PE [0] Memory: LBManager: 37 KB CentralLB: 1 KB
CharmLB> RotateLB: PE [0] #Objects migrating: 2, LBMigrateMsg size: 0.00 MB
CharmLB> RotateLB: PE [0] strategy finished at 0.012478 duration 0.000007 s
CharmLB> RotateLB: PE [0] step 0 finished at 0.012588 duration 0.000380 s
```