### PR TITLE
ARMCI: Add libmodulearmci.dep

### DIFF
--- a/src/libs/ck-libs/CMakeLists.txt
+++ b/src/libs/ck-libs/CMakeLists.txt
@@ -13,6 +13,7 @@ add_library(modulemsa multiphaseSharedArrays/msa.h multiphaseSharedArrays/msa-co
 add_dependencies(modulemsa ck)
 
 # armci
+configure_file(armci/libmodulearmci.dep ${CMAKE_BINARY_DIR}/lib COPYONLY)
 configure_file(armci/armci.h ${CMAKE_BINARY_DIR}/include COPYONLY)
 add_library(modulearmci armci/armci_vp.C armci/armci_impl.h armci/armci_api.C armci/armci.h)
 add_dependencies(modulearmci ck)

--- a/src/libs/ck-libs/armci/Makefile
+++ b/src/libs/ck-libs/armci/Makefile
@@ -1,12 +1,15 @@
 CDIR=../../../..
 CHARMC=$(CDIR)/bin/charmc $(OPTS)
 
-DEST= $(CDIR)/lib/libmodulearmci.a
+ARMCI_LIB := libmodulearmci
+ARMCI_LIBDIR := $(CDIR)/lib
+DEST := $(ARMCI_LIBDIR)/$(ARMCI_LIB).a
 
 all: $(DEST)
 
 $(DEST): armci_vp.o armci_api.o 
 	$(CHARMC) armci_vp.o armci_api.o -o $@
+	cp $(ARMCI_LIB).dep $(ARMCI_LIBDIR)/$(ARMCI_LIB).dep
 	cp armci.h $(CDIR)/include
 
 armci_vp.o: armci_vp.C armci.decl.h armci.def.h armci_impl.h

--- a/src/libs/ck-libs/armci/libmodulearmci.dep
+++ b/src/libs/ck-libs/armci/libmodulearmci.dep
@@ -1,0 +1,1 @@
+-module tcharm


### PR DESCRIPTION
Fixes errors due to not linking with -ltcharm-compat.