### PR TITLE
Fix CUDA hello example to offload kernels from all chares

### DIFF
--- a/examples/charm++/cuda/hello/hello.C
+++ b/examples/charm++/cuda/hello/hello.C
@@ -66,21 +66,20 @@ class Hello : public CBase_Hello {
     CkPrintf("Hello, I'm chare %d, on PE %d using GPU #%d %s (UUID: %x-%x-%x-%x)\n",
         thisIndex, CkMyPe(), device, prop.name, *uuid_p, *(uuid_p+1), *(uuid_p+2), *(uuid_p+3));
 
-    if (thisIndex < nElements - 1) {
-      CkArrayIndex1D myIndex = CkArrayIndex1D(thisIndex);
-      CkCallback* cb = new CkCallback(CkIndex_Hello::pass(), myIndex, thisArrayID);
+    CkArrayIndex1D myIndex = CkArrayIndex1D(thisIndex);
+    CkCallback* cb = new CkCallback(CkIndex_Hello::pass(), myIndex, thisArrayID);
 
-      kernelSetup(stream, (void*)cb);
-    }
-    else {
-      // we've been around once, we're done
-      mainProxy.done();
-    }
+    kernelSetup(stream, (void*)cb);
   }
 
   void pass() {
-    // pass the hello on
-    thisProxy[thisIndex + 1].greet();
+    if (thisIndex == nElements - 1) {
+      // we've been around once, we're done
+      mainProxy.done();
+    } else {
+      // pass the hello on
+      thisProxy[thisIndex + 1].greet();
+    }
   }
 };
 


### PR DESCRIPTION
The CUDA hello example only offloaded kernels from `n_chares-1` chares (which excludes the last chare). This patch fixes it so that all chares offload kernels to the GPU, including the last one.