### PR TITLE
cmake: add Makefile to build and run tests from tmp/

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -896,7 +896,7 @@ file(WRITE ${CMAKE_BINARY_DIR}/include/VERSION "${CHARM_VERSION}\n")
 
 
 # Copy the Makefile used for building and running tests
-configure_file(${CMAKE_SOURCE_DIR}/cmake/Makefile.tests ${CMAKE_BINARY_DIR}/tmp/Makefile COPYONLY)
+configure_file(${CMAKE_SOURCE_DIR}/cmake/Makefile.tests ${CMAKE_BINARY_DIR}/include/Makefile COPYONLY)
 
 
 # Installation rules

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -895,6 +895,10 @@ file(WRITE ${CMAKE_BINARY_DIR}/include/.vdir   "${CMK_VDIR}\n")
 file(WRITE ${CMAKE_BINARY_DIR}/include/VERSION "${CHARM_VERSION}\n")
 
 
+# Copy the Makefile used for building and running tests
+configure_file(${CMAKE_SOURCE_DIR}/cmake/Makefile.tests ${CMAKE_BINARY_DIR}/tmp/Makefile COPYONLY)
+
+
 # Installation rules
 install(DIRECTORY ${CMAKE_BINARY_DIR}/bin DESTINATION . PATTERN * PERMISSIONS OWNER_EXECUTE OWNER_WRITE OWNER_READ GROUP_EXECUTE GROUP_READ WORLD_READ WORLD_EXECUTE)
 install(DIRECTORY ${CMAKE_BINARY_DIR}/lib     DESTINATION .)

--- a/cmake/Makefile.tests
+++ b/cmake/Makefile.tests
@@ -3,7 +3,7 @@
 # The rules below are for compatibility with the CMake build system
 
 charm++:
-	make -C .. -q lib/libckpics.a || make -C ..
+	make -C .. -q lib/libmoduletcharm.a || make -C ..
 
 AMPI: charm++
 	make -C .. -q lib/libmoduleampi.a || { echo "=== You are missing the AMPI targets. Please build Charm++ with './build AMPI <...>' . ==="; exit 1; }

--- a/cmake/Makefile.tests
+++ b/cmake/Makefile.tests
@@ -1,0 +1,96 @@
+# This Makefile contains the rules to build & test Charm++
+
+# The rules below are for compatibility with the CMake build system
+
+charm++:
+	make -C .. -q lib/libckpics.a || make -C ..
+
+AMPI: charm++
+	make -C .. -q lib/libmoduleampi.a || { echo "=== You are missing the AMPI targets. Please build Charm++ with './build AMPI <...>' . ==="; exit 1; }
+
+LIBS: charm++
+	make -C .. -q lib/moduleCkCache.a || { echo "=== You are missing the LIBS targets. Please build Charm++ with './build LIBS <...>' . ==="; exit 1; }
+
+converse: charm++
+
+
+# The rules below are copied verbatim from the Makefile in the old build system
+
+all-test: all-test-tests all-test-examples all-test-benchmarks
+
+all-test-tests: LIBS
+	$(MAKE) -C ../tests all
+
+all-test-examples: LIBS
+	$(MAKE) -C ../examples all
+
+all-test-benchmarks: LIBS
+	$(MAKE) -C ../benchmarks all
+
+all-zc: charm++
+	$(MAKE) -C ../tests/charm++/zerocopy all
+	$(MAKE) -C ../examples/charm++/zerocopy all
+	$(MAKE) -C ../benchmarks/charm++/zerocopy all
+
+all-test-AMPI: all-test-AMPI-tests all-test-AMPI-examples all-test-AMPI-benchmarks
+
+all-test-AMPI-tests: AMPI
+	$(MAKE) -C ../tests/ampi all
+
+all-test-AMPI-examples: AMPI
+	$(MAKE) -C ../examples/ampi all
+
+all-test-AMPI-benchmarks: AMPI
+	$(MAKE) -C ../benchmarks/ampi all
+
+test: LIBS
+	$(MAKE) -C ../tests test
+	$(MAKE) -C ../examples test
+	$(MAKE) -C ../benchmarks test
+
+test-tests: LIBS
+	$(MAKE) -C ../tests test
+
+test-examples: LIBS
+	$(MAKE) -C ../examples test
+
+test-benchmarks: LIBS
+	$(MAKE) -C ../benchmarks test
+
+test-zc: charm++
+	$(MAKE) -C ../tests/charm++/zerocopy test
+	$(MAKE) -C ../examples/charm++/zerocopy test
+	$(MAKE) -C ../benchmarks/charm++/zerocopy test
+
+test-converse: converse test-tests-converse test-examples-converse test-benchmarks-converse
+
+test-charm: charm++ test-tests-charm test-tests-charm test-tests-charm
+
+test-AMPI: AMPI test-tests-AMPI test-examples-AMPI test-benchmarks-AMPI
+
+test-tests-converse: converse
+	$(MAKE) -C ../tests test-converse
+
+test-tests-charm: charm++
+	$(MAKE) -C ../tests test-charm
+
+test-tests-AMPI: AMPI
+	$(MAKE) -C ../tests test-AMPI
+
+test-examples-converse: converse
+	$(MAKE) -C ../examples test-converse
+
+test-examples-charm: charm++
+	$(MAKE) -C ../examples test-charm
+
+test-examples-AMPI: AMPI
+	$(MAKE) -C ../examples test-AMPI
+
+test-benchmarks-converse: converse
+	$(MAKE) -C ../benchmarks test-converse
+
+test-benchmarks-charm: charm++
+	$(MAKE) -C ../benchmarks test-charm
+
+test-benchmarks-AMPI: AMPI
+	$(MAKE) -C ../benchmarks test-AMPI


### PR DESCRIPTION
For compatibility with the old build system.