### PR TITLE
Fix projections logs for CREATION_{BCAST, MULTICAST} broken in e77ede

### DIFF
--- a/src/ck-perf/trace-projections.C
+++ b/src/ck-perf/trace-projections.C
@@ -878,13 +878,13 @@ void LogEntry::pup(PUP::er &p)
     case CREATION_BCAST:
       if (p.isPacking()) irecvtime = (CMK_TYPEDEF_UINT8)(1.0e6*recvTime);
       p|mIdx; p|eIdx; p|itime;
-      p|event; p|pe; p|msglen; p|irecvtime;
+      p|event; p|pe; p|msglen; p|irecvtime; p|pes.size();
       if (p.isUnpacking()) recvTime = irecvtime/1.0e6;
       break;
     case CREATION_MULTICAST:
       if (p.isPacking()) irecvtime = (CMK_TYPEDEF_UINT8)(1.0e6*recvTime);
       p|mIdx; p|eIdx; p|itime;
-      p|event; p|pe; p|msglen; p|irecvtime;
+      p|event; p|pe; p|msglen; p|irecvtime; p|pes.size();
       p|pes;
       if (p.isUnpacking()) recvTime = irecvtime/1.0e6;
       break;

--- a/src/ck-perf/trace-projections.C
+++ b/src/ck-perf/trace-projections.C
@@ -878,15 +878,25 @@ void LogEntry::pup(PUP::er &p)
     case CREATION_BCAST:
       if (p.isPacking()) irecvtime = (CMK_TYPEDEF_UINT8)(1.0e6*recvTime);
       p|mIdx; p|eIdx; p|itime;
-      p|event; p|pe; p|msglen; p|irecvtime; p|pes.size();
-      if (p.isUnpacking()) recvTime = irecvtime/1.0e6;
+      p|event; p|pe; p|msglen; p|irecvtime;
+      { // Needed to control the scope of numpes
+        int numpes = pes.size();
+        p | numpes;
+        if (p.isUnpacking()) pes.resize(numpes);
+      }
+      if (p.isUnpacking()) recvTime = irecvtime / 1.0e6;
       break;
     case CREATION_MULTICAST:
       if (p.isPacking()) irecvtime = (CMK_TYPEDEF_UINT8)(1.0e6*recvTime);
       p|mIdx; p|eIdx; p|itime;
-      p|event; p|pe; p|msglen; p|irecvtime; p|pes.size();
-      p|pes;
-      if (p.isUnpacking()) recvTime = irecvtime/1.0e6;
+      p|event; p|pe; p|msglen; p|irecvtime;
+      { // Needed to control the scope of numpes
+        int numpes = pes.size();
+        p | numpes;
+        if (p.isUnpacking()) pes.resize(numpes);
+      }
+      p | pes;
+      if (p.isUnpacking()) recvTime = irecvtime / 1.0e6;
       break;
     case MESSAGE_RECV:
       p|mIdx; p|eIdx; p|itime; p|event; p|pe; p|msglen;


### PR DESCRIPTION
e77edeca133aa0c7584a6b89d555cf408abc6887 removed the number of PEs from the `LogEntry::pup` function, which Projections needs to read the logs.