### PR TITLE
ampiCC: Accept arguments from environment variable

### DIFF
--- a/src/libs/ck-libs/ampi/ampiCC
+++ b/src/libs/ck-libs/ampi/ampiCC
@@ -80,7 +80,7 @@ do
 done
 }
 
-eval processArgs "$@"
+eval processArgs "$AMPI_BUILD_FLAGS" "$@"
 
 # If there are no filename arguments specified, just pass through
 # compiler options to charmc. Helps with configure scripts that


### PR DESCRIPTION
Exporting AMPI_BUILD_FLAGS with values such as `-charm-shared` will
allow passing options without modifying an MPI program's build scripts.