### PR TITLE
charm4py: cleanups

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -92,7 +92,6 @@ option(PERSISTENT          "Enable Persistent Communication API" OFF)
 option(LBUSERDATA          "Enable LB user data" OFF)
 option(LOCKLESS_QUEUE      "Enable lockless queue for PE local and node queue" OFF)
 option(SHRINKEXPAND        "Enable malleable jobs / shrink expand" OFF)
-option(CHARMPY             "Enable CharmPy support" OFF)
 option(NUMA                "Support memory affinity with NUMA" OFF)
 set(LBTIME_TYPE "double" CACHE STRING "Load balancing timer type")
 option(QLOGIC              "QLogic based Infiniband" OFF)
@@ -230,7 +229,6 @@ set(CMK_WITH_CONTROLPOINT ${CONTROLPOINT})
 set(CMK_WITH_STATS ${STATS})
 
 set(CMK_CHARMDEBUG ${CHARMDEBUG})
-set(CMK_CHARMPY ${CHARMPY})
 
 
 set(CMK_MSG_PRIO_TYPE ${PRIO_TYPE})
@@ -361,8 +359,9 @@ if(${CMAKE_BUILD_TYPE} MATCHES "Release" OR ${CMAKE_BUILD_TYPE} MATCHES "RelWith
     set(OPTSATBUILDTIME "${OPTSATBUILDTIME} -optimize -production")
 endif()
 
-if(${TARGET} STREQUAL "charm4py" OR ${TARGET} STREQUAL "charmpy")
-  set(CMK_CHARMPY 1)
+set(CMK_CHARM4PY 0)
+if(${TARGET} STREQUAL "charm4py")
+  set(CMK_CHARM4PY 1)
   # Create libcharm.so for Charm4py
   add_compile_options(-build-shared)
   set(BUILDOPTS "${BUILDOPTS} -build-shared")
@@ -780,7 +779,7 @@ if(${NETWORK} STREQUAL "uth")
 endif()
 
 # Charm4py
-if(${TARGET} STREQUAL "charm4py" OR ${TARGET} STREQUAL "charmpy")
+if(${TARGET} STREQUAL "charm4py")
   # Create libcharm.so for Charm4py
   # add_compile_options(-build-shared)
   file(WRITE empty.cpp "// This file left intentionally blank. It is used for the charm4py build.")

--- a/README.charm4py
+++ b/README.charm4py
@@ -14,7 +14,7 @@ Adding modules (e.g. load balancers) to libcharm.so
 ---------------------------------------------------
 
 Currently, modules need to be manually registered (there is a section in
-init.C with #if CMK_CHARMPY where this can be done), and the LIBCHARM_LIBS variable in the Makefile
+init.C with #if CMK_CHARM4PY where this can be done), and the LIBCHARM_LIBS variable in the Makefile
 needs to be modified to include the module.
 
 Developer documentation
@@ -76,7 +76,7 @@ during linking of final program executable.
 
 Problem is that when accesing the Charm shared library from Charm4py, these functions
 are never defined, so I have disabled calls to them in some cases, or bypassed with alternative
-code with #if CMK_CHARMPY macro.
+code with #if CMK_CHARM4PY macro.
 
 This means that I implemented an alternative way of registering the main
 module, via a callback to external client (called from init.C).

--- a/buildcmake
+++ b/buildcmake
@@ -71,7 +71,6 @@ opt_ampi_only=0
 opt_build_shared=0
 opt_ccs=0
 opt_charmdebug=0
-opt_charmpy=0
 opt_controlpoint=0
 opt_cuda=0
 opt_drone_mode=0
@@ -268,9 +267,6 @@ while [[ $# -gt 0 ]]; do
     --enable-shrinkexpand)
       opt_shrinkexpand=1
       ;;
-    --enable-charmpy)
-      opt_charmpy=1
-      ;;
     --with-numa)
       opt_numa=1
       ;;
@@ -435,7 +431,6 @@ CC=$opt_CC CXX=$opt_CXX FC=$opt_FC cmake .. \
   -DBUILD_SHARED="$opt_build_shared" \
   -DCCS="$opt_ccs" \
   -DCHARMDEBUG="$opt_charmdebug" \
-  -DCHARMPY="$opt_charmpy" \
   -DCONTROLPOINT="$opt_controlpoint" \
   -DBUILD_CUDA="$opt_cuda" \
   -DDRONE_MODE="$opt_drone_mode" \

--- a/buildold
+++ b/buildold
@@ -632,7 +632,7 @@ then
 fi
 
 # build for Charm4py
-if [ "$PROGRAM" = "charmpy" ] || [ "$PROGRAM" = "charm4py" ]; then
+if [ "$PROGRAM" = "charm4py" ]; then
 
     if [ -n "$BOPTS" ] && [ "$HAS_SMP" -eq 1 ]; then
         echo "Error: SMP mode is currently not supported with charm4py. Choose a non-smp version."
@@ -644,9 +644,9 @@ if [ "$PROGRAM" = "charmpy" ] || [ "$PROGRAM" = "charm4py" ]; then
         exit 1
     fi
 
-    if test `echo "$CONFIG_OPTS" | grep -c "\--enable-charmpy"` -eq 0
+    if test `echo "$CONFIG_OPTS" | grep -c "\--enable-charm4py"` -eq 0
     then
-        CONFIG_OPTS="$CONFIG_OPTS --enable-charmpy"
+        CONFIG_OPTS="$CONFIG_OPTS --enable-charm4py"
     fi
 
     if test `echo "$BASEVERSION" | grep -c "win"` -gt 0

--- a/src/arch/netlrts/machine.C
+++ b/src/arch/netlrts/machine.C
@@ -950,7 +950,7 @@ static int sendone_abort_fn(SOCKET skt,int code,const char *msg) {
 	// so printing an error makes no sense. The message is not seen normally
 	// since processes are spawned by charmrun as DETACHED_PROCESS by default and
 	// have no console output.
-	// With CMK_CHARMPY=1 on Windows, charmrun spawns one process in same console,
+	// With CMK_CHARM4PY=1 on Windows, charmrun spawns one process in same console,
 	// because any output before charm starts needs to be seen (e.g. Python syntax errors)
 	// so this print needs to be disabled
 	fprintf(stderr,"Socket error %d in ctrl_sendone! %s\n",code,msg);

--- a/src/ck-core/charm++.h
+++ b/src/ck-core/charm++.h
@@ -355,7 +355,7 @@ class IrrGroup : public Chare {
 #endif
 };
 
-#if CMK_CHARMPY
+#if CMK_CHARM4PY
 
 extern void (*GroupMsgRecvExtCallback)(int, int, int, char *, int);        // callback to forward received msg to external Group chare
 extern void (*ChareMsgRecvExtCallback)(int, void*, int, int, char *, int); // callback to forward received msg to external Chare
@@ -1098,7 +1098,7 @@ typedef CProxySection_Group CProxySection_IrrGroup;
 //Defines the actual "Group"
 #include "ckreduction.h"
 
-#if CMK_CHARMPY
+#if CMK_CHARM4PY
 
 /// Lightweight object to support chares defined outside of the C/C++ runtime
 /// Relays messages to appropiate external chare. See README.charm4py

--- a/src/ck-core/charm.h
+++ b/src/ck-core/charm.h
@@ -118,7 +118,7 @@ extern void* CkPriorityPtr(void *msg);
  * Functions be to called from external clients (e.g. Charm4py)
  *
  *****************************************************************************/
-#if CMK_CHARMPY
+#if CMK_CHARM4PY
 
 extern void registerCkRegisterMainModuleCallback(void (*cb)(void));
 extern void registerMainchareCtorExtCallback(void (*cb)(int, void*, int, int, char **));
@@ -212,7 +212,7 @@ extern void CkRegisterMigCtor(int chareIndex, int ctorEpIndex);
 extern void CkRegisterGroupIrr(int chareIndex,int isIrr);
 /** Register the chare baseIdx as a base class of the chare derivedIdx. */
 extern void CkRegisterBase(int derivedIdx, int baseIdx);
-#if CMK_CHARMPY
+#if CMK_CHARM4PY
 extern void CkRegisterMainChareExt(const char *s, int numEntryMethods, int *chareIdx, int *startEpIdx);
 extern void CkRegisterGroupExt(const char *s, int numEntryMethods, int *chareIdx, int *startEpIdx);
 extern void CkRegisterSectionManagerExt(const char *s, int numEntryMethods, int *chareIdx, int *startEpIdx);
@@ -293,7 +293,7 @@ extern CkGroupID CkCreateNodeGroup(int chareIdx, int constructorIdx, void *msg);
 extern void CkCreateLocalGroup(CkGroupID groupID, int constructorIdx, envelope *env);
 extern void CkCreateLocalNodeGroup(CkGroupID groupID, int constructorIdx, envelope *env);
 
-#if CMK_CHARMPY
+#if CMK_CHARM4PY
 extern int CkCreateGroupExt(int cIdx, int eIdx, int num_bufs, char **bufs, int *buf_sizes);
 extern int CkCreateArrayExt(int cIdx, int ndims, int *dims, int eIdx, int num_bufs, char **bufs, int *buf_sizes, int map_gid, char useAtSync);
 extern void CkInsertArrayExt(int aid, int ndims, int *index, int epIdx, int onPE, int num_bufs, char **bufs, int *buf_sizes, char useAtSync);
@@ -406,7 +406,7 @@ extern void *CkLocalChare(const CkChareID *chare);
 
 extern void CkArrayManagerDeliver(int onPe,void *msg, int opts CK_MSGOPTIONAL);
 
-#if CMK_CHARMPY
+#if CMK_CHARM4PY
 /// Send msg to chare with ID (onPe,objPtr) to entry method 'epIdx'
 extern void CkChareExtSend(int onPE, void *objPtr, int epIdx, char *msg, int msgSize);
 /// Send msg to chare copying data into CkMessage from multiple input buffers

--- a/src/ck-core/ck.C
+++ b/src/ck-core/ck.C
@@ -2142,7 +2142,7 @@ void CkDeleteChares() {
 
 
 //------------------- External client support (e.g. Charm4py) ----------------
-#if CMK_CHARMPY
+#if CMK_CHARM4PY
 
 static std::vector< std::vector<char> > ext_args;
 static std::vector<char*> ext_argv;

--- a/src/ck-core/ckarray.C
+++ b/src/ck-core/ckarray.C
@@ -456,7 +456,7 @@ void ArrayElement::CkAbort(const char *format, ...) const
 void ArrayElement::recvBroadcast(CkMessage *m){
 }
 
-#if CMK_CHARMPY
+#if CMK_CHARM4PY
 
 ArrayElemExt::ArrayElemExt(void *impl_msg)
 {
@@ -1292,7 +1292,7 @@ bool CkArrayBroadcaster::deliver(CkArrayMessage *bcast, ArrayElement *el,
   }
 }
 
-#if CMK_CHARMPY
+#if CMK_CHARM4PY
 
 extern void (*ArrayBcastRecvExtCallback)(int, int, int, int, int *, int, int, char *, int);
 
@@ -1560,7 +1560,7 @@ void CkArray::recvBroadcast(CkMessage* m) {
   } else
 #endif
   {
-#if CMK_CHARMPY
+#if CMK_CHARM4PY
     broadcaster->deliver(msg, localElemVec, thisgroup.idx, stableLocations);
 #else
     for (unsigned int i = 0; i < len; ++i) {
@@ -1575,7 +1575,7 @@ void CkArray::recvBroadcast(CkMessage* m) {
       broadcaster->deliver(msg, (ArrayElement*)localElemVec[i], doFree);
     }
 
-#endif // CMK_CHARMPY
+#endif // CMK_CHARM4PY
   }
 
   // CkArrayBroadcaster doesn't have msg buffered, and there was no last

--- a/src/ck-core/ckarray.h
+++ b/src/ck-core/ckarray.h
@@ -425,7 +425,7 @@ typedef ArrayElementT<CkIndex5D> ArrayElement5D;
 typedef ArrayElementT<CkIndex6D> ArrayElement6D;
 typedef ArrayElementT<CkIndexMax> ArrayElementMax;
 
-#if CMK_CHARMPY
+#if CMK_CHARM4PY
 
 extern void (*ArrayMsgRecvExtCallback)(int, int, int *, int, int, char *, int);
 extern int (*ArrayElemLeaveExt)(int, int, int *, char**, int);
@@ -796,7 +796,7 @@ public:
   int incrementBcastNo();
 
   bool deliver(CkArrayMessage *bcast, ArrayElement *el, bool doFree);
-#if CMK_CHARMPY
+#if CMK_CHARM4PY
   void deliver(CkArrayMessage *bcast, std::vector<CkMigratable*> &elements, int arrayId, bool doFree);
 #endif
 

--- a/src/ck-core/ckcallback.C
+++ b/src/ck-core/ckcallback.C
@@ -178,7 +178,7 @@ CkCallback::CkCallback(int ep,const CProxyElement_ArrayBase &arrElt,bool forceIn
         d.array.refnum = 0;
 }
 
-#if !CMK_CHARMPY
+#if !CMK_CHARM4PY
 CkCallback::CkCallback(int ep,CProxySection_ArrayBase &sectElt,bool forceInline) {
 #if CMK_ERROR_CHECKING
       memset(this, 0, sizeof(CkCallback));
@@ -223,7 +223,7 @@ CkCallback::CkCallback(ArrayElement *p, int ep,bool forceInline) {
         d.array.refnum = 0;
 }
 
-#if CMK_CHARMPY
+#if CMK_CHARM4PY
 
 // currently this is only used with Charm4py, so we are only enabling it for that case
 // to guarantee best performance for non-charm4py applications
@@ -320,7 +320,7 @@ void CkCallback::send(void *msg) const
   // immediate entry method
   int opts = 0;
 
-#if CMK_CHARMPY
+#if CMK_CHARM4PY
   if (isExtCallback) { // callback target is external
     CkCallbackSendExt(*this, msg);
     return;
@@ -417,7 +417,7 @@ void CkCallback::send(void *msg) const
                 if (d.array.hasRefnum) CkSetRefNum(msg, d.array.refnum);
 		CkBroadcastMsgArray(d.array.ep, msg, d.array.id);
 		break;
-#if !CMK_CHARMPY
+#if !CMK_CHARM4PY
 	case bcastSection: {
 		if(!msg)msg=CkAllocSysMsg();
                 if (d.section.hasRefnum) CkSetRefNum(msg, d.section.refnum);
@@ -506,7 +506,7 @@ void CkCallback::pup(PUP::er &p) {
   default:
     CkAbort("Inconsistent CkCallback type");
   }
-#if CMK_CHARMPY
+#if CMK_CHARM4PY
   p|isExtCallback;
 #endif
 }
@@ -525,7 +525,7 @@ bool CkCallback::containsPointer() const {
   case bcastGroup:
   case bcastNodeGroup:
   case bcastArray:
-#if CMK_CHARMPY
+#if CMK_CHARM4PY
   case bcastSection:
 #endif
     return false;
@@ -534,7 +534,7 @@ bool CkCallback::containsPointer() const {
   case callCFn:
   case call1Fn:
   case replyCCS:
-#if !CMK_CHARMPY
+#if !CMK_CHARM4PY
   case bcastSection:
 #endif
     return true;

--- a/src/ck-core/ckcallback.h
+++ b/src/ck-core/ckcallback.h
@@ -117,7 +117,7 @@ private:
 		CMK_REFNUM_TYPE refnum; // Reference number to set on the message
 		bool hasRefnum;
 	} array;
-#if CMK_CHARMPY
+#if CMK_CHARM4PY
 	struct s_section {
 		int sid_pe; // section ID
 		int sid_cnt; // section ID
@@ -148,7 +148,7 @@ private:
 public:
 	callbackType type;
 	callbackData d;
-#if CMK_CHARMPY
+#if CMK_CHARM4PY
 	bool isExtCallback = false;
 #endif
 
@@ -201,7 +201,7 @@ public:
 		  d.cfn.onPE == other.d.cfn.onPE &&
 		  d.cfn.param == other.d.cfn.param);
 	    case bcastSection:
-#if CMK_CHARMPY
+#if CMK_CHARM4PY
 	      return (d.section.sid_pe == other.d.section.sid_pe &&
 		d.section.sid_cnt == other.d.section.sid_cnt &&
 		d.section.rootPE == other.d.section.rootPE &&
@@ -333,7 +333,7 @@ public:
     // Bcast to array
 	CkCallback(int ep,const CProxyElement_ArrayBase &arrElt,bool forceInline=false);
 	
-#if !CMK_CHARMPY
+#if !CMK_CHARM4PY
 	//Bcast to section
 	CkCallback(int ep,CProxySection_ArrayBase &sectElt,bool forceInline=false);
 	CkCallback(int ep, CkSectionID &sid);
@@ -359,7 +359,7 @@ public:
 	  d.ccsReply.reply=reply;
 	}
 
-#if CMK_CHARMPY
+#if CMK_CHARM4PY
 
   CkCallback(int onPE, void* objPtr, int ep, CMK_REFNUM_TYPE fid) {
     CkChareID id;
@@ -488,7 +488,7 @@ public:
                   d.array.refnum = refnum;
                   break;
 
-#if !CMK_CHARMPY
+#if !CMK_CHARM4PY
                 case bcastSection:
                   d.section.hasRefnum = true;
                   d.section.refnum = refnum;

--- a/src/ck-core/cklocation.h
+++ b/src/ck-core/cklocation.h
@@ -126,7 +126,7 @@ public:
   std::unordered_map<int, bool> dynamicIns;
 };
 
-#if CMK_CHARMPY
+#if CMK_CHARM4PY
 
 extern int (*ArrayMapProcNumExtCallback)(int, int, const int *);
 

--- a/src/ck-core/ckreduction.C
+++ b/src/ck-core/ckreduction.C
@@ -86,7 +86,7 @@ waits for the migrant contributions to straggle in.
 #endif
 
 extern bool _inrestart;
-#if CMK_CHARMPY
+#if CMK_CHARM4PY
 //define a global instance of CkReductionTypesExt for external access
 CkReductionTypesExt charm_reducers;
 extern int (*PyReductionExt)(char**, int*, int, char**);
@@ -1676,7 +1676,7 @@ CkReductionMsg* CkReduction::tupleReduction_fn(int num_messages, CkReductionMsg*
 }
 
 
-#if CMK_CHARMPY
+#if CMK_CHARM4PY
 /////////////// external Python reducer ////////////////
 static CkReductionMsg *external_py(int nMsgs, CkReductionMsg **msg)
 {
@@ -1839,7 +1839,7 @@ std::vector<CkReduction::reducerStruct> CkReduction::initReducerTable()
   // Allows multiple reductions to be done in the same message
   vec.emplace_back(CkReduction::tupleReduction_fn, false, "CkReduction::tuple");
 
-#if CMK_CHARMPY
+#if CMK_CHARM4PY
   // Perform reduction using an external reducer defined in Python
   vec.emplace_back(CkReduction::reducerStruct(::external_py, false, "CkReduction::custom_python"));
 #endif
@@ -1855,7 +1855,7 @@ std::vector<CkReduction::reducerStruct>& CkReduction::reducerTable()
   return table;
 }
 
-#if CMK_CHARMPY
+#if CMK_CHARM4PY
 
 // Enum to detect type of contributors in a reduction
 typedef enum : uint8_t {

--- a/src/ck-core/ckreduction.h
+++ b/src/ck-core/ckreduction.h
@@ -271,7 +271,7 @@ private:
 };
 PUPbytes(CkReduction::reducerType)
 
-#if CMK_CHARMPY
+#if CMK_CHARM4PY
 //CkReductionTypesExt struct to expose the reducerTypes for external
 //modules like Charm4py
         /*  !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!

--- a/src/ck-core/init.C
+++ b/src/ck-core/init.C
@@ -72,7 +72,7 @@ never be excluded...
 #include <sstream>
 #include <limits.h>
 #include "spanningTree.h"
-#if CMK_CHARMPY
+#if CMK_CHARM4PY
 #include "TreeLB.h"
 #endif
 
@@ -1505,7 +1505,7 @@ void _initCharm(int unused_argc, char **argv)
 #if CMK_MEM_CHECKPOINT
 		_registerCkMemCheckpoint();
 #endif
-#if CMK_CHARMPY
+#if CMK_CHARM4PY
                 /**
                   Load balancers are currently registered in Charm++ through a C file that is generated and
                   and compiled by charmc when making an executable. That file contains appropriate calls to
@@ -1521,7 +1521,7 @@ void _initCharm(int unused_argc, char **argv)
 		  "mainmodule" .ci file.  It will include calls to 
 		  register all the .ci files.
 		*/
-#if !CMK_CHARMPY
+#if !CMK_CHARM4PY
 		CkRegisterMainModule();
 #else
                 // CkRegisterMainModule doesn't exist in charm4py because there is no executable.
@@ -1542,7 +1542,7 @@ void _initCharm(int unused_argc, char **argv)
 		  programs, which don't have a .ci file and hence have
 		  no other way to control the _register process.
 		*/
-#if !CMK_CHARMPY
+#if !CMK_CHARM4PY
 		_registerExternalModules(argv);
 #endif
 	}

--- a/src/ck-core/register.C
+++ b/src/ck-core/register.C
@@ -44,7 +44,7 @@ static
 int CkRegisterEpInternal(const char *name, CkCallFnPtr call, int msgIdx, int chareIdx,
 	int ck_ep_flags, bool isTemplated)
 {
-#if !CMK_CHARMPY    // charm4py can support dynamic registration of Chares after program start
+#if !CMK_CHARM4PY    // charm4py can support dynamic registration of Chares after program start
   if (__registerDone) {
     CkPrintf("Charm++: late entry method registration happened after init\nEntry point: %s, addr: %p\n", name, call);
     CkAbort("Did you forget to import a module or instantiate a templated entry method in a .ci file?\n");
@@ -96,7 +96,7 @@ void CkRegisterGroupIrr(int chareIndex,int isIrr){
   _chareTable[chareIndex]->isIrr = (isIrr!=0);
 }
 
-#if CMK_CHARMPY
+#if CMK_CHARM4PY
 
 // TODO give a unique name to entry methods when calling CkRegisterEp
 // (no need has appeared for this so this is very low priority)
@@ -182,7 +182,7 @@ int CkRegisterMainChare(int chareIdx, int entryIdx)
   return mIdx;
 }
 
-#if CMK_CHARMPY
+#if CMK_CHARM4PY
 
 void CkRegisterMainChareExt(const char *s, int numEntryMethods, int *chareIdx, int *startEpIdx) {
   int __idx = CkRegisterChare(s, sizeof(MainchareExt), TypeMainChare);
@@ -220,7 +220,7 @@ void CkRegisterReadonly(const char *name,const char *type,
   _readonlyTable.add(new ReadonlyInfo(name,type,size,ptr,pup_fn));
 }
 
-#if CMK_CHARMPY
+#if CMK_CHARM4PY
 void CkRegisterReadonlyExt(const char *name, const char *type, size_t msgSize, char *msg) {
   if (msgSize > 0) ReadOnlyExt::setData(msg, msgSize);
   CkRegisterReadonly(name, type, msgSize, ReadOnlyExt::ro_data, ReadOnlyExt::_roPup);

--- a/src/ck-perf/trace-common.C
+++ b/src/ck-perf/trace-common.C
@@ -435,7 +435,7 @@ static inline void _traceInit(char **argv)
   // check if trace is turned on/off for this pe
   CkpvAccess(traceOnPe) = checkTraceOnPe(argv);
 
-#if !CMK_CHARMPY
+#if !CMK_CHARM4PY
   // defined in moduleInit.C
   _createTraces(argv);
 #endif

--- a/src/scripts/Makefile
+++ b/src/scripts/Makefile
@@ -99,8 +99,6 @@ f90charm: charm++ $(L)/libf90charm.a
 libcharm: charm++
 	cd $(L) ; $(CHARMC) -standalone -whole-archive -c++stl -shared -o libcharm.so $(LIBCHARM_LIBS)
 
-charmpy: libcharm
-
 charm4py: libcharm
 
 LIBCHARM_LIBS= libck.a libconv-core.a libconv-util.a libmemory-default.a libconv-machine.a \

--- a/src/scripts/configure.ac
+++ b/src/scripts/configure.ac
@@ -370,19 +370,19 @@ else
   AC_DEFINE_UNQUOTED(CMK_SHRINK_EXPAND, 0, [disable shrinkexpand])
 fi
 
-AC_ARG_ENABLE([charmpy],
-            [AS_HELP_STRING([--enable-charmpy],
+AC_ARG_ENABLE([charm4py],
+            [AS_HELP_STRING([--enable-charm4py],
               [enable charm4py support])],
-            [enable_charmpy=$enableval],
-            [enable_charmpy=no])
+            [enable_charm4py=$enableval],
+            [enable_charm4py=no])
 
-if test "$enable_charmpy" = "yes"
+if test "$enable_charm4py" = "yes"
 then
   Echo "charm4py support is enabled"
-  AC_DEFINE_UNQUOTED(CMK_CHARMPY, 1, [enable charmpy])
+  AC_DEFINE_UNQUOTED(CMK_CHARM4PY, 1, [enable charm4py])
 else
   Echo "charm4py support is disabled"
-  AC_DEFINE_UNQUOTED(CMK_CHARMPY, 0, [disable charmpy])
+  AC_DEFINE_UNQUOTED(CMK_CHARM4PY, 0, [disable charm4py])
 fi
 
 AC_ARG_WITH([numa],
@@ -824,7 +824,7 @@ then
 fi
 
 # Determine compiler/linker flags to build libcharm.so for charm4py
-if test "$enable_charmpy" = "yes"
+if test "$enable_charm4py" = "yes"
 then
 
   cat > $t <<EOT

--- a/src/util/charmrun-src/charmrun.C
+++ b/src/util/charmrun-src/charmrun.C
@@ -4464,7 +4464,7 @@ struct local_nodestart
                         NULL, /*&sa,*/ /* process SA */
                         NULL, /*&sa,*/ /* thread SA */
                         FALSE,         /* inherit flag */
-#if CMK_CHARMPY
+#if CMK_CHARM4PY
                         // don't disable console output on rank 0 process (need to be able to see python syntax errors, etc)
                         CREATE_NEW_PROCESS_GROUP | (p.nodeno == 0 ? 0 : DETACHED_PROCESS),
 #elif 1
@@ -5577,7 +5577,7 @@ struct local_nodestart
 
     posix_spawn_file_actions_t file_actions;
     posix_spawn_file_actions_init(&file_actions);
-#if CMK_CHARMPY
+#if CMK_CHARM4PY
     // don't disable initial output on rank 0 process (need to be able to see python syntax errors, etc)
     if (p.nodeno != 0)
 #endif
@@ -5620,7 +5620,7 @@ struct local_nodestart
     }
     if (pid == 0) {
       int fd, fd2 = dup(2);
-#if CMK_CHARMPY
+#if CMK_CHARM4PY
       // don't disable initial output on rank 0 process (need to be able to see python syntax errors, etc)
       if ((p.nodeno != 0) && (-1 != (fd = open("/dev/null", O_RDWR)))) {
 #else


### PR DESCRIPTION
- rename all remaining 'charmpy' references to 'charm4py'
- remove charmpy cmake build option ('charm4py' must be the target)