### PR TITLE
ci: add multicore-darwin with tracing test

### DIFF
--- a/.github/workflows/multicore_darwin.yml
+++ b/.github/workflows/multicore_darwin.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - name: build
-      run: ./build all-test multicore-darwin-x86_64 -g -j3 --with-production --enable-tracing --enable-tracing-commthread
+      run: ./build all-test multicore-darwin-x86_64 -g -j3 --with-production --enable-tracing
     - name: test
       run: |
         make -C multicore-darwin-x86_64/tests all -j3 OPTS="-tracemode projections"

--- a/.github/workflows/multicore_darwin.yml
+++ b/.github/workflows/multicore_darwin.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: macos-latest
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
     - name: build
       run: ./build all-test multicore-darwin-x86_64 -g -j3 --with-production --enable-tracing
     - name: test

--- a/.github/workflows/multicore_darwin.yml
+++ b/.github/workflows/multicore_darwin.yml
@@ -1,0 +1,22 @@
+name: Multicore Darwin tracing
+
+on: [push]
+
+jobs:
+  build:
+    timeout-minutes: 60
+
+    runs-on: macos-latest
+
+    steps:
+    - uses: actions/checkout@v1
+    - name: build
+      run: ./build all-test multicore-darwin-x86_64 -g -j3 --with-production --enable-tracing --enable-tracing-commthread
+    - name: test
+      run: |
+        make -C multicore-darwin-x86_64/tests all -j3 OPTS="-tracemode projections"
+        make -C multicore-darwin-x86_64/tests test
+        make -C multicore-darwin-x86_64/examples all -j3 OPTS="-tracemode projections"
+        make -C multicore-darwin-x86_64/examples test
+        make -C multicore-darwin-x86_64/benchmarks all -j3 OPTS="-tracemode projections"
+        make -C multicore-darwin-x86_64/benchmarks test

--- a/.github/workflows/multicore_darwin.yml
+++ b/.github/workflows/multicore_darwin.yml
@@ -10,11 +10,6 @@ jobs:
 
     steps:
     - uses: actions/checkout@v1
-    - name: projections
-      run: |
-        git clone https://github.com/UIUC-PPL/projections
-        cd projections
-        make
     - name: build
       run: ./build all-test multicore-darwin-x86_64 -g -j3 --with-production --enable-tracing --enable-tracing-commthread
     - name: test
@@ -25,3 +20,11 @@ jobs:
         make -C multicore-darwin-x86_64/examples test
         make -C multicore-darwin-x86_64/benchmarks all -j3 OPTS="-tracemode projections"
         make -C multicore-darwin-x86_64/benchmarks test
+    - name: projections
+      run: |
+        git clone https://github.com/UIUC-PPL/projections
+        cd projections
+        make
+        cd ../multicore-darwin-x86_64/tests/charm++/megatest
+        ../../../../projections/bin/projections --exit pgm.sts
+        

--- a/.github/workflows/multicore_darwin.yml
+++ b/.github/workflows/multicore_darwin.yml
@@ -10,6 +10,11 @@ jobs:
 
     steps:
     - uses: actions/checkout@v1
+    - name: projections
+      run: |
+        git clone https://github.com/UIUC-PPL/projections
+        cd projections
+        make
     - name: build
       run: ./build all-test multicore-darwin-x86_64 -g -j3 --with-production --enable-tracing --enable-tracing-commthread
     - name: test

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,15 @@
 
 cmake_minimum_required(VERSION 3.4)
 
+# Print warning
+message("#################################################################")
+message("# The CMake build system is currently a beta version.           #")
+message("# Please let us know if you experience any problems by opening  #")
+message("# an issue on our GitHub (https://github.com/UIUC-PPL/charm),   #")
+message("# with the below configuration information.                     #")
+message("# You can run './buildold' to use the previous build system.    #")
+message("#################################################################")
+
 if(CMAKE_VERSION VERSION_GREATER 3.11)
   cmake_policy(SET CMP0075 OLD)
 endif()
@@ -911,10 +920,34 @@ if(NOT opts_enabled)
   set(opts_enabled "---")
 endif()
 
+# Get version information
+find_program(GIT git)
+
+if(GIT)
+  execute_process(COMMAND git describe --exact-match --dirty=*
+             OUTPUT_VARIABLE CHARM_VERSION_GIT
+             RESULT_VARIABLE git_result
+             OUTPUT_STRIP_TRAILING_WHITESPACE
+             ERROR_QUIET
+             )
+  if(NOT ${git_result} EQUAL 0)
+    execute_process(COMMAND git describe --long --always --dirty=*
+             OUTPUT_VARIABLE CHARM_VERSION_GIT
+             OUTPUT_STRIP_TRAILING_WHITESPACE
+             )
+    set(CHARM_REL "(dev)")
+  else()
+    set(CHARM_REL "(release)")
+  endif()
+else()
+  set(CHARM_VERSION_GIT "v${CHARM_VERSION}")
+endif()
+
 # Print configuration
 message("==============================")
 message("Charm++ ${PROJECT_VERSION} configuration: ")
 message("  OS version:      ${OS_RELEASE}")
+message("  Charm++ version: ${CHARM_VERSION_GIT} ${CHARM_REL}")
 message("  Hostname:        ${MY_HOSTNAME}")
 message("  Machine layer:   ${CHARM_PLATFORM}")
 message("  Build target:    ${TARGET}")
@@ -930,15 +963,6 @@ message("  CMake:           ${CMAKE_COMMAND} [${CMAKE_VERSION}]")
 message("  Charmc flags:    ${MAIN_CFLAGS}")
 message("  Enabled options: ${opts_enabled}")
 message("==============================")
-
-# Print warning
-message("#################################################################")
-message("# The CMake build system is currently a beta version.           #")
-message("# Please let us know if you experience any problems by opening  #")
-message("# an issue on our GitHub (https://github.com/UIUC-PPL/charm),   #")
-message("# with the above configuration information.                     #")
-message("# You can run ./buildold to use the previous build system.      #")
-message("#################################################################")
 
 # Make symlinks
 add_custom_target(create_symlinks ALL


### PR DESCRIPTION
Also tests that the stats files (`.sts`) generated from tracing megatest can be loaded by Projections.