### PR TITLE
TRAM: Change test to use 2 PEs to avoid hang on UCX

### DIFF
--- a/tests/charm++/varTRAM/Makefile
+++ b/tests/charm++/varTRAM/Makefile
@@ -16,12 +16,13 @@ vartest.o: vartest.C vartest.def.h
 	$(CHARMC) $(CHARMCFLAGS) -c vartest.C
 
 test: vartest
-	$(call run, ./vartest +p4 8 100 100)
+	$(call run, ./vartest +p2 8 100 100)
 
 testp: vartest
 	$(call run, ./vartest +p$(P) $$(( $(P) * 10 )) 100 100)
 
 smptest: vartest
 	$(call run, ./vartest 8 100 100 +p4 ++ppn 2)
+
 clean:
 	rm -f *.o *.decl.h *.def.h vartest charmrun*


### PR DESCRIPTION
Related to #2987.
The varTRAM test hangs when PEs are oversubscribed in the UCX build, e.g. 4 PEs on 2 physical cores of GitHub CI.
This is a band-aid solution to avoid oversubscribing which causes the hang, but the test itself and/or TRAM internals should be ultimately fixed to not hang even with oversubscription.