### PR TITLE
Verbs Machine Layer: Add incorrectly removed rdma ack handling code

### DIFF
--- a/src/arch/verbs/machine-ibverbs.C
+++ b/src/arch/verbs/machine-ibverbs.C
@@ -1839,6 +1839,10 @@ static inline void processRecvWC(struct ibv_wc *recvWC,const int toBuffer){
 			processRdmaRequest(rdmaPacket,nodeNo,0);
 		}*/
 	}
+	if(rdma && header->code == INFIRDMA_ACK){ // Ack processing for RDMA operations issued by the regular API (through LrtsSendFunc)
+		struct infiRdmaPacket *rdmaPacket = (struct infiRdmaPacket *)(buffer->buf+sizeof(struct infiPacketHeader)) ;
+		processRdmaAck(rdmaPacket);
+	}
 #if CMK_ONESIDED_IMPL
 	if(header->code == INFIRDMA_DIRECT_REG_AND_PUT){
 		// Register the source buffer and perform PUT


### PR DESCRIPTION
This code is exercised when sending large messages through the regular API (from LrtsSendFunc)