### PR TITLE
cmake: clean up extra args parsing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -118,7 +118,9 @@ option(BUILD_CUDA          "Build with CUDA support" OFF)
 set(UCX_PMI "" CACHE STRING "PMI type for UCX layer, can be one of simplepmi, simplepmi2, or ompipmix")
 
 set(EXTRA_OPTS "" CACHE STRING "Extra flags to pass to compilers.")
-add_compile_options(${EXTRA_OPTS})
+
+separate_arguments(MY_EXTRA_OPTS UNIX_COMMAND ${EXTRA_OPTS})
+add_compile_options("${MY_EXTRA_OPTS}")
 
 set(CMK_REPLAYSYSTEM ${REPLAY})
 

--- a/cmake/README.md
+++ b/cmake/README.md
@@ -55,5 +55,6 @@ Currently, the CMake build system has the following limitations.
 
 - No Windows support. 
 - No support for `gni-*` and `*-crayx?` targets.
-- Not all options available in the old build system are supported (e.g. those that
-  require specifying `-D` options).
+- Not all options available in the old build system are supported
+
+See https://github.com/UIUC-PPL/charm/issues/2839 for details.

--- a/cmake/README.md
+++ b/cmake/README.md
@@ -55,6 +55,6 @@ Currently, the CMake build system has the following limitations.
 
 - No Windows support. 
 - No support for `gni-*` and `*-crayx?` targets.
-- Not all options available in the old build system are supported
+- Not all options available in the old build system are supported.
 
 See https://github.com/UIUC-PPL/charm/issues/2839 for details.


### PR DESCRIPTION
no functional change, just removes quotes from command line passed to charmc.