### PR TITLE
AMPI: Temporarily disable formatted print statements in privatization test

### DIFF
--- a/tests/ampi/privatization/test-f90-tlsglobals.f90
+++ b/tests/ampi/privatization/test-f90-tlsglobals.f90
@@ -23,8 +23,9 @@
         integer :: rank, ierr
 
         call mpi_comm_rank(MPI_COMM_WORLD, rank, ierr)
-        print 1000, rank
-        1000 format ('[', I0, '] About to migrate.')
+        ! Uncomment here and below when issue #2932 is fixed.
+        ! print 1000, rank
+        ! 1000 format ('[', I0, '] About to migrate.')
 
       end subroutine about_to_migrate
 
@@ -36,8 +37,8 @@
         integer :: rank, ierr
 
         call mpi_comm_rank(MPI_COMM_WORLD, rank, ierr)
-        print 2000, rank
-        2000 format ('[', I0, '] Just migrated.')
+        ! print 2000, rank
+        ! 2000 format ('[', I0, '] Just migrated.')
 
       end subroutine just_migrated
 

--- a/tests/ampi/privatization/test-f90.f90
+++ b/tests/ampi/privatization/test-f90.f90
@@ -20,8 +20,9 @@
         integer :: rank, ierr
 
         call mpi_comm_rank(MPI_COMM_WORLD, rank, ierr)
-        print 1000, rank
-        1000 format ('[', I0, '] About to migrate.')
+        ! Uncomment here and below when issue #2932 is fixed.
+        ! print 1000, rank
+        ! 1000 format ('[', I0, '] About to migrate.')
 
       end subroutine about_to_migrate
 
@@ -33,8 +34,8 @@
         integer :: rank, ierr
 
         call mpi_comm_rank(MPI_COMM_WORLD, rank, ierr)
-        print 2000, rank
-        2000 format ('[', I0, '] Just migrated.')
+        ! print 2000, rank
+        ! 2000 format ('[', I0, '] Just migrated.')
 
       end subroutine just_migrated
 


### PR DESCRIPTION
Prevents #2932 from causing autobuild to fail.