### PR TITLE
Make relink.script more resilient

### DIFF
--- a/relink.script
+++ b/relink.script
@@ -23,11 +23,12 @@ fi
 
 subdirs="bin include lib lib_so tmp"
 
+# remove symbolic link
+rm -f $subdirs
+
 for i in $subdirs
 do
-  # remove symbolic link
-  rm -f "$i"
-  # skip nonexistent subdir
+# skip nonexistent subdir
   test ! -d "$1/$i" && continue;
   echo ln -s "$1/$i" "$i"
   ln -s "$1/$i" "$i"

--- a/relink.script
+++ b/relink.script
@@ -23,12 +23,11 @@ fi
 
 subdirs="bin include lib lib_so tmp"
 
-# remove symbolic link
-rm -f "$subdirs"
-
 for i in $subdirs
 do
-# skip nonexistent subdir
+  # remove symbolic link
+  rm -f "$i"
+  # skip nonexistent subdir
   test ! -d "$1/$i" && continue;
   echo ln -s "$1/$i" "$i"
   ln -s "$1/$i" "$i"

--- a/relink.script
+++ b/relink.script
@@ -24,6 +24,7 @@ fi
 subdirs="bin include lib lib_so tmp"
 
 # remove symbolic link
+# shellcheck disable=SC2086
 rm -f $subdirs
 
 for i in $subdirs


### PR DESCRIPTION
If one of subdirs was missing, rm would fail to remove any of
them, so now rm each member of subdirs individually.