### PR TITLE
cmake: add conv-mach-smp for gni/persistent

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -88,6 +88,7 @@ option(CHARMDEBUG          "Enable charmDebug" OFF)
 option(REPLAY              "Enable record/replay" OFF)
 option(CCS                 "Enable CCS" OFF)
 option(CONTROLPOINT        "Enable control point" OFF)
+option(PERSISTENT          "Enable Persistent Communication API" OFF)
 option(LBUSERDATA          "Enable LB user data" OFF)
 option(LOCKLESS_QUEUE      "Enable lockless queue for PE local and node queue" OFF)
 option(SHRINKEXPAND        "Enable malleable jobs / shrink expand" OFF)
@@ -536,6 +537,14 @@ if(EXISTS ${CMAKE_SOURCE_DIR}/src/arch/${GDIR}/conv-mach-syncft.h)
   configure_file(src/arch/${GDIR}/conv-mach-syncft.h            include/ COPYONLY)
 endif()
 
+if(EXISTS ${CMAKE_SOURCE_DIR}/src/arch/${GDIR}/machine-persistent.h)
+  configure_file(src/arch/${GDIR}/machine-persistent.h          include/ COPYONLY)
+endif()
+
+if(EXISTS ${CMAKE_SOURCE_DIR}/src/arch/${GDIR}/machine-persistent.C)
+  configure_file(src/arch/${GDIR}/machine-persistent.C          include/ COPYONLY)
+endif()
+
 if(UCX_PMI)
   configure_file(${CMAKE_SOURCE_DIR}/src/arch/${VDIR}/conv-mach-${UCX_PMI}.sh include/ COPYONLY)
   configure_file(${CMAKE_SOURCE_DIR}/src/arch/${VDIR}/conv-mach-${UCX_PMI}.h include/ COPYONLY)
@@ -854,7 +863,7 @@ foreach(l BUILD_CUDA CMK_AMPI_WITH_ROMIO CMK_MACOSX CMK_BLUEGENEQ CMK_BUILD_PYTH
 endforeach(l)
 
 # Add options
-foreach(opt SMP OMP TCP PTHREADS SYNCFT PXSHM)
+foreach(opt SMP OMP TCP PTHREADS SYNCFT PXSHM PERSISTENT)
     if(${opt})
         string(TOLOWER ${opt} optl)
         file(APPEND ${optfile_sh} ". ${CMAKE_BINARY_DIR}/include/conv-mach-${optl}.sh\n")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -517,6 +517,11 @@ if(EXISTS ${CMAKE_SOURCE_DIR}/src/arch/${VDIR}/conv-mach-smp.sh)
   configure_file(src/arch/${VDIR}/conv-mach-smp.h            include/ COPYONLY)
 endif()
 
+if(EXISTS ${CMAKE_SOURCE_DIR}/src/arch/${GDIR}/conv-mach-smp.sh)
+  configure_file(src/arch/${GDIR}/conv-mach-smp.sh           include/ COPYONLY)
+  configure_file(src/arch/${GDIR}/conv-mach-smp.h            include/ COPYONLY)
+endif()
+
 if(EXISTS ${CMAKE_SOURCE_DIR}/src/arch/${GDIR}/conv-mach-tcp.sh)
   configure_file(src/arch/${GDIR}/conv-mach-tcp.sh           include/ COPYONLY)
   configure_file(src/arch/${GDIR}/conv-mach-tcp.h            include/ COPYONLY)

--- a/buildcmake
+++ b/buildcmake
@@ -77,6 +77,7 @@ opt_network=0
 opt_numa=0
 opt_omp=0
 opt_parallel=-j1
+opt_persistent=0
 opt_prio_type="bitvec"
 opt_production=0
 opt_pthreads=0
@@ -146,6 +147,9 @@ while [[ $# -gt 0 ]]; do
       ;;
     slumrpmi|slurmpmi2|ompipmix)
       opt_ucx_pmi=$arg
+      ;;
+    persistent)
+      opt_persistent=1
       ;;
   # Compilers
     gcc)
@@ -378,7 +382,7 @@ done
 
 # Append certain features and compilers to the end of the build directory name
 builddir_extra=""
-for flag in opt_omp opt_smp opt_tcp opt_pthreads opt_pxshm opt_syncft; do
+for flag in opt_omp opt_smp opt_tcp opt_pthreads opt_pxshm opt_syncft opt_persistent; do
   [[ $flag -eq 1 ]] && builddir_extra+="-${flag/opt_/}"
 done
 
@@ -427,6 +431,7 @@ CC=$opt_CC CXX=$opt_CXX FC=$opt_FC cmake .. \
   -DNETWORK="$opt_network" \
   -DNUMA="$opt_numa" \
   -DOMP="$opt_omp" \
+  -DPERSISTENT="opt_persistent" \
   -DPRIO_TYPE="$opt_prio_type" \
   -DPTHREADS="$opt_pthreads" \
   -DPXSHM="$opt_pxshm" \

--- a/buildcmake
+++ b/buildcmake
@@ -431,7 +431,7 @@ CC=$opt_CC CXX=$opt_CXX FC=$opt_FC cmake .. \
   -DNETWORK="$opt_network" \
   -DNUMA="$opt_numa" \
   -DOMP="$opt_omp" \
-  -DPERSISTENT="opt_persistent" \
+  -DPERSISTENT="$opt_persistent" \
   -DPRIO_TYPE="$opt_prio_type" \
   -DPTHREADS="$opt_pthreads" \
   -DPXSHM="$opt_pxshm" \


### PR DESCRIPTION
Fixes the autobuild failure.