### PR TITLE
Fix for SDAG Code with Tracing Enabled

### DIFF
--- a/src/xlat-i/sdag/CSdagConstruct.C
+++ b/src/xlat-i/sdag/CSdagConstruct.C
@@ -581,7 +581,7 @@ void SdagConstruct::generateTraceBeginCall(XStr& op, int indent) {
        << "_sdag_idx_" << traceName << "()), CkMyPe(), 0, ";
 
     if (entry->getContainer()->isArray())
-      op << "ckGetArrayIndex().getProjectionID()";
+      op << "this->ckGetArrayIndex().getProjectionID()";
     else
       op << "NULL";
 
@@ -594,7 +594,7 @@ void SdagConstruct::generateDummyBeginExecute(XStr& op, int indent, Entry* entry
   op << "_TRACE_BEGIN_EXECUTE_DETAILED(-1, -1, _sdagEP, CkMyPe(), 0, ";
 
   if (entry->getContainer()->isArray())
-    op << "ckGetArrayIndex().getProjectionID()";
+    op << "this->ckGetArrayIndex().getProjectionID()";
   else
     op << "NULL";
 


### PR DESCRIPTION
This issue fixes an error Ajay reported on Slack, in which `ckGetArrayIndex` requires a prefix of `this->` for the code to compile. Reproducible by trying to compile templated SDAG code with `--enable-tracing`, errors take the form:

    ./data_container.def.h:1075:63: error: use of undeclared identifier 'ckGetArrayIndex'
    _TRACE_BEGIN_EXECUTE_DETAILED(-1, -1, _sdagEP, CkMyPe(), 0, ckGetArrayIndex()....
                                                                ^
    ./data_container.def.h:1158:92: error: use of undeclared identifier 'ckGetArrayIndex'
    ...-1, (_sdag_idx_DataContainer_serial_0()), CkMyPe(), 0, ckGetArrayIndex().getProj...
                                                                ^
    data_container.def.h:1229:92: error: use of undeclared identifier 'ckGetArrayIndex'
    ...-1, (_sdag_idx_DataContainer_serial_1()), CkMyPe(), 0, ckGetArrayIndex().getProj...
                                                                ^
    data_container.def.h:1249:92: error: use of undeclared identifier 'ckGetArrayIndex'
    ...-1, (_sdag_idx_DataContainer_serial_2()), CkMyPe(), 0, ckGetArrayIndex().getProj...
                                                                ^
    data_container.def.h:1291:92: error: use of undeclared identifier 'ckGetArrayIndex'
    ...-1, (_sdag_idx_DataContainer_serial_3()), CkMyPe(), 0, ckGetArrayIndex().getProj...
                                                                ^
    data_container.def.h:1331:65: error: use of undeclared identifier 'ckGetArrayIndex'
        _TRACE_BEGIN_EXECUTE_DETAILED(-1, -1, _sdagEP, CkMyPe(), 0, ckGetArrayIndex(...
                                                                    ^
    data_container.def.h:1355:65: error: use of undeclared identifier 'ckGetArrayIndex'
        _TRACE_BEGIN_EXECUTE_DETAILED(-1, -1, _sdagEP, CkMyPe(), 0, ckGetArrayIndex(...
                                                                    ^
    7 errors generated.