### PR TITLE
LocMgr: Fix IDs for CMK_GLOBAL_LOCATION_UPDATE

### DIFF
--- a/src/ck-core/cklocation.C
+++ b/src/ck-core/cklocation.C
@@ -2513,7 +2513,7 @@ int CkLocMgr::deliverMsg(CkArrayMessage *msg, CkArrayID mgr, CmiUInt8 id, const 
     // LB deals in IDs with collection information only when CMK_GLOBAL_LOCATION_UPDATE
     // is enabled, so add the group information if so.
 #if CMK_GLOBAL_LOCATION_UPDATE
-    const CmiUInt8 lbObjId = ck::ObjID(thisgroup.idx, id).getID();
+    const CmiUInt8 lbObjId = ck::ObjID(getGroupID(), id).getID();
 #else
     const CmiUInt8 lbObjId = id;
 #endif

--- a/src/ck-core/cklocation.C
+++ b/src/ck-core/cklocation.C
@@ -1800,9 +1800,7 @@ CkLocRec::CkLocRec(CkLocMgr *mgr,bool fromMigration,
 	if(_lb_args.metaLbOn())
 	  the_metalb=mgr->getMetaBalancer();
 #if CMK_GLOBAL_LOCATION_UPDATE
-	CmiUInt8 locMgrGid = mgr->getGroupID().idx;
-	id_ = ck::ObjID(id_).getElementID();
-	id_ |= locMgrGid << ck::ObjID().ELEMENT_BITS;
+	id_ = ck::ObjID(mgr->getGroupID(), id_).getID();
 #endif        
 	ldHandle=lbmgr->RegisterObj(mgr->getOMHandle(),
 		id_, (void *)this,1);

--- a/src/ck-core/cklocation.C
+++ b/src/ck-core/cklocation.C
@@ -2513,7 +2513,7 @@ int CkLocMgr::deliverMsg(CkArrayMessage *msg, CkArrayID mgr, CmiUInt8 id, const 
     // LB deals in IDs with collection information only when CMK_GLOBAL_LOCATION_UPDATE
     // is enabled, so add the group information if so.
 #if CMK_GLOBAL_LOCATION_UPDATE
-    const CmiUInt8 lbObjId = ck::ObjID(getGroupID(), id).getID();
+    const CmiUInt8 lbObjId = ck::ObjID(thisgroup, id).getID();
 #else
     const CmiUInt8 lbObjId = id;
 #endif
@@ -3296,5 +3296,4 @@ void CkLocMgr::doneInserting(void)
 #endif
 
 #include "CkLocation.def.h"
-
 


### PR DESCRIPTION
CkLocMgr deals only with element IDs. This fixes the pathway where
CMK_GLOBAL_LOCATION_UPDATE is enabled so that it does not pass IDs
with collection information to CkLocMgr functions