### PR TITLE
cmake: add jpeg include dir

### DIFF
--- a/src/libs/ck-libs/CMakeLists.txt
+++ b/src/libs/ck-libs/CMakeLists.txt
@@ -68,6 +68,9 @@ foreach(file ${liveviz-h-sources})
 endforeach()
 
 target_compile_options(moduleliveViz PRIVATE -DEXTERIOR_BLACK_PIXEL_ELIMINATION)
+if(CMK_USE_LIBJPEG)
+    target_include_directories(moduleliveViz PRIVATE ${JPEG_INCLUDE_DIRS})
+endif()
 
 file(WRITE ${CMAKE_BINARY_DIR}/lib/libmoduleliveViz.dep "${CMK_LIBJPEG}\n")
 


### PR DESCRIPTION
Fixes darwin autobuild failure.