### PR TITLE
cast fixes for C++20

### DIFF
--- a/src/ck-core/cklocation.C
+++ b/src/ck-core/cklocation.C
@@ -2551,7 +2551,7 @@ int CkLocMgr::deliverMsg(CkArrayMessage *msg, CkArrayID mgr, CmiUInt8 id, const 
     return true;
   }
 
-  CkAssert(mgr == UsrToEnv(msg)->getArrayMgr());
+  CkAssert((CkGroupID)mgr == UsrToEnv(msg)->getArrayMgr());
   CkArray *arr = managers[mgr];
   if (!arr) {
     bufferedShadowElemMsgs[id].push_back(msg);

--- a/src/ck-core/ckmulticast.C
+++ b/src/ck-core/ckmulticast.C
@@ -385,7 +385,7 @@ void CkMulticastMgr::resetSection(CProxySection_ArrayBase &proxy)
   DEBUGF(("[%d] resetSection: old entry:%p new entry:%p\n", CkMyPe(), oldentry, entry));
 
   const std::vector<CkArrayIndex> &al = sid->_elems;
-  CmiAssert(info.get_aid() == aid);
+  CmiAssert(info.get_aid() == (CkGroupID)aid);
   prepareCookie(entry, *sid, al.data(), sid->_elems.size(), aid);
 
   CProxy_CkMulticastMgr  mCastGrp(thisgroup);
@@ -1063,7 +1063,7 @@ void CkMulticastMgr::recvMsg(multicastGrpMsg *msg)
   int i;
   CkSectionInfo &sectionInfo = msg->_cookie;
   mCastEntry *entry = (mCastEntry *)msg->_cookie.get_val();
-  CmiAssert(entry->getAid() == sectionInfo.get_aid());
+  CmiAssert((CkGroupID)entry->getAid() == sectionInfo.get_aid());
 
   if (entry->notReady()) {
     DEBUGF(("entry not ready, enq buffer %p, msg-used?: %d\n", msg, UsrToEnv(msg)->isUsed()));
@@ -1088,7 +1088,7 @@ void CkMulticastMgr::sendToLocal(multicastGrpMsg *msg)
   int i;
   CkSectionInfo &sectionInfo = msg->_cookie;
   mCastEntry *entry = (mCastEntry *)msg->_cookie.get_val();
-  CmiAssert(entry->getAid() == sectionInfo.get_aid());
+  CmiAssert((CkGroupID)entry->getAid() == sectionInfo.get_aid());
   CkGroupID aid = sectionInfo.get_aid();
   
   // send to local


### PR DESCRIPTION
Charm++ can be compiled and run with -std=c++20 now.