### PR TITLE
Check if __has_include is defined before using it

### DIFF
--- a/src/arch/util/machine-smp.C
+++ b/src/arch/util/machine-smp.C
@@ -81,12 +81,13 @@ CmiIdleLock_checkMessage
 #include "machine-smp.h"
 #include "sockRoutines.h"
 
-#if __has_include(<barrier>)
-#  include <barrier>
-#else
-#  include <mutex>
-#  include <condition_variable>
+#if defined(__has_include)
+#  if __has_include(<barrier>)
+#    include <barrier>
+#  endif
 #endif
+#include <mutex>
+#include <condition_variable>
 
 void CmiStateInit(int pe, int rank, CmiState state);
 void CommunicationServerInit(void);


### PR DESCRIPTION
Fixes 1cadca2c05b7eaa6f5339a6a0b5890610bcead6e.