### PR TITLE
Use CkReferenceMsg to avoid duplicating TreeLB messages

### DIFF
--- a/src/ck-ldb/TreeLB.C
+++ b/src/ck-ldb/TreeLB.C
@@ -317,6 +317,9 @@ void TreeLB::loadBalanceSubtree(int level)
     else
     {
       decisions[i]->level = level;
+      // Necessary because in some cases every message in decisions is actually
+      // the same message that we are reusing, so mark as unused
+      _SET_USED(UsrToEnv(decisions[i]), 0);
       thisProxy[children[curr_child++]].sendDecisionDown((CkMessage*)decisions[i]);
     }
   }
@@ -359,6 +362,9 @@ void TreeLB::sendDecisionDown(CkMessage* msg)
     for (int i = 0; i < children.size(); i++)
     {
       decisions[i + 1]->level = level;
+      // Necessary because in some cases every message in decisions is actually
+      // the same message that we are reusing, so mark as unused
+      _SET_USED(UsrToEnv(decisions[i + 1]), 0);
       thisProxy[children[i]].sendDecisionDown((CkMessage*)decisions[i + 1]);
     }
   }

--- a/src/ck-ldb/TreeLevel.h
+++ b/src/ck-ldb/TreeLevel.h
@@ -552,7 +552,9 @@ class RootLevel : public LevelLogic
       decisions.resize(num_children);
       decisions[0] = migMsg;
       for (int i = 1; i < num_children; i++)
-        decisions[i] = (TreeLBMessage*)CkCopyMsg((void**)&migMsg);
+      {
+        decisions[i] = CkReferenceMsg(migMsg);
+      }
     }
     else
     {
@@ -635,7 +637,9 @@ class RootLevel : public LevelLogic
       decisions.resize(num_children);
       decisions[0] = migMsg;
       for (int i = 1; i < num_children; i++)
-        decisions[i] = (TreeLBMessage*)CkCopyMsg((void**)&migMsg);
+      {
+        decisions[i] = CkReferenceMsg(migMsg);
+      }
     }
   }
 
@@ -881,7 +885,9 @@ class NodeSetLevel : public LevelLogic
     decisions.resize(num_children);
     decisions[0] = migMsg;
     for (int i = 1; i < num_children; i++)
-      decisions[i] = (TreeLBMessage*)CkCopyMsg((void**)&migMsg);
+    {
+      decisions[i] = CkReferenceMsg(migMsg);
+    }
     migMsg = nullptr;
   }
 
@@ -975,7 +981,9 @@ class NodeLevel : public LevelLogic
       // just forward decision from root to children
       decisions[0] = decision;
       for (int i = 1; i < pes.size(); i++)
-        decisions[i] = (TreeLBMessage*)CkCopyMsg((void**)&decision);
+      {
+        decisions[i] = CkReferenceMsg(decision);
+      }
     }
   }
 
@@ -1025,7 +1033,9 @@ class NodeLevel : public LevelLogic
     stats_msgs.clear();
     decisions[0] = migMsg;
     for (int i = 1; i < pes.size(); i++)
-      decisions[i] = (TreeLBMessage*)CkCopyMsg((void**)&migMsg);
+    {
+      decisions[i] = CkReferenceMsg(migMsg);
+    }
   }
 
   LBManager* lbmgr;
@@ -1226,7 +1236,9 @@ class MsgAggregator : public LevelLogic
     decisions.resize(num_children + 1);
     decisions[0] = decision;
     for (int i = 1; i < num_children + 1; i++)
-      decisions[i] = (TreeLBMessage*)CkCopyMsg((void**)&decision);
+    {
+      decisions[i] = CkReferenceMsg(decision);
+    }
   }
 
  protected:

--- a/src/ck-ldb/TreeLevel.h
+++ b/src/ck-ldb/TreeLevel.h
@@ -553,7 +553,8 @@ class RootLevel : public LevelLogic
       decisions[0] = migMsg;
       for (int i = 1; i < num_children; i++)
       {
-        decisions[i] = CkReferenceMsg(migMsg);
+        CkReferenceMsg(migMsg);
+        decisions[i] = migMsg;
       }
     }
     else
@@ -638,7 +639,8 @@ class RootLevel : public LevelLogic
       decisions[0] = migMsg;
       for (int i = 1; i < num_children; i++)
       {
-        decisions[i] = CkReferenceMsg(migMsg);
+        CkReferenceMsg(migMsg);
+        decisions[i] = migMsg;
       }
     }
   }
@@ -886,7 +888,8 @@ class NodeSetLevel : public LevelLogic
     decisions[0] = migMsg;
     for (int i = 1; i < num_children; i++)
     {
-      decisions[i] = CkReferenceMsg(migMsg);
+      CkReferenceMsg(migMsg);
+      decisions[i] = migMsg;
     }
     migMsg = nullptr;
   }
@@ -982,7 +985,8 @@ class NodeLevel : public LevelLogic
       decisions[0] = decision;
       for (int i = 1; i < pes.size(); i++)
       {
-        decisions[i] = CkReferenceMsg(decision);
+        CkReferenceMsg(decision);
+        decisions[i] = decision;
       }
     }
   }
@@ -1034,7 +1038,8 @@ class NodeLevel : public LevelLogic
     decisions[0] = migMsg;
     for (int i = 1; i < pes.size(); i++)
     {
-      decisions[i] = CkReferenceMsg(migMsg);
+      CkReferenceMsg(migMsg);
+      decisions[i] = migMsg;
     }
   }
 
@@ -1237,7 +1242,8 @@ class MsgAggregator : public LevelLogic
     decisions[0] = decision;
     for (int i = 1; i < num_children + 1; i++)
     {
-      decisions[i] = CkReferenceMsg(decision);
+      CkReferenceMsg(decision);
+      decisions[i] = decision;
     }
   }
 


### PR DESCRIPTION
Closes #2857.