### PR TITLE
cmake: remove warning regarding CheckIncludeFile

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,10 @@
 
 cmake_minimum_required(VERSION 3.4)
 
+if(CMAKE_VERSION VERSION_GREATER 3.11)
+  cmake_policy(SET CMP0075 OLD)
+endif()
+
 # Fortran is optional, so don't include it in LANGUAGES here
 project(Charm++ LANGUAGES CXX C VERSION 6.10.1)
 


### PR DESCRIPTION
Fixes #2948.
Tested with cmake 3.4, 3.10, 3.11, 3.17.