### PR TITLE
AMR: Fix hashing and update style of custom array index

### DIFF
--- a/src/libs/ck-libs/amr/bitvec.h
+++ b/src/libs/ck-libs/amr/bitvec.h
@@ -1,34 +1,38 @@
-#define MAXDIMENSION 3
+#include <array>
+
+constexpr int MAXDIMENSION = 3;
+
 class BitVec
 {
- public:
-  unsigned short vec[MAXDIMENSION];
-  short  numbits;
-  BitVec() {
-    vec[0] = 0;
-    vec[1] = 0;
-    vec[2] = 0;
+public:
+  std::array<unsigned short, MAXDIMENSION> vec;
+  short numbits;
+  BitVec()
+  {
+    vec.fill(0);
     numbits = 0;
   }
-  BitVec(unsigned short *in_vec , short nobits){
-    memset(vec, 0,(sizeof(unsigned short)*MAXDIMENSION));
-    memcpy(vec, in_vec, (sizeof (unsigned short)*MAXDIMENSION));
-    numbits = nobits ;
+  BitVec(const BitVec& in)
+  {
+    vec = in.vec;
+    numbits = in.numbits;
   }
-  void pup(PUP::er &p){
-    p(vec, MAXDIMENSION);
-    p(numbits);
+  void pup(PUP::er& p)
+  {
+    p | vec;
+    p | numbits;
   }
 };
 
-			 
-class CkArrayIndexBitVec : public CkArrayIndex 
+class CkArrayIndexBitVec : public CkArrayIndex
 {
- public:
-  BitVec vecIndex;
-  CkArrayIndexBitVec(){}
-  CkArrayIndexBitVec(const BitVec &in) {
-    vecIndex = in;
-    nInts = sizeof(vecIndex)/sizeof(int);
+private:
+  BitVec* vecIndex;
+
+public:
+  CkArrayIndexBitVec(const BitVec& in)
+  {
+    vecIndex = new (index) BitVec(in);
+    nInts = sizeof(BitVec) / sizeof(int);
   }
 };


### PR DESCRIPTION
Use placement new to put custom BitVec array index in the index member
of CkArrayIndex.