### PR TITLE
Add CkReferenceMsg function

### DIFF
--- a/src/ck-core/charm.h
+++ b/src/ck-core/charm.h
@@ -109,6 +109,7 @@ extern void  CkFreeSysMsg(void *msg);
 extern void* CkAllocBuffer(void *msg, int bufsize);
 extern void  CkFreeMsg(void *msg);
 extern void* CkCopyMsg(void **pMsg);
+extern void* CkReferenceMsg(void *msg);
 extern void  CkSetQueueing(void *msg, int strategy);
 extern void* CkPriorityPtr(void *msg);
 

--- a/src/ck-core/debug-charm.C
+++ b/src/ck-core/debug-charm.C
@@ -66,8 +66,7 @@ void CpdBeforeEp(int ep, void *obj, void *msg) {
     entry.memoryBackup = NULL;
     entry.obj = obj;
     if (msg != NULL) {
-      entry.msg = msg;
-      CkReferenceMsg(msg);
+      entry.msg = CkReferenceMsg(msg);
     }
     else entry.msg = NULL;
     _debugData.push(entry);

--- a/src/ck-core/debug-charm.C
+++ b/src/ck-core/debug-charm.C
@@ -67,7 +67,7 @@ void CpdBeforeEp(int ep, void *obj, void *msg) {
     entry.obj = obj;
     if (msg != NULL) {
       entry.msg = msg;
-      CmiReference(UsrToEnv(msg));
+      CkReferenceMsg(msg);
     }
     else entry.msg = NULL;
     _debugData.push(entry);

--- a/src/ck-core/msgalloc.C
+++ b/src/ck-core/msgalloc.C
@@ -95,6 +95,12 @@ void* CkCopyMsg(void **pMsg)
   return srcMsg;
 }
 
+void* CkReferenceMsg(void* msg)
+{
+  CmiReference(UsrToEnv(msg));
+  return msg;
+}
+
 void  CkSetQueueing(void *msg, int strategy)
 {
   UsrToEnv(msg)->setQueueing((unsigned char) strategy);

--- a/src/ck-core/sdag.h
+++ b/src/ck-core/sdag.h
@@ -76,7 +76,7 @@ namespace SDAG {
       init();
       setRefnum(CkGetRefNum(msg));
       continuations = 0;
-      CmiReference(UsrToEnv(msg));
+      CkReferenceMsg(msg);
     }
 
     void pup(PUP::er& p) {
@@ -84,7 +84,7 @@ namespace SDAG {
       p | hasMsg;
       if (hasMsg) CkPupMessage(p, (void**)&msg);
       if (hasMsg && p.isUnpacking())
-        CmiReference(UsrToEnv(msg));
+        CkReferenceMsg(msg);
       packClosure(p);
     }
 

--- a/src/libs/ck-libs/ampi/ampi.C
+++ b/src/libs/ck-libs/ampi/ampi.C
@@ -2737,7 +2737,7 @@ void ampi::inorderBcast(AmpiMsg* msg, bool deleteMsg) noexcept
     req->receive(this, msg, deleteMsg);
   } else {
     // Reference the [nokeep] msg so it isn't freed by the runtime
-    CmiReference(UsrToEnv(msg));
+    CkReferenceMsg(msg);
     unexpectedBcastMsgs.put(msg);
   }
 }
@@ -3911,7 +3911,7 @@ void AmpiSeqQ::putOutOfOrder(int seqIdx, AmpiMsg *msg) noexcept
   if (msg->getSeqIdx() != COLL_SEQ_IDX && msg->getSeq() < el.getSeqIncoming())
     CkAbort("AMPI logic error: received late out-of-order message!\n");
 #endif
-  if (seqIdx == COLL_SEQ_IDX) CmiReference(UsrToEnv(msg)); // bcast msg is [nokeep]
+  if (seqIdx == COLL_SEQ_IDX) CkReferenceMsg(msg); // bcast msg is [nokeep]
   out.enq(msg);
   el.incNumOutOfOrder(); // We have another message in the out-of-order queue
 }

--- a/src/libs/ck-libs/pythonCCS/charmdebug-python.C
+++ b/src/libs/ck-libs/pythonCCS/charmdebug-python.C
@@ -201,7 +201,7 @@ void CpdPythonGroup::cpdCheck(void *m) {
     CkPrintf("[%d] CpdPythonGroup::cpdCheck error while preparing interpreter\n",CkMyPe());
   }
   pyWorkers[pyReference].inUse = true;
-  CmiReference(UsrToEnv(msg));
+  CkReferenceMsg(msg);
   CthResume(CthCreate((CthVoidFn)_callthr_executeThread, new CkThrCallArg(msg,(PythonObject*)this), 0));
   if (resultNotNone) CpdFreeze();
 }

--- a/src/xlat-i/sdag/CEntry.C
+++ b/src/xlat-i/sdag/CEntry.C
@@ -154,7 +154,7 @@ void CEntry::generateCode(XStr& decls, XStr& defs) {
     // keeping a meta-structure for every message passed in
 
     // increase reference count by one for the state parameter
-    defs << "  CmiReference(UsrToEnv(" << sv->name << "_msg));\n";
+    defs << "  CkReferenceMsg(" << sv->name << "_msg);\n";
 
     // refnum automatically extracted from msg by MsgClosure::MsgClosure(...)
     defs << "  __dep->pushBuffer(" << entryNum << ", new SDAG::MsgClosure(" << sv->name

--- a/src/xlat-i/sdag/constructs/SdagEntry.C
+++ b/src/xlat-i/sdag/constructs/SdagEntry.C
@@ -95,7 +95,7 @@ void SdagEntryConstruct::generateCode(XStr& decls, XStr& defs, Entry* entry) {
   // will only be one parameter which is the message (called 'gen0')
   if (!entry->paramIsMarshalled() && !entry->param->isVoid()) {
     // increase reference count by one for the state parameter
-    defs << "  CmiReference(UsrToEnv(gen0));\n";
+    defs << "  CkReferenceMsg(gen0);\n";
   }
 
   defs << "  ";

--- a/src/xlat-i/xi-Parameter.C
+++ b/src/xlat-i/xi-Parameter.C
@@ -712,7 +712,7 @@ void ParamList::beginUnmarshallSDAGCall(XStr& str, bool usesImplBuf) {
     if (hasArray || hasRdma()) {
       if (!usesImplBuf) {
         str << "  genClosure->_impl_marshall = impl_msg_typed;\n";
-        str << "  CmiReference(UsrToEnv(genClosure->_impl_marshall));\n";
+        str << "  CkReferenceMsg(genClosure->_impl_marshall);\n";
       } else {
         if (hasRdma() && !hasArray) str << "#if !CMK_ONESIDED_IMPL\n";
         str << "  genClosure->_impl_buf_in = impl_buf;\n";

--- a/src/xlat-i/xi-Parameter.C
+++ b/src/xlat-i/xi-Parameter.C
@@ -711,7 +711,8 @@ void ParamList::beginUnmarshallSDAGCall(XStr& str, bool usesImplBuf) {
     callEach(&Parameter::unmarshallRegArrayDataSDAGCall, str);
     if (hasArray || hasRdma()) {
       if (!usesImplBuf) {
-        str << "  genClosure->_impl_marshall = CkReferenceMsg(impl_msg_typed);\n";
+        str << "  genClosure->_impl_marshall = impl_msg_typed;\n";
+        str << "  CkReferenceMsg(genClosure->_impl_marshall);\n";
       } else {
         if (hasRdma() && !hasArray) str << "#if !CMK_ONESIDED_IMPL\n";
         str << "  genClosure->_impl_buf_in = impl_buf;\n";

--- a/src/xlat-i/xi-Parameter.C
+++ b/src/xlat-i/xi-Parameter.C
@@ -711,8 +711,7 @@ void ParamList::beginUnmarshallSDAGCall(XStr& str, bool usesImplBuf) {
     callEach(&Parameter::unmarshallRegArrayDataSDAGCall, str);
     if (hasArray || hasRdma()) {
       if (!usesImplBuf) {
-        str << "  genClosure->_impl_marshall = impl_msg_typed;\n";
-        str << "  CkReferenceMsg(genClosure->_impl_marshall);\n";
+        str << "  genClosure->_impl_marshall = CkReferenceMsg(impl_msg_typed);\n";
       } else {
         if (hasRdma() && !hasArray) str << "#if !CMK_ONESIDED_IMPL\n";
         str << "  genClosure->_impl_buf_in = impl_buf;\n";


### PR DESCRIPTION
A common paradigm in the codebase is to increment the refcount of a
message by using CmiReference(UsrToEnv(msg)), this creates a function
to simplify this usage.