### PR TITLE
AMPI Benchmarks: Add a testp target for scalable testing on P pes

### DIFF
--- a/benchmarks/ampi/Makefile
+++ b/benchmarks/ampi/Makefile
@@ -7,9 +7,18 @@ DIRS = \
 
 TESTDIRS = $(DIRS)
 
+NONSCALEDIRS = \
+  onesided \
+  pingpong \
+  speed \
+
+TESTPDIRS = $(filter-out $(NONSCALEDIRS),$(TESTDIRS))
+
 all: $(foreach i,$(DIRS),build-$i)
 
 test: $(foreach i,$(TESTDIRS),test-$i)
+
+testp: $(foreach i,$(TESTPDIRS),testp-$i)
 
 clean: $(foreach i,$(DIRS),clean-$i)
 	rm -f TAGS #*#
@@ -20,6 +29,9 @@ $(foreach i,$(DIRS),build-$i):
 
 $(foreach i,$(DIRS),test-$i):
 	$(MAKE) -C $(subst test-,,$@) test OPTS='$(OPTS)' TESTOPTS='$(TESTOPTS)'
+
+$(foreach i,$(TESTPDIRS),testp-$i):
+	$(MAKE) -C $(subst testp-,,$@) testp OPTS='$(OPTS)' TESTOPTS='$(TESTOPTS)' P='$(P)'
 
 $(foreach i,$(DIRS),clean-$i):
 	$(MAKE) -C $(subst clean-,,$@) clean OPTS='$(OPTS)'

--- a/benchmarks/ampi/alltoall/Makefile
+++ b/benchmarks/ampi/alltoall/Makefile
@@ -46,8 +46,9 @@ test-mpi: all-mpi
 	mpirun -n 4 ./mpibench.mpi
 
 testp: all
-	$(call run, +p$(P) ./mpibench +vp2)
-	mpirun -n $(P) ./mpibench.mpi
+	$(call run, +p$(P) ./mpibench +vp$(P) )
+	$(call run, +p$(P) ./mpibench +vp$$(( $(P) * 2 )) )
+	$(call run, +p$(P) ./mpibench +vp$$(( $(P) * 4 )) )
 
 clean:
 	rm -rf *~ *.o alltoall mpibench mpibench.mpi charmrun conv-host allgather ampirun

--- a/benchmarks/ampi/alltoall/Makefile
+++ b/benchmarks/ampi/alltoall/Makefile
@@ -45,5 +45,9 @@ test: all
 test-mpi: all-mpi
 	mpirun -n 4 ./mpibench.mpi
 
+testp: all
+	$(call run, +p$(P) ./mpibench +vp2)
+	mpirun -n $(P) ./mpibench.mpi
+
 clean:
 	rm -rf *~ *.o alltoall mpibench mpibench.mpi charmrun conv-host allgather ampirun

--- a/benchmarks/ampi/isomalloc/Makefile
+++ b/benchmarks/ampi/isomalloc/Makefile
@@ -56,8 +56,9 @@ test-$1: $1
 	$$(call run, ./$1 +p2 +vp4 $(TESTFLAGS) )
 
 testp-$1: $1
-	$$(call run, ./$1 +p$(P) +vp1 $(TESTFLAGS) )
-	$$(call run, ./$1 +p$(P) +vp2 $(TESTFLAGS) )
+	$$(call run, ./$1 +p$(P) +vp$(P) $(TESTFLAGS) )
+	$$(call run, ./$1 +p$(P) +vp$$(( $(P) * 2 )) $(TESTFLAGS) )
+	$$(call run, ./$1 +p$(P) +vp$$(( $(P) * 4 )) $(TESTFLAGS) )
 
 endef
 

--- a/benchmarks/ampi/isomalloc/Makefile
+++ b/benchmarks/ampi/isomalloc/Makefile
@@ -34,6 +34,7 @@ TESTFLAGS := +balancer RandCentLB
 # build rules
 all: $(foreach i,$(TARGETS),$i)
 test: $(foreach i,$(TARGETS),test-$i)
+testp: $(foreach i,$(TARGETS),testp-$i)
 
 everything: $(foreach i,$(VARIANTS),$i)
 test-everything: $(foreach i,$(VARIANTS),test-$i)
@@ -53,6 +54,10 @@ test-$1: $1
 	$$(call run, ./$1 +p1 +vp4 $(TESTFLAGS) )
 	$$(call run, ./$1 +p2 +vp2 $(TESTFLAGS) )
 	$$(call run, ./$1 +p2 +vp4 $(TESTFLAGS) )
+
+testp-$1: $1
+	$$(call run, ./$1 +p$(P) +vp1 $(TESTFLAGS) )
+	$$(call run, ./$1 +p$(P) +vp2 $(TESTFLAGS) )
 
 endef
 


### PR DESCRIPTION
It looks like

  onesided \
  pingpong \
  speed \

are designed for 2 PE runs. 