### PR TITLE
Adding CkChannel for Go-like Channel Functionality

### DIFF
--- a/examples/channels/Makefile
+++ b/examples/channels/Makefile
@@ -1,5 +1,6 @@
 DIRS = \
   single \
+  multi \
 
 TESTDIRS = $(DIRS)
 

--- a/examples/channels/Makefile
+++ b/examples/channels/Makefile
@@ -1,0 +1,21 @@
+DIRS = \
+  single \
+
+TESTDIRS = $(DIRS)
+
+all: $(foreach i,$(DIRS),build-$i)
+
+test: $(foreach i,$(TESTDIRS),test-$i)
+
+clean: $(foreach i,$(DIRS),clean-$i)
+	rm -f TAGS #*#
+	rm -f core *~
+
+$(foreach i,$(DIRS),build-$i):
+	$(MAKE) -C $(subst build-,,$@) all OPTS='$(OPTS)'
+
+$(foreach i,$(DIRS),test-$i):
+	$(MAKE) -C $(subst test-,,$@) test OPTS='$(OPTS)' TESTOPTS='$(TESTOPTS)'
+
+$(foreach i,$(DIRS),clean-$i):
+	$(MAKE) -C $(subst clean-,,$@) clean OPTS='$(OPTS)'

--- a/examples/channels/Makefile
+++ b/examples/channels/Makefile
@@ -1,6 +1,7 @@
 DIRS = \
   single \
   multi \
+  stress \
 
 TESTDIRS = $(DIRS)
 

--- a/examples/channels/multi/Makefile
+++ b/examples/channels/multi/Makefile
@@ -1,0 +1,16 @@
+-include ../../common.mk
+CHARMC=../../../bin/charmc $(OPTS)
+
+all: pgm
+
+pgm: multi.o
+	$(CHARMC) multi.o  -o pgm -language charm++
+
+multi.o : multi.C multi.h multi.ci
+	$(CHARMC) -c multi.ci multi.C
+
+test: pgm
+	$(call run, ++local +p4 ./pgm )
+
+clean:
+	rm -f conv-host pgm *.def.h *.decl.h *.o *~ charmrun charmrun.exe pgm.exe pgm.pdb pgm.ilk

--- a/examples/channels/multi/multi.C
+++ b/examples/channels/multi/multi.C
@@ -1,0 +1,51 @@
+#include "multi.h"
+#include <cstdlib>
+#include <ctime>
+#include <numeric>
+
+Main::Main(CkArgMsg *m) {
+  mainProxy = thisProxy;
+  numWorkers = CkNumPes();
+  CkPrintf("[MAIN] Creating channel, producer, and consumer.\n");
+  channel = CProxy_CkMultiChannel<2, int>::ckNew();
+  CProxy_JobConsumer consumer = CProxy_JobConsumer::ckNew(channel);
+  CProxy_JobProducer producer = CProxy_JobProducer::ckNew(channel);
+  // Run the consumers and producer
+  consumer.run();
+  producer.run();
+}
+
+void Main::stageI() {
+  CkPrintf("[MAIN] Setting a callback for data from any channel.\n");
+  CkCallback cb(CkIndex_Main::stageII(std::make_pair(0, 0)), mainProxy);
+  int channels[2];
+  std::iota(channels, channels + 2, 0);
+  channel.receiveFromAny(channels, 2, cb);
+  CkPrintf("[MAIN] Sending data to a random channel...\n");
+  std::srand(std::time(nullptr));
+  int ch = std::rand() % 2;
+  channel.send(ch, ch);
+}
+
+void Main::stageII(std::pair<int, int> response) {
+  CkPrintf("[MAIN] Received data from channel %d...\n", response.first);
+  CkExit();
+}
+
+void JobConsumer::run() {
+  CkPrintf("[CONSUMER%d] Received job %d from channel 0.\n", thisIndex, channel.receive(0));
+  channel.send(1, thisIndex);
+}
+
+void JobProducer::run() {
+  CkPrintf("[PRODUCER] Putting %d jobs into channel 0.\n", numWorkers);
+  for (int i = 0; i < numWorkers; i++) {
+    channel.send(0, 2 * (i + 1));
+  }
+  CkPrintf("[PRODUCER] Awaiting completion notices from consumers (on channel 1).\n");
+  channel.waitN(1, numWorkers);
+  mainProxy.stageI();
+}
+
+#include "multi.def.h"
+

--- a/examples/channels/multi/multi.C
+++ b/examples/channels/multi/multi.C
@@ -20,7 +20,7 @@ void Main::stageI() {
   CkCallback cb(CkIndex_Main::stageII(std::make_pair(0, 0)), mainProxy);
   int channels[2];
   std::iota(channels, channels + 2, 0);
-  channel.receiveFromAny(channels, 2, cb);
+  channel.receiveAnyAsync(channels, 2, cb);
   CkPrintf("[MAIN] Sending data to a random channel...\n");
   std::srand(std::time(nullptr));
   int ch = std::rand() % 2;

--- a/examples/channels/multi/multi.ci
+++ b/examples/channels/multi/multi.ci
@@ -1,0 +1,24 @@
+mainmodule multi {
+
+  readonly CProxy_Main mainProxy;
+  readonly int numWorkers;
+
+  mainchare Main {
+    entry Main(CkArgMsg *m);
+    entry void stageI();
+    entry void stageII(std::pair<int, int>);
+  };
+
+  chare JobProducer {
+    entry JobProducer(CProxy_CkMultiChannel<2, int>);
+    entry [threaded] void run();
+  };
+
+  group JobConsumer {
+    entry JobConsumer(CProxy_CkMultiChannel<2, int>);
+    entry [threaded] void run();
+  }
+
+  chare CkMultiChannel<2, int>;
+}
+

--- a/examples/channels/multi/multi.ci
+++ b/examples/channels/multi/multi.ci
@@ -4,7 +4,7 @@ mainmodule multi {
   readonly int numWorkers;
 
   mainchare Main {
-    entry Main(CkArgMsg *m);
+    entry [nokeep] Main(CkArgMsg *m);
     entry void stageI();
     entry void stageII(std::pair<int, int>);
   };

--- a/examples/channels/multi/multi.h
+++ b/examples/channels/multi/multi.h
@@ -1,0 +1,30 @@
+#include "charm++.h"
+#include "channel.h"
+#include "multi.decl.h"
+
+CProxy_Main mainProxy;
+int numWorkers;
+
+class JobConsumer : public CBase_JobConsumer {
+  CProxy_CkMultiChannel<2, int> channel;
+public:
+  JobConsumer(CkMigrateMessage *m) {}
+  JobConsumer(CProxy_CkMultiChannel<2, int> channel_) : channel(channel_) {}
+  void run();
+};
+
+class JobProducer : public CBase_JobProducer {
+  CProxy_CkMultiChannel<2, int> channel;
+public:
+  JobProducer(CkMigrateMessage *m) {}
+  JobProducer(CProxy_CkMultiChannel<2, int> channel_) : channel(channel_) {}
+  void run();
+};
+
+class Main : public CBase_Main {
+  CProxy_CkMultiChannel<2, int> channel;
+public:
+  Main(CkArgMsg *);
+  void stageI();
+  void stageII(std::pair<int, int> response);
+};

--- a/examples/channels/single/Makefile
+++ b/examples/channels/single/Makefile
@@ -1,0 +1,16 @@
+-include ../../common.mk
+CHARMC=../../../bin/charmc $(OPTS)
+
+all: pgm
+
+pgm: single.o
+	$(CHARMC) single.o  -o pgm -language charm++
+
+single.o : single.C single.h single.ci
+	$(CHARMC) -c single.ci single.C
+
+test: pgm
+	$(call run, ++local +p4 ./pgm )
+
+clean:
+	rm -f conv-host pgm *.def.h *.decl.h *.o *~ charmrun charmrun.exe pgm.exe pgm.pdb pgm.ilk

--- a/examples/channels/single/single.C
+++ b/examples/channels/single/single.C
@@ -1,0 +1,28 @@
+#include "single.h"
+
+Main::Main(CkArgMsg *m) {
+  CkPrintf("[MAIN] Creating channel, producer, and consumer.\n");
+  CProxy_CkChannel<int> channel = CProxy_CkChannel<int>::ckNew();
+  CProxy_JobConsumer consumer = CProxy_JobConsumer::ckNew(channel);
+  CProxy_JobProducer producer = CProxy_JobProducer::ckNew(channel);
+  // Run the consumers and producer
+  consumer.run();
+  producer.run();
+  // Exit on quiescence
+  CkStartQD(CkCallback(CkCallback::ckExit));
+}
+
+void JobConsumer::run() {
+  CkPrintf("[CONSUMER%d] Received job %d from the channel.\n", thisIndex, channel.receive());
+}
+
+void JobProducer::run() {
+  int numJobs = CkNumPes();
+  CkPrintf("[PRODUCER] Putting %d jobs into the channel.\n", numJobs);
+  for (int i = 0; i < numJobs; i++) {
+    channel.send(2 * (i + 1));
+  }
+}
+
+#include "single.def.h"
+

--- a/examples/channels/single/single.ci
+++ b/examples/channels/single/single.ci
@@ -1,0 +1,18 @@
+mainmodule single {
+  mainchare Main {
+    entry Main(CkArgMsg *m);
+  };
+
+  chare JobProducer {
+    entry JobProducer(CProxy_CkChannel<int>);
+    entry void run();
+  };
+
+  group JobConsumer {
+    entry JobConsumer(CProxy_CkChannel<int>);
+    entry [threaded] void run();
+  }
+
+  chare CkChannel<int>;
+}
+

--- a/examples/channels/single/single.ci
+++ b/examples/channels/single/single.ci
@@ -1,6 +1,6 @@
 mainmodule single {
   mainchare Main {
-    entry Main(CkArgMsg *m);
+    entry [nokeep] Main(CkArgMsg *m);
   };
 
   chare JobProducer {
@@ -15,4 +15,3 @@ mainmodule single {
 
   chare CkChannel<int>;
 }
-

--- a/examples/channels/single/single.h
+++ b/examples/channels/single/single.h
@@ -1,0 +1,24 @@
+#include "charm++.h"
+#include "channel.h"
+#include "single.decl.h"
+
+class JobConsumer : public CBase_JobConsumer {
+  CProxy_CkChannel<int> channel;
+public:
+  JobConsumer(CkMigrateMessage *m) {}
+  JobConsumer(CProxy_CkChannel<int> channel_) : channel(channel_) {}
+  void run();
+};
+
+class JobProducer : public CBase_JobProducer {
+  CProxy_CkChannel<int> channel;
+public:
+  JobProducer(CkMigrateMessage *m) {}
+  JobProducer(CProxy_CkChannel<int> channel_) : channel(channel_) {}
+  void run();
+};
+
+class Main : public CBase_Main {
+public:
+  Main(CkArgMsg *);
+};

--- a/examples/channels/stress/Makefile
+++ b/examples/channels/stress/Makefile
@@ -1,0 +1,16 @@
+-include ../../common.mk
+CHARMC=../../../bin/charmc $(OPTS)
+
+all: pgm
+
+pgm: stress.o
+	$(CHARMC) stress.o  -o pgm -language charm++
+
+stress.o : stress.C stress.h stress.ci
+	$(CHARMC) -c stress.ci stress.C
+
+test: pgm
+	$(call run, ++local +p4 ./pgm )
+
+clean:
+	rm -f conv-host pgm *.def.h *.decl.h *.o *~ charmrun charmrun.exe pgm.exe pgm.pdb pgm.ilk

--- a/examples/channels/stress/README.md
+++ b/examples/channels/stress/README.md
@@ -1,0 +1,8 @@
+
+In essence, one producer puts many values into a channel, and every consumer scans every channel for a value. Every few iterations, the consumers put a value into a channel and the consumer waits for all such values to be received. The consumers span many chare-arrays. This applies a lot stress to the multi-channel construct, particularly stressing its any-channel receive functionality.
+
+Variables:
+    - `NUM_ITERS` - Number of iterations to run for (and channels to create).
+    - `numArrays` - Number of chare-arrays to create.
+    - `elementsPerArray` - Number of chares per chare-array.
+    - `itersPerHeartbeat` - Number of iterations between consumer check-ins.

--- a/examples/channels/stress/stress.C
+++ b/examples/channels/stress/stress.C
@@ -1,0 +1,53 @@
+#include "stress.h"
+#include <cstdlib>
+#include <ctime>
+#include <numeric>
+
+Main::Main(CkArgMsg *m) {
+  mainProxy = thisProxy;
+  channel = CProxy_CkMultiChannel<NUM_ITERS, int>::ckNew();
+  // Create all of the consumer arrays
+  std::array<CProxy_JobConsumer, numArrays> consumers;
+  for (int i = 0; i < numArrays; i++) {
+    consumers[i] = CProxy_JobConsumer::ckNew(channel, elementsPerArray);
+  }
+  // Create the producer
+  CProxy_JobProducer producer = CProxy_JobProducer::ckNew(channel);
+  // Run the consumers and producer
+  for (auto consumer : consumers) {
+    consumer.run();
+  }
+  producer.run();
+  // Exit on quiescence
+  CkStartQD(CkCallback(CkCallback::ckExit));
+}
+
+void JobConsumer::run() {
+  int channels[NUM_ITERS];
+  std::iota(channels, channels + NUM_ITERS, 0);
+  std::pair<int, int> result = channel.receiveFromAny(channels, NUM_ITERS);
+  int iter = result.first + 1;
+  if (iter % itersPerHeartbeat == 0) {
+    channel.send(result.first, result.second);
+  }
+  if (iter < NUM_ITERS) {
+    thisProxy[thisIndex].run();
+  }
+}
+
+void JobProducer::run() {
+  const int numElements = numArrays * elementsPerArray;
+  for (int i = 0; i < NUM_ITERS; i++) {
+    CkPrintf("[%d/%d] Putting %d values into the channel.\n", i + 1, NUM_ITERS, numElements);
+    for (int j = 0; j < numElements; j++) {
+      channel.send(i, j);
+    }
+    if ((i + 1) % itersPerHeartbeat == 0) {
+      CkPrintf("[%d/%d] Waiting for %d values from the channel.\n", i + 1, NUM_ITERS, numElements);
+      channel.waitN(i, numElements);
+    }
+  }
+}
+
+#include "stress.def.h"
+

--- a/examples/channels/stress/stress.C
+++ b/examples/channels/stress/stress.C
@@ -25,7 +25,7 @@ Main::Main(CkArgMsg *m) {
 void JobConsumer::run() {
   int channels[NUM_ITERS];
   std::iota(channels, channels + NUM_ITERS, 0);
-  std::pair<int, int> result = channel.receiveFromAny(channels, NUM_ITERS);
+  std::pair<int, int> result = channel.receiveAny(channels, NUM_ITERS);
   int iter = result.first + 1;
   if (iter % itersPerHeartbeat == 0) {
     channel.send(result.first, result.second);

--- a/examples/channels/stress/stress.ci
+++ b/examples/channels/stress/stress.ci
@@ -1,0 +1,21 @@
+mainmodule stress {
+
+  readonly CProxy_Main mainProxy;
+
+  mainchare Main {
+    entry [nokeep] Main(CkArgMsg *m);
+  };
+
+  chare JobProducer {
+    entry JobProducer(CProxy_CkMultiChannel<NUM_ITERS, int>);
+    entry [threaded] void run();
+  };
+
+  array [1D] JobConsumer {
+    entry JobConsumer(CProxy_CkMultiChannel<NUM_ITERS, int>);
+    entry [threaded] void run();
+  }
+
+  chare CkMultiChannel<NUM_ITERS, int>;
+}
+

--- a/examples/channels/stress/stress.h
+++ b/examples/channels/stress/stress.h
@@ -1,0 +1,33 @@
+#define NUM_ITERS 16
+#include "charm++.h"
+#include "channel.h"
+#include "stress.decl.h"
+
+const int numArrays = 16;
+const int elementsPerArray = 16;
+const int itersPerHeartbeat = 4;
+CProxy_Main mainProxy;
+
+class JobConsumer : public CBase_JobConsumer {
+  CProxy_CkMultiChannel<NUM_ITERS, int> channel;
+public:
+  JobConsumer(CkMigrateMessage *m) {}
+  JobConsumer(CProxy_CkMultiChannel<NUM_ITERS, int> channel_) : channel(channel_) {}
+  void run();
+};
+
+class JobProducer : public CBase_JobProducer {
+  CProxy_CkMultiChannel<NUM_ITERS, int> channel;
+public:
+  JobProducer(CkMigrateMessage *m) {}
+  JobProducer(CProxy_CkMultiChannel<NUM_ITERS, int> channel_) : channel(channel_) {}
+  void run();
+};
+
+class Main : public CBase_Main {
+  CProxy_CkMultiChannel<NUM_ITERS, int> channel;
+public:
+  Main(CkArgMsg *);
+  void stageI();
+  void stageII(std::pair<int, int> response);
+};

--- a/src/libs/ck-libs/channel/Makefile
+++ b/src/libs/ck-libs/channel/Makefile
@@ -1,0 +1,23 @@
+CDIR=../../../..
+CHARMC=$(CDIR)/bin/charmc $(OPTS)
+DEST=$(CDIR)/lib/libmodulechannel.a
+
+all: $(DEST) $(CDIR)/include/channel.h $(CDIR)/include/channel.decl.h
+
+$(DEST): channel.o
+	$(CHARMC) -o $(DEST) channel.o
+
+channel.o: channel.C channel.h channel.decl.h channel.def.h
+	$(CHARMC) -c channel.C
+
+channel.decl.h channel.def.h: channel.ci
+	$(CHARMC) channel.ci
+
+$(CDIR)/include/channel.decl.h: channel.decl.h
+	/bin/cp channel.decl.h $(CDIR)/include
+
+$(CDIR)/include/channel.h: channel.h
+	/bin/cp channel.h $(CDIR)/include
+
+clean:
+	rm -f *.decl.h *.def.h *.o $(DEST)

--- a/src/libs/ck-libs/channel/Makefile
+++ b/src/libs/ck-libs/channel/Makefile
@@ -2,7 +2,7 @@ CDIR=../../../..
 CHARMC=$(CDIR)/bin/charmc $(OPTS)
 DEST=$(CDIR)/lib/libmodulechannel.a
 
-all: $(DEST) $(CDIR)/include/channel.h $(CDIR)/include/channel.decl.h
+all: $(DEST) $(CDIR)/include/channel.h $(CDIR)/include/channel.decl.h $(CDIR)/include/channel.def.h
 
 $(DEST): channel.o
 	$(CHARMC) -o $(DEST) channel.o
@@ -12,6 +12,9 @@ channel.o: channel.C channel.h channel.decl.h channel.def.h
 
 channel.decl.h channel.def.h: channel.ci
 	$(CHARMC) channel.ci
+
+$(CDIR)/include/channel.def.h: channel.def.h
+	/bin/cp channel.def.h $(CDIR)/include
 
 $(CDIR)/include/channel.decl.h: channel.decl.h
 	/bin/cp channel.decl.h $(CDIR)/include

--- a/src/libs/ck-libs/channel/channel.C
+++ b/src/libs/ck-libs/channel/channel.C
@@ -1,0 +1,3 @@
+#include "charm++.h"
+#include "channel.h"
+#include "channel.def.h"

--- a/src/libs/ck-libs/channel/channel.ci
+++ b/src/libs/ck-libs/channel/channel.ci
@@ -4,21 +4,35 @@ module channel {
   chare CkChannel {
     entry CkChannel();
     entry void send(T);
+
     entry [sync] T receive();
-    entry [threaded] void receive(CkCallback);
+    entry [threaded] void receiveAsync(CkCallback);
+
+    entry [threaded] void receiveN(int);
+    entry [threaded] void receiveNAsync(int, CkCallback);
+
+    entry [threaded] void waitN(int numMsgs);
   };
 
   template <int N, typename T>
   chare CkMultiChannel {
     entry CkMultiChannel();
     entry void send(int, T);
-    entry [sync] T receive(int);
-    entry [sync] std::pair<int, T> receiveFromAny(int channels[numChannels], int numChannels);
 
-    entry [threaded] void receive(int, CkCallback);
-    entry [threaded] void receiveFromAny(int channels[numChannels], int numChannels, CkCallback cb);
+    entry [sync] T receive(int);
+    entry [threaded] void receiveAsync(int, CkCallback);
+
+    entry [threaded] void receiveN(int channel, int numMsgs);
+    entry [threaded] void receiveNAsync(int channel, int numMsgs, CkCallback cb);
+
+    entry [sync] std::vector<T> receiveAll(int channels[numChannels], int numChannels);
+    entry [threaded] void receiveAllAsync(int channels[numChannels], int numChannels, CkCallback cb);
+
+    entry [sync] std::pair<int, T> receiveAny(int channels[numChannels], int numChannels);
+    entry [threaded] void receiveAnyAsync(int channels[numChannels], int numChannels, CkCallback cb);
 
     entry [sync] void waitAll(int channels[numChannels], int numChannels);
+    entry [sync] int waitAny(int channels[numChannels], int numChannels);
     entry [sync] void waitN(int channel, int numMsgs);
   };
 };

--- a/src/libs/ck-libs/channel/channel.ci
+++ b/src/libs/ck-libs/channel/channel.ci
@@ -1,0 +1,10 @@
+
+module channel {
+  template <typename T>
+  chare CkChannel {
+    entry CkChannel();
+    entry void send(T);
+    entry [sync] T receive();
+    entry [threaded] void receive(CkCallback cb);
+  };
+};

--- a/src/libs/ck-libs/channel/channel.ci
+++ b/src/libs/ck-libs/channel/channel.ci
@@ -5,6 +5,20 @@ module channel {
     entry CkChannel();
     entry void send(T);
     entry [sync] T receive();
-    entry [threaded] void receive(CkCallback cb);
+    entry [threaded] void receive(CkCallback);
+  };
+
+  template <int N, typename T>
+  chare CkMultiChannel {
+    entry CkMultiChannel();
+    entry void send(int, T);
+    entry [sync] T receive(int);
+    entry [sync] std::pair<int, T> receiveFromAny(int channels[numChannels], int numChannels);
+
+    entry [threaded] void receive(int, CkCallback);
+    entry [threaded] void receiveFromAny(int channels[numChannels], int numChannels, CkCallback cb);
+
+    entry [sync] void waitAll(int channels[numChannels], int numChannels);
+    entry [sync] void waitN(int channel, int numMsgs);
   };
 };

--- a/src/libs/ck-libs/channel/channel.h
+++ b/src/libs/ck-libs/channel/channel.h
@@ -8,6 +8,64 @@
 #include <utility>
 #include <memory>
 
+namespace ck {
+  namespace channel {
+    template<typename Value>
+    inline void sendToCallback(CkCallback cb, Value value) {
+      PUP::sizer szr;
+      szr | value;
+      CkMarshallMsg *msg = CkAllocateMarshallMsg(szr.size(), NULL);
+      PUP::toMem ppr((void *)msg->msgBuf);
+      ppr | value;
+      cb.send(msg);
+    }
+
+    struct WaitRequest {
+      CthThread thread;
+      bool expired;
+      WaitRequest(const CthThread& thread_)
+      : thread(thread_), expired(false) { }
+    };
+
+    template<int N>
+    class MultiWait {
+      std::array<std::queue<std::shared_ptr<WaitRequest>>, N> waiting;
+    public:
+      // Returns true when a thread is waiting on a channel
+      // Stores the waiting thread in the reference argument
+      bool hasWaiter(int channel, CthThread &thread) {
+        // While a thread is waiting on a channel
+        while (!waiting[channel].empty()) {
+          // Pop a request from the wait-queue
+          auto request = waiting[channel].front();
+          waiting[channel].pop();
+          // If it is not expired
+          if (!request->expired) {
+            // Mark it as expired
+            request->expired = true;
+            // Return thread
+            thread = request->thread;
+            return true;
+          }
+        }
+        // Return nothing
+        return false;
+      }
+      // Places a waiter into the queue for the specified channel
+      void wait(int channel, const CthThread &thread) {
+        waiting[channel].emplace(new WaitRequest(thread));
+      }
+      // Places a (common) waiter into the queue for all specified channels
+      void waitForAny(int* channels, int numChannels, const CthThread &thread) {
+        std::shared_ptr<WaitRequest> ptr(new WaitRequest(thread));
+        for (int i = 0; i < numChannels; i++) {
+          waiting[channels[i]].push(ptr);
+        }
+      }
+    };
+  }
+}
+
 template<typename T>
 class CkChannel : public CBase_CkChannel<T> {
 public:
@@ -33,73 +91,42 @@ public:
     return front;
   }
 
-  void receive(CkCallback cb) {
-    auto value = this->receive();
-    PUP::sizer szr;
-    szr | value;
-    CkMarshallMsg *msg = CkAllocateMarshallMsg(szr.size(), NULL);
-    PUP::toMem ppr((void *)msg->msgBuf);
-    ppr | value;
-    cb.send(msg);
+  void receiveAsync(CkCallback cb) {
+    ck::channel::sendToCallback(cb, this->receive());
+  }
+
+  std::vector<T> receiveN(int numMsgs) {
+    std::vector<T> res;
+    for (int i = 0; i < numMsgs; i++) {
+      res.push_back(this->receive());
+    }
+    return res;
+  }
+
+  void receiveNAsync(int numMsgs, CkCallback cb) {
+    ck::channel::sendToCallback(cb, this->receiveN(numMsgs));
+  }
+
+  void waitN(int numMsgs) {
+    for (int i = 0; i < numMsgs; i++) {
+      this->receive();
+    }
   }
 private:
   std::queue<CthThread> waiting;
   std::queue<T> data;
 };
 
-template<int N>
-class CkMultiWait {
-  struct CkWaitRequest {
-    CthThread thread;
-    bool expired;
-    CkWaitRequest(const CthThread& thread_)
-    : thread(thread_), expired(false) { }
-  };
-  std::array<std::queue<std::shared_ptr<CkWaitRequest>>, N> waiting;
-public:
-  // Returns true when a thread is waiting on a channel
-  // Stores the waiting thread in the reference argument
-  bool hasWaiter(int channel, CthThread &thread) {
-    // While a thread is waiting on a channel
-    while (!waiting[channel].empty()) {
-      // Pop a request from the wait-queue
-      auto request = waiting[channel].front();
-      waiting[channel].pop();
-      // If it is not expired
-      if (!request->expired) {
-        // Mark it as expired
-        request->expired = true;
-        // Return thread
-        thread = request->thread;
-        return true;
-      }
-    }
-    // Return nothing
-    return false;
-  }
-  // Places a waiter into the queue for the specified channel
-  void wait(int channel, const CthThread &thread) {
-    waiting[channel].emplace(new CkWaitRequest(thread));
-  }
-  // Places a (common) waiter into the queue for all specified channels
-  void waitForAny(int* channels, int numChannels, const CthThread &thread) {
-    std::shared_ptr<CkWaitRequest> ptr(new CkWaitRequest(thread));
-    for (int i = 0; i < numChannels; i++) {
-      waiting[channels[i]].push(ptr);
-    }
-  }
-};
-
 template<int N, typename T>
 class CkMultiChannel : public CBase_CkMultiChannel<N, T> {
-  template<typename Value>
-  inline void sendToCallback(CkCallback cb, Value value) {
-    PUP::sizer szr;
-    szr | value;
-    CkMarshallMsg *msg = CkAllocateMarshallMsg(szr.size(), NULL);
-    PUP::toMem ppr((void *)msg->msgBuf);
-    ppr | value;
-    cb.send(msg);
+  int checkChannels(int* channels, int numChannels) {
+    for (int i = 0; i < numChannels; i++) {
+      int channel = channels[i] % N;
+      if (!data[channel].empty()) {
+        return channel;
+      }
+    }
+    return -1;
   }
 public:
   CkMultiChannel() {}
@@ -125,8 +152,20 @@ public:
     return front;
   }
 
-  void receive(int channel, CkCallback cb) {
-    sendToCallback(cb, this->receive(channel));
+  void receiveAsync(int channel, CkCallback cb) {
+    ck::channel::sendToCallback(cb, this->receive(channel));
+  }
+
+  std::vector<T> receiveAll(int* channels, int numChannels) {
+    std::vector<T> res;
+    for (int i = 0; i < numChannels; i++) {
+      res.push_back(this->receive(channels[i]));
+    }
+    return res;
+  }
+
+  void receiveAllAsync(int* channels, int numChannels, CkCallback cb) {
+    ck::channel::sendToCallback(cb, this->receiveAll(channels, numChannels));
   }
 
   void waitAll(int* channels, int numChannels) {
@@ -135,39 +174,46 @@ public:
     }
   }
 
-  void waitN(int channel, int numMsgs) {
-    for (int i = 0; i < numMsgs; i++) {
-      this->receive(channel);
-    }
-  }
-
-  int checkChannels(int* channels, int numChannels) {
-    for (int i = 0; i < numChannels; i++) {
-      int channel = channels[i] % N;
-      if (!data[channel].empty()) {
-        return channel;
-      }
-    }
-    return -1;
-  }
-
-  std::pair<int, T> receiveFromAny(int* channels, int numChannels) {
+  int waitAny(int* channels, int numChannels) {
     int which = checkChannels(channels, numChannels);
     if (which < 0) {
       waiting.waitForAny(channels, numChannels, CthSelf());
       CthSuspend();
       which = checkChannels(channels, numChannels);
     }
+    return which;
+  }
+
+std::vector<T> receiveN(int channel, int numMsgs) {
+    std::vector<T> res;
+    for (int i = 0; i < numMsgs; i++) {
+      res.push_back(this->receive(channel));
+    }
+    return res;
+  }
+
+  void receiveNAsync(int channel, int numMsgs, CkCallback cb) {
+    ck::channel::sendToCallback(cb, this->receiveN(channel, numMsgs));
+  }
+
+  void waitN(int channel, int numMsgs) {
+    for (int i = 0; i < numMsgs; i++) {
+      this->receive(channel);
+    }
+  }
+
+  std::pair<int, T> receiveAny(int* channels, int numChannels) {
+    int which = this->waitAny(channels, numChannels);
     auto front = data[which].front();
     data[which].pop();
     return std::make_pair(which, front);
   }
 
-  void receiveFromAny(int* channels, int numChannels, CkCallback cb) {
-    sendToCallback(cb, this->receiveFromAny(channels, numChannels));
+  void receiveAnyAsync(int* channels, int numChannels, CkCallback cb) {
+    ck::channel::sendToCallback(cb, this->receiveAny(channels, numChannels));
   }
 private:
-  CkMultiWait<N> waiting;
+  ck::channel::MultiWait<N> waiting;
   std::array<std::queue<T>, N> data;
 };
 

--- a/src/libs/ck-libs/channel/channel.h
+++ b/src/libs/ck-libs/channel/channel.h
@@ -1,0 +1,54 @@
+#ifndef _CHANNEL_H_
+#define _CHANNEL_H_
+
+#include "channel.decl.h"
+#include <queue>
+
+template<typename T>
+class CkChannel : public CBase_CkChannel<T> {
+public:
+  CkChannel() {}
+  CkChannel(CkMigrateMessage*) {}
+
+  void send(T value) {
+    data.push(value);
+    if (!waiting.empty()) {
+      auto front = waiting.front();
+      waiting.pop();
+      CthAwaken(front);
+    }
+  }
+
+  inline T waitForData() {
+    if (data.empty()) {
+      waiting.push(CthSelf());
+      CthSuspend();
+    }
+    auto front = data.front();
+    data.pop();
+    return front;
+  }
+
+  T receive() {
+    return waitForData();
+  }
+
+  void receive(CkCallback cb) {
+    auto value = waitForData();
+    PUP::sizer szr;
+    szr | value;
+    CkMarshallMsg *msg = CkAllocateMarshallMsg(szr.size(), NULL);
+    PUP::toMem ppr((void *)msg->msgBuf);
+    ppr | value;
+    cb.send(msg);
+  }
+private:
+  std::queue<CthThread> waiting;
+  std::queue<T> data;
+};
+
+#define CK_TEMPLATES_ONLY
+#include "channel.def.h"
+#undef CK_TEMPLATES_ONLY
+
+#endif

--- a/src/libs/ck-libs/channel/channel.h
+++ b/src/libs/ck-libs/channel/channel.h
@@ -155,11 +155,11 @@ public:
 
   std::pair<int, T> receiveFromAny(int* channels, int numChannels) {
     int which = checkChannels(channels, numChannels);
-    if (which >= 0) goto END;
-    waiting.waitForAny(channels, numChannels, CthSelf());
-    CthSuspend();
-    which = checkChannels(channels, numChannels);
-  END:
+    if (which < 0) {
+      waiting.waitForAny(channels, numChannels, CthSelf());
+      CthSuspend();
+      which = checkChannels(channels, numChannels);
+    }
     auto front = data[which].front();
     data[which].pop();
     return std::make_pair(which, front);

--- a/src/libs/ck-libs/channel/channel.h
+++ b/src/libs/ck-libs/channel/channel.h
@@ -2,7 +2,11 @@
 #define _CHANNEL_H_
 
 #include "channel.decl.h"
+
+#include <array>
 #include <queue>
+#include <utility>
+#include <memory>
 
 template<typename T>
 class CkChannel : public CBase_CkChannel<T> {
@@ -19,7 +23,7 @@ public:
     }
   }
 
-  inline T waitForData() {
+  T receive() {
     if (data.empty()) {
       waiting.push(CthSelf());
       CthSuspend();
@@ -29,12 +33,8 @@ public:
     return front;
   }
 
-  T receive() {
-    return waitForData();
-  }
-
   void receive(CkCallback cb) {
-    auto value = waitForData();
+    auto value = this->receive();
     PUP::sizer szr;
     szr | value;
     CkMarshallMsg *msg = CkAllocateMarshallMsg(szr.size(), NULL);
@@ -45,6 +45,132 @@ public:
 private:
   std::queue<CthThread> waiting;
   std::queue<T> data;
+};
+
+template<int N>
+class CkMultiWait {
+  struct CkWaitRequest {
+    CthThread thread;
+    bool expired;
+    CkWaitRequest(const CthThread& thread_)
+    : thread(thread_), expired(false) { }
+  };
+  std::array<std::queue<std::shared_ptr<CkWaitRequest>>, N> waiting;
+public:
+  // Returns true when a thread is waiting on a channel
+  // Stores the waiting thread in the reference argument
+  bool hasWaiter(int channel, CthThread &thread) {
+    if (waiting[channel].empty()) {
+      return false;
+    } else {
+      // Pop a request from the wait-queue
+      auto request = waiting[channel].front();
+      waiting[channel].pop();
+      // If it has expired
+      if (request->expired) {
+        // Recurse and check for another waiter
+        return hasWaiter(channel, thread);
+      } else {
+        // Otherwise, mark it as expired
+        request->expired = true;
+        // And set the return values
+        thread = request->thread;
+        return true;
+      }
+    }
+  }
+  // Places a waiter into the queue for the specified channel
+  void wait(int channel, const CthThread &thread) {
+    waiting[channel].emplace(new CkWaitRequest(thread));
+  }
+  // Places a (common) waiter into the queue for all specified channels
+  void waitForAny(int* channels, int numChannels, const CthThread &thread) {
+    std::shared_ptr<CkWaitRequest> ptr(new CkWaitRequest(thread));
+    for (int i = 0; i < numChannels; i++) {
+      waiting[channels[i]].push(ptr);
+    }
+  }
+};
+
+template<int N, typename T>
+class CkMultiChannel : public CBase_CkMultiChannel<N, T> {
+  template<typename Value>
+  inline void sendToCallback(CkCallback cb, Value value) {
+    PUP::sizer szr;
+    szr | value;
+    CkMarshallMsg *msg = CkAllocateMarshallMsg(szr.size(), NULL);
+    PUP::toMem ppr((void *)msg->msgBuf);
+    ppr | value;
+    cb.send(msg);
+  }
+public:
+  CkMultiChannel() {}
+  CkMultiChannel(CkMigrateMessage*) {}
+
+  void send(int channel, T value) {
+    channel = channel % N;
+    data[channel].push(value);
+    CthThread thread;
+    if (waiting.hasWaiter(channel, thread)) {
+      CthAwaken(thread);
+    }
+  }
+
+  T receive(int channel) {
+    channel = channel % N;
+    if (data[channel].empty()) {
+      waiting.wait(channel, CthSelf());
+      CthSuspend();
+    }
+    auto front = data[channel].front();
+    data[channel].pop();
+    return front;
+  }
+
+  void receive(int channel, CkCallback cb) {
+    sendToCallback(cb, this->receive(channel));
+  }
+
+  void waitAll(int* channels, int numChannels) {
+    for (int i = 0; i < numChannels; i++) {
+      this->receive(channels[i]);
+    }
+  }
+
+  void waitN(int channel, int numMsgs) {
+    for (int i = 0; i < numMsgs; i++) {
+      this->receive(channel);
+    }
+  }
+
+  int checkChannels(int* channels, int numChannels) {
+    for (int i = 0; i < numChannels; i++) {
+      int channel = channels[i] % N;
+      if (!data[channel].empty()) {
+        return channel;
+      }
+    }
+    return -1;
+  }
+
+  std::pair<int, T> receiveFromAny(int* channels, int numChannels) {
+    int which = checkChannels(channels, numChannels);
+    if (which >= 0) goto END;
+    waiting.waitForAny(channels, numChannels, CthSelf());
+    CthSuspend();
+    which = checkChannels(channels, numChannels);
+  END:
+    auto front = data[which].front();
+    data[which].pop();
+    return std::make_pair(which, front);
+  }
+
+  void receiveFromAny(int* channels, int numChannels, CkCallback cb) {
+    sendToCallback(cb, this->receiveFromAny(channels, numChannels));
+  }
+private:
+  CkMultiWait<N> waiting;
+  std::array<std::queue<T>, N> data;
 };
 
 #define CK_TEMPLATES_ONLY

--- a/src/libs/ck-libs/channel/channel.h
+++ b/src/libs/ck-libs/channel/channel.h
@@ -60,24 +60,22 @@ public:
   // Returns true when a thread is waiting on a channel
   // Stores the waiting thread in the reference argument
   bool hasWaiter(int channel, CthThread &thread) {
-    if (waiting[channel].empty()) {
-      return false;
-    } else {
+    // While a thread is waiting on a channel
+    while (!waiting[channel].empty()) {
       // Pop a request from the wait-queue
       auto request = waiting[channel].front();
       waiting[channel].pop();
-      // If it has expired
-      if (request->expired) {
-        // Recurse and check for another waiter
-        return hasWaiter(channel, thread);
-      } else {
-        // Otherwise, mark it as expired
+      // If it is not expired
+      if (!request->expired) {
+        // Mark it as expired
         request->expired = true;
-        // And set the return values
+        // Return thread
         thread = request->thread;
         return true;
       }
     }
+    // Return nothing
+    return false;
   }
   // Places a waiter into the queue for the specified channel
   void wait(int channel, const CthThread &thread) {


### PR DESCRIPTION
First swipe at adding channels to Charm++, adding two constructs: `CkChannel` and `CkMultiChannel`. The first of which is a simple channel, with non-blocking send and blocking receive functionality. The second is, effectively, a 1D array of channels with the aforementioned functionality but adds mechanisms to get responses from multiple channels. Both objects are migratable, singleton chares.

TODOs:
- Add `pup` to channel objects.
- Write documentation for new features/examples.

Making a PR to start getting feedback. Open questions include which other API functions these objects should provide, such as:
- Should these have a "wait for a single value without saving the response" function?
- Should these have a channel closing mechanism?