### PR TITLE
build: remove pedantic option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -100,7 +100,6 @@ option(BUILD_SHARED        "Build Charm++ dynamic libraries" OFF)
 
 # Other options
 option(F90CHARM            "Build f90charm" OFF)
-option(PEDANTIC            "Build with -pedantic" OFF)
 option(BUILD_CUDA          "Build with CUDA support" OFF)
 
 option(PXSHM               "Build with PXSHM" OFF)
@@ -444,8 +443,6 @@ configure_file(src/arch/common/conv-mach-omp.sh              include/ COPYONLY)
 configure_file(src/arch/common/conv-mach-omp.h               include/ COPYONLY)
 configure_file(src/arch/common/conv-mach-ooc.sh              include/ COPYONLY)
 configure_file(src/arch/common/conv-mach-papi.sh             include/ COPYONLY)
-configure_file(src/arch/common/conv-mach-pedantic.sh         include/ COPYONLY)
-configure_file(src/arch/common/conv-mach-pedantic.h          include/ COPYONLY)
 configure_file(src/arch/common/conv-mach-perftools.sh        include/ COPYONLY)
 configure_file(src/arch/common/conv-mach-persistent.sh       include/ COPYONLY)
 configure_file(src/arch/common/conv-mach-pgf90.sh            include/ COPYONLY)
@@ -792,7 +789,7 @@ foreach(l BUILD_CUDA CMK_AMPI_WITH_ROMIO CMK_MACOSX CMK_BLUEGENEQ CMK_BUILD_PYTH
 endforeach(l)
 
 # Add options
-foreach(opt SMP OMP TCP PTHREADS PEDANTIC SYNCFT PXSHM)
+foreach(opt SMP OMP TCP PTHREADS SYNCFT PXSHM)
     if(${opt})
         string(TOLOWER ${opt} optl)
         file(APPEND ${optfile_sh} ". ${CMAKE_BINARY_DIR}/include/conv-mach-${optl}.sh\n")

--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ for more information:
      will give:
     
       Supported compilers: clang craycc gcc icc iccstatic msvc pgcc xlc xlc64
-      Supported options: clustermatic common cuda flang gfortran ifort local nolb omp ooc papi pedantic perftools persistent pgf90 pxshm scyld smp syncft sysvshm tcp tsan
+      Supported options: clustermatic common cuda flang gfortran ifort local nolb omp ooc papi perftools persistent pgf90 pxshm scyld smp syncft sysvshm tcp tsan
 
 
 ## Building the Source

--- a/buildcmake
+++ b/buildcmake
@@ -77,7 +77,6 @@ opt_network=0
 opt_numa=0
 opt_omp=0
 opt_parallel=-j1
-opt_pedantic=0
 opt_prio_type="bitvec"
 opt_production=0
 opt_pthreads=0
@@ -137,9 +136,6 @@ while [[ $# -gt 0 ]]; do
       ;;
     tcp)
       opt_tcp=1
-      ;;
-    pedantic)
-      opt_pedantic=1
       ;;
     pthreads)
       opt_pthreads=1
@@ -372,7 +368,7 @@ done
 
 # Append certain features and compilers to the end of the build directory name
 builddir_extra=""
-for flag in opt_omp opt_smp opt_tcp opt_pthreads opt_pedantic opt_pxshm opt_syncft; do
+for flag in opt_omp opt_smp opt_tcp opt_pthreads opt_pxshm opt_syncft; do
   [[ $flag -eq 1 ]] && builddir_extra+="-${flag/opt_/}"
 done
 
@@ -421,7 +417,6 @@ CC=$opt_CC CXX=$opt_CXX FC=$opt_FC cmake .. \
   -DNETWORK="$opt_network" \
   -DNUMA="$opt_numa" \
   -DOMP="$opt_omp" \
-  -DPEDANTIC="$opt_pedantic" \
   -DPRIO_TYPE="$opt_prio_type" \
   -DPTHREADS="$opt_pthreads" \
   -DPXSHM="$opt_pxshm" \

--- a/smart-build.pl
+++ b/smart-build.pl
@@ -456,7 +456,6 @@ $explanations{"pgf90"} = "Use Portland Group's pgf90 Fortran compiler";
 $explanations{"syncft"} = "Use fault tolerance support";
 $explanations{"omp"} = "Build Charm++ with integrated OpenMP support";
 $explanations{"papi"} = "Enable PAPI performance counters";
-$explanations{"pedantic"} = "Enable pedantic compiler warnings";
 $explanations{"nolb"} = "Build without load balancing support";
 $explanations{"perftools"} = "Build with support for the Cray perftools";
 $explanations{"persistent"} = "Build the persistent communication interface";

--- a/src/arch/common/conv-mach-pedantic.sh
+++ b/src/arch/common/conv-mach-pedantic.sh
@@ -1,1 +1,0 @@
-CMK_CXX_FLAGS="$CMK_CXX_FLAGS -pedantic -Wno-long-long"


### PR DESCRIPTION
-pedantic can just be passed to ./build if needed; -Wno-long-long is
irrelevant in C++11