### PR TITLE
Converse randomttl benchmark: Move variable init to main function

### DIFF
--- a/benchmarks/converse/randomttl/randomttl.C
+++ b/benchmarks/converse/randomttl/randomttl.C
@@ -166,7 +166,7 @@ CmiStartFn mymain(int argc, char *argv[])
   std::srand (unsigned(std::time(0)) + CmiMyPe());
 
   // set values to Pes
-  for (int i=0; i <  CmiNumPes(); i++) CpvAccess(peVector).push_back(i);
+  for (int i=0; i < CmiNumPes(); i++) CpvAccess(peVector).push_back(i);
 
   // using built-in random generator
   std::random_shuffle(CpvAccess(peVector).begin(), CpvAccess(peVector).end());

--- a/benchmarks/converse/randomttl/randomttl.C
+++ b/benchmarks/converse/randomttl/randomttl.C
@@ -36,6 +36,7 @@ std::mt19937 gen(rd());
 
 // Method to get a random value from the peVector
 int getRandomKFromPeVector() {
+  CmiAssert(CpvAccess(peVector).size() == CmiNumPes());
   std::vector<int>::iterator start = CpvAccess(peVector).begin();
   std::vector<int>::iterator end = CpvAccess(peVector).end();
 
@@ -49,18 +50,11 @@ void handleInitiate(char *initiateMsg) {
 
   CmiFree(initiateMsg);
 
-  std::srand (unsigned(std::time(0)) + CmiMyPe());
-
   // Create a message to hold an integer
   ttlMsg *msg = (ttlMsg *)CmiAlloc(sizeof(ttlMsg));
   msg->ttlVal = CpvAccess(ttl);
   CmiSetHandler(msg, CpvAccess(ttlMsgHandler));
 
-  // set values to Pes
-  for (int i=0; i <  CmiNumPes(); i++) CpvAccess(peVector).push_back(i);
-
-  // using built-in random generator
-  std::random_shuffle(CpvAccess(peVector).begin(), CpvAccess(peVector).end());
 
   // send messages to random k pes
   for (int i=0; i < CpvAccess(k); i++) {
@@ -95,8 +89,8 @@ void handleCompletion(ttlMsg *msg) {
   if(CpvAccess(compCounter) == CpvAccess(k) * CmiNumPes()) { // All launched ttls are complete
 
     CpvAccess(endTime) = CmiWallTimer();
-    CmiPrintf("[%d][%d][%d] Random TTL Completed, time taken is %lf us\n", CmiMyPe(), CmiMyNode(),
-                                                  CmiMyRank(), 1e6*(CpvAccess(endTime)-CpvAccess(startTime)));
+    CmiPrintf("[%d][%d][%d] Random TTL Completed, time taken is %lf s\n", CmiMyPe(), CmiMyNode(),
+                                                  CmiMyRank(), (CpvAccess(endTime)-CpvAccess(startTime)));
     // Exit, reuse msg
     CmiSetHandler(msg, CpvAccess(exitHandler));
     CmiSyncBroadcastAllAndFree(sizeof(ttlMsg), msg);
@@ -168,6 +162,14 @@ CmiStartFn mymain(int argc, char *argv[])
     if(CmiMyPe() == 0)
       CmiAbort("Usage: ./randomttl <k> <ttl>\n");
   }
+
+  std::srand (unsigned(std::time(0)) + CmiMyPe());
+
+  // set values to Pes
+  for (int i=0; i <  CmiNumPes(); i++) CpvAccess(peVector).push_back(i);
+
+  // using built-in random generator
+  std::random_shuffle(CpvAccess(peVector).begin(), CpvAccess(peVector).end());
 
   if(CmiMyPe() == 0) {
     if(CpvAccess(k) > CmiNumPes())

--- a/benchmarks/converse/randomttl/randomttl.C
+++ b/benchmarks/converse/randomttl/randomttl.C
@@ -166,7 +166,8 @@ CmiStartFn mymain(int argc, char *argv[])
   std::srand (unsigned(std::time(0)) + CmiMyPe());
 
   // set values to Pes
-  for (int i=0; i < CmiNumPes(); i++) CpvAccess(peVector).push_back(i);
+  CpvAccess(peVector).resize(CmiNumPes());
+  std::iota(CpvAccess(peVector).begin(), CpvAccess(peVector).end(), 0);
 
   // using built-in random generator
   std::random_shuffle(CpvAccess(peVector).begin(), CpvAccess(peVector).end());


### PR DESCRIPTION
This fixes the crash in the program caused because of accessing
variables before their initialization. Previously, the vector 'peVector'
was being accessed by a message handler function before the values in
'peVector' were set.