### PR TITLE
Update hapiPoolMalloc to match signature of cudaMallocHost

### DIFF
--- a/examples/charm++/cuda/matmul/matmul.C
+++ b/examples/charm++/cuda/matmul/matmul.C
@@ -135,14 +135,14 @@ class Workers : public CBase_Workers {
     NVTXTracer nvtx_range("Workers::~Workers", NVTXColor::WetAsphalt);
 #endif
 
-    hapiFreeHost(h_A);
-    hapiFreeHost(h_B);
-    hapiFreeHost(h_C);
+    hapiCheck(cudaFreeHost(h_A));
+    hapiCheck(cudaFreeHost(h_B));
+    hapiCheck(cudaFreeHost(h_C));
     hapiCheck(cudaStreamDestroy(stream));
 #ifndef USE_WR
-    hapiFree(d_A);
-    hapiFree(d_B);
-    hapiFree(d_C);
+    hapiCheck(cudaFree(d_A));
+    hapiCheck(cudaFree(d_B));
+    hapiCheck(cudaFree(d_C));
 
     if (useCublas) cublasDestroy(handle);
 #endif

--- a/examples/charm++/cuda/vecadd/vecadd.C
+++ b/examples/charm++/cuda/vecadd/vecadd.C
@@ -122,14 +122,14 @@ class Workers : public CBase_Workers {
     NVTXTracer nvtx_range("Workers::~Workers", NVTXColor::WetAsphalt);
 #endif
 
-    hapiFreeHost(h_A);
-    hapiFreeHost(h_B);
-    hapiFreeHost(h_C);
+    hapiCheck(cudaFreeHost(h_A));
+    hapiCheck(cudaFreeHost(h_B));
+    hapiCheck(cudaFreeHost(h_C));
     hapiCheck(cudaStreamDestroy(stream));
 #ifndef USE_WR
-    hapiFree(d_A);
-    hapiFree(d_B);
-    hapiFree(d_C);
+    hapiCheck(cudaFree(d_A));
+    hapiCheck(cudaFree(d_B));
+    hapiCheck(cudaFree(d_C));
 #endif
   }
 

--- a/src/arch/cuda/hybridAPI/README.txt
+++ b/src/arch/cuda/hybridAPI/README.txt
@@ -80,11 +80,6 @@ and is set as the default.
     Use CUDA callback based scheme for Charm++ callback support. Default scheme
     is based on CUDA events.
 
-  HAPI_MEMPOOL
-    Allocate a pool of page-locked memory in advance to draw allocations from.
-    Can be useful when page-locked memory are frequently allocated/freed during
-    program execution.
-
   HAPI_TRACE
     Time for invocation and completion of GPU events (e.g. memory allocation,
     data transfer, kernel execution) are recorded.

--- a/src/arch/cuda/hybridAPI/hapi.h
+++ b/src/arch/cuda/hybridAPI/hapi.h
@@ -5,15 +5,6 @@
 /* See hapi_functions.h for the majority of function declarations provided
  * by the Hybrid API. */
 
-// HAPI wrappers for pinned host memory allocation
-#ifdef HAPI_MEMPOOL
-#define hapiMallocHost hapiPoolMalloc
-#define hapiFreeHost   hapiPoolFree
-#else
-#define hapiMallocHost cudaMallocHost
-#define hapiFreeHost   cudaFreeHost
-#endif // HAPI_MEMPOOL
-
 #ifdef __cplusplus
 
 #include <cstring>
@@ -271,10 +262,10 @@ static inline void hapiAddCallback(cudaStream_t a, void* b) {
 
 // Overloaded C++ wrappers for selecting whether to pool or not using a bool.
 static inline cudaError_t hapiMallocHost(void** ptr, size_t size, bool pool) {
-  return pool ? hapiMallocHostPool(ptr, size) : hapiMallocHost(ptr, size);
+  return pool ? hapiPoolMalloc(ptr, size) : hapiMallocHost(ptr, size);
 }
 static inline cudaError_t hapiFreeHost(void* ptr, bool pool) {
-  return pool ? hapiFreeHostPool(ptr) : hapiFreeHost(ptr);
+  return pool ? hapiPoolFree(ptr) : hapiFreeHost(ptr);
 }
 
 #endif /* defined __cplusplus */

--- a/src/arch/cuda/hybridAPI/hapi.h
+++ b/src/arch/cuda/hybridAPI/hapi.h
@@ -269,6 +269,14 @@ static inline void hapiAddCallback(cudaStream_t a, void* b) {
   hapiAddCallback(a, b, NULL);
 }
 
+// Overloaded C++ wrappers for selecting whether to pool or not using a bool.
+static inline cudaError_t hapiMallocHost(void** ptr, size_t size, bool pool) {
+  return pool ? hapiMallocHostPool(ptr, size) : hapiMallocHost(ptr, size);
+}
+static inline cudaError_t hapiFreeHost(void* ptr, bool pool) {
+  return pool ? hapiFreeHostPool(ptr) : hapiFreeHost(ptr);
+}
+
 #endif /* defined __cplusplus */
 
 #endif /* !defined AMPI_INTERNAL_SKIP_FUNCTIONS */

--- a/src/arch/cuda/hybridAPI/hapi.h
+++ b/src/arch/cuda/hybridAPI/hapi.h
@@ -269,14 +269,6 @@ static inline void hapiAddCallback(cudaStream_t a, void* b) {
   hapiAddCallback(a, b, NULL);
 }
 
-// Overloaded C++ wrappers for selecting whether to pool or not using a bool.
-static inline cudaError_t hapiMallocHost(void** ptr, size_t size, bool pool) {
-  return pool ? hapiMallocHostPool(ptr, size) : hapiMallocHost(ptr, size);
-}
-static inline cudaError_t hapiFreeHost(void* ptr, bool pool) {
-  return pool ? hapiFreeHostPool(ptr) : hapiFreeHost(ptr);
-}
-
 #endif /* defined __cplusplus */
 
 #endif /* !defined AMPI_INTERNAL_SKIP_FUNCTIONS */

--- a/src/arch/cuda/hybridAPI/hapi.h
+++ b/src/arch/cuda/hybridAPI/hapi.h
@@ -5,21 +5,14 @@
 /* See hapi_functions.h for the majority of function declarations provided
  * by the Hybrid API. */
 
-/******************** DEPRECATED ********************/
-// HAPI wrappers whose behavior is controlled by user defined variables,
-// which are HAPI_USE_CUDAMALLOCHOST and HAPI_MEMPOOL.
-#ifdef HAPI_USE_CUDAMALLOCHOST
-#  ifdef HAPI_MEMPOOL
-#    define hapiHostMalloc hapiPoolMalloc
-#    define hapiHostFree   hapiPoolFree
-#  else
-#    define hapiHostMalloc cudaMallocHost
-#    define hapiHostFree   cudaFreeHost
-#  endif // HAPI_MEMPOOL
+// HAPI wrappers for pinned host memory allocation
+#ifdef HAPI_MEMPOOL
+#define hapiHostMalloc hapiPoolMalloc
+#define hapiHostFree   hapiPoolFree
 #else
-#  define hapiHostMalloc malloc
-#  define hapiHostFree   free
-#endif // HAPI_USE_CUDAMALLOCHOST
+#define hapiHostMalloc cudaMallocHost
+#define hapiHostFree   cudaFreeHost
+#endif // HAPI_MEMPOOL
 
 #ifdef __cplusplus
 

--- a/src/arch/cuda/hybridAPI/hapi.h
+++ b/src/arch/cuda/hybridAPI/hapi.h
@@ -7,11 +7,11 @@
 
 // HAPI wrappers for pinned host memory allocation
 #ifdef HAPI_MEMPOOL
-#define hapiHostMalloc hapiPoolMalloc
-#define hapiHostFree   hapiPoolFree
+#define hapiMallocHost hapiPoolMalloc
+#define hapiFreeHost   hapiPoolFree
 #else
-#define hapiHostMalloc cudaMallocHost
-#define hapiHostFree   cudaFreeHost
+#define hapiMallocHost cudaMallocHost
+#define hapiFreeHost   cudaFreeHost
 #endif // HAPI_MEMPOOL
 
 #ifdef __cplusplus

--- a/src/arch/cuda/hybridAPI/hapi_functions.h
+++ b/src/arch/cuda/hybridAPI/hapi_functions.h
@@ -43,7 +43,7 @@ AMPI_CUSTOM_FUNC(cudaError_t, hapiFreeHostPool, void*)
 AMPI_CUSTOM_FUNC(cudaError_t, hapiMemcpyAsync, void*, const void*, size_t, enum cudaMemcpyKind, cudaStream_t)
 
 // Explicit memory allocations using pinned memory pool.
-AMPI_CUSTOM_FUNC(void*, hapiPoolMalloc, size_t)
+AMPI_CUSTOM_FUNC(void, hapiPoolMalloc, void**, size_t)
 AMPI_CUSTOM_FUNC(void, hapiPoolFree, void*)
 
 // Provides support for detecting errors with CUDA API calls.

--- a/src/arch/cuda/hybridAPI/hapi_functions.h
+++ b/src/arch/cuda/hybridAPI/hapi_functions.h
@@ -33,6 +33,15 @@ AMPI_CUSTOM_FUNC(cudaStream_t, hapiGetStream, void)
 // a kernel invocation.
 AMPI_CUSTOM_FUNC(void, hapiAddCallback, cudaStream_t, void*, void*)
 
+// Thin wrappers for memory related CUDA API calls.
+AMPI_CUSTOM_FUNC(cudaError_t, hapiMalloc, void**, size_t)
+AMPI_CUSTOM_FUNC(cudaError_t, hapiFree, void*)
+AMPI_CUSTOM_FUNC(cudaError_t, hapiMallocHost, void**, size_t)
+AMPI_CUSTOM_FUNC(cudaError_t, hapiFreeHost, void*)
+AMPI_CUSTOM_FUNC(cudaError_t, hapiMallocHostPool, void**, size_t)
+AMPI_CUSTOM_FUNC(cudaError_t, hapiFreeHostPool, void*)
+AMPI_CUSTOM_FUNC(cudaError_t, hapiMemcpyAsync, void*, const void*, size_t, enum cudaMemcpyKind, cudaStream_t)
+
 // Explicit memory allocations using pinned memory pool.
 AMPI_CUSTOM_FUNC(cudaError_t, hapiPoolMalloc, void**, size_t)
 AMPI_CUSTOM_FUNC(cudaError_t, hapiPoolFree, void*)

--- a/src/arch/cuda/hybridAPI/hapi_functions.h
+++ b/src/arch/cuda/hybridAPI/hapi_functions.h
@@ -43,8 +43,8 @@ AMPI_CUSTOM_FUNC(cudaError_t, hapiFreeHostPool, void*)
 AMPI_CUSTOM_FUNC(cudaError_t, hapiMemcpyAsync, void*, const void*, size_t, enum cudaMemcpyKind, cudaStream_t)
 
 // Explicit memory allocations using pinned memory pool.
-AMPI_CUSTOM_FUNC(void, hapiPoolMalloc, void**, size_t)
-AMPI_CUSTOM_FUNC(void, hapiPoolFree, void*)
+AMPI_CUSTOM_FUNC(cudaError_t, hapiPoolMalloc, void**, size_t)
+AMPI_CUSTOM_FUNC(cudaError_t, hapiPoolFree, void*)
 
 // Provides support for detecting errors with CUDA API calls.
 AMPI_CUSTOM_FUNC(void, hapiErrorDie, cudaError_t, const char*, const char*, int)

--- a/src/arch/cuda/hybridAPI/hapi_functions.h
+++ b/src/arch/cuda/hybridAPI/hapi_functions.h
@@ -38,8 +38,6 @@ AMPI_CUSTOM_FUNC(cudaError_t, hapiMalloc, void**, size_t)
 AMPI_CUSTOM_FUNC(cudaError_t, hapiFree, void*)
 AMPI_CUSTOM_FUNC(cudaError_t, hapiMallocHost, void**, size_t)
 AMPI_CUSTOM_FUNC(cudaError_t, hapiFreeHost, void*)
-AMPI_CUSTOM_FUNC(cudaError_t, hapiMallocHostPool, void**, size_t)
-AMPI_CUSTOM_FUNC(cudaError_t, hapiFreeHostPool, void*)
 AMPI_CUSTOM_FUNC(cudaError_t, hapiMemcpyAsync, void*, const void*, size_t, enum cudaMemcpyKind, cudaStream_t)
 
 // Explicit memory allocations using pinned memory pool.

--- a/src/arch/cuda/hybridAPI/hapi_functions.h
+++ b/src/arch/cuda/hybridAPI/hapi_functions.h
@@ -33,15 +33,6 @@ AMPI_CUSTOM_FUNC(cudaStream_t, hapiGetStream, void)
 // a kernel invocation.
 AMPI_CUSTOM_FUNC(void, hapiAddCallback, cudaStream_t, void*, void*)
 
-// Thin wrappers for memory related CUDA API calls.
-AMPI_CUSTOM_FUNC(cudaError_t, hapiMalloc, void**, size_t)
-AMPI_CUSTOM_FUNC(cudaError_t, hapiFree, void*)
-AMPI_CUSTOM_FUNC(cudaError_t, hapiMallocHost, void**, size_t)
-AMPI_CUSTOM_FUNC(cudaError_t, hapiFreeHost, void*)
-AMPI_CUSTOM_FUNC(cudaError_t, hapiMallocHostPool, void**, size_t)
-AMPI_CUSTOM_FUNC(cudaError_t, hapiFreeHostPool, void*)
-AMPI_CUSTOM_FUNC(cudaError_t, hapiMemcpyAsync, void*, const void*, size_t, enum cudaMemcpyKind, cudaStream_t)
-
 // Explicit memory allocations using pinned memory pool.
 AMPI_CUSTOM_FUNC(cudaError_t, hapiPoolMalloc, void**, size_t)
 AMPI_CUSTOM_FUNC(cudaError_t, hapiPoolFree, void*)

--- a/src/arch/cuda/hybridAPI/hapi_impl.cpp
+++ b/src/arch/cuda/hybridAPI/hapi_impl.cpp
@@ -1481,37 +1481,6 @@ void hapiAddCallback(cudaStream_t stream, void* cb, void* cb_msg) {
   hapiQdCreate(1);
 }
 
-cudaError_t hapiMalloc(void** devPtr, size_t size) {
-  return cudaMalloc(devPtr, size);
-}
-
-cudaError_t hapiFree(void* devPtr) {
-  return cudaFree(devPtr);
-}
-
-cudaError_t hapiMallocHost(void** ptr, size_t size) {
-  return cudaMallocHost(ptr, size);
-}
-
-cudaError_t hapiMallocHostPool(void** ptr, size_t size) {
-  hapiPoolMalloc(ptr, size);
-  if (*ptr) return cudaSuccess;
-  else return cudaErrorMemoryAllocation;
-}
-
-cudaError_t hapiFreeHost(void* ptr) {
-  return cudaFreeHost(ptr);
-}
-
-cudaError_t hapiFreeHostPool(void *ptr) {
-  hapiPoolFree(ptr);
-  return cudaSuccess;
-}
-
-cudaError_t hapiMemcpyAsync(void* dst, const void* src, size_t count, cudaMemcpyKind kind, cudaStream_t stream = 0) {
-  return cudaMemcpyAsync(dst, src, count, kind, stream);
-}
-
 void hapiErrorDie(cudaError_t retCode, const char* code, const char* file, int line) {
   if (retCode != cudaSuccess) {
     fprintf(stderr, "Fatal CUDA Error [%d] %s at %s:%d\n", retCode, cudaGetErrorString(retCode), file, line);

--- a/src/arch/cuda/hybridAPI/hapi_impl.cpp
+++ b/src/arch/cuda/hybridAPI/hapi_impl.cpp
@@ -1481,6 +1481,37 @@ void hapiAddCallback(cudaStream_t stream, void* cb, void* cb_msg) {
   hapiQdCreate(1);
 }
 
+cudaError_t hapiMalloc(void** devPtr, size_t size) {
+  return cudaMalloc(devPtr, size);
+}
+
+cudaError_t hapiFree(void* devPtr) {
+  return cudaFree(devPtr);
+}
+
+cudaError_t hapiMallocHost(void** ptr, size_t size) {
+  return cudaMallocHost(ptr, size);
+}
+
+cudaError_t hapiMallocHostPool(void** ptr, size_t size) {
+  hapiPoolMalloc(ptr, size);
+  if (*ptr) return cudaSuccess;
+  else return cudaErrorMemoryAllocation;
+}
+
+cudaError_t hapiFreeHost(void* ptr) {
+  return cudaFreeHost(ptr);
+}
+
+cudaError_t hapiFreeHostPool(void *ptr) {
+  hapiPoolFree(ptr);
+  return cudaSuccess;
+}
+
+cudaError_t hapiMemcpyAsync(void* dst, const void* src, size_t count, cudaMemcpyKind kind, cudaStream_t stream = 0) {
+  return cudaMemcpyAsync(dst, src, count, kind, stream);
+}
+
 void hapiErrorDie(cudaError_t retCode, const char* code, const char* file, int line) {
   if (retCode != cudaSuccess) {
     fprintf(stderr, "Fatal CUDA Error [%d] %s at %s:%d\n", retCode, cudaGetErrorString(retCode), file, line);

--- a/src/arch/cuda/hybridAPI/hapi_impl.cpp
+++ b/src/arch/cuda/hybridAPI/hapi_impl.cpp
@@ -1493,19 +1493,8 @@ cudaError_t hapiMallocHost(void** ptr, size_t size) {
   return cudaMallocHost(ptr, size);
 }
 
-cudaError_t hapiMallocHostPool(void** ptr, size_t size) {
-  hapiPoolMalloc(ptr, size);
-  if (*ptr) return cudaSuccess;
-  else return cudaErrorMemoryAllocation;
-}
-
 cudaError_t hapiFreeHost(void* ptr) {
   return cudaFreeHost(ptr);
-}
-
-cudaError_t hapiFreeHostPool(void *ptr) {
-  hapiPoolFree(ptr);
-  return cudaSuccess;
 }
 
 cudaError_t hapiMemcpyAsync(void* dst, const void* src, size_t count, cudaMemcpyKind kind, cudaStream_t stream = 0) {


### PR DESCRIPTION
Related to #1505.
`hapiHostMalloc` defined in `hapi.h` does not work properly since it is defined as either `void* hapiPoolMalloc(size_t size)` or `cudaError_t cudaMallocHost(void** ptr, size_t size)` depending on the compile-time flags.
This PR updates `hapiPoolMalloc` to have the same signature as `cudaMallocHost` to resolve this issue.