### PR TITLE
Collision detection library and examples: Formatting/Stylistic cleanup 

### DIFF
--- a/examples/collide/collidecharm/Makefile
+++ b/examples/collide/collidecharm/Makefile
@@ -14,7 +14,7 @@ cifiles: hello.ci
 clean:
 	rm -f *.decl.h *.def.h conv-host *.o hello charmrun
 
-hello.o: hello.C 
+hello.o: hello.C
 	$(CHARMC) -c hello.C
 
 test: all

--- a/examples/collide/collidecharm/hello.C
+++ b/examples/collide/collidecharm/hello.C
@@ -1,7 +1,7 @@
 /*
-Simple Charm++ collision detection test program--
-Orion Sky Lawlor, olawlor@acm.org, 2003/3/18
- */
+   Simple Charm++ collision detection test program--
+   Orion Sky Lawlor, olawlor@acm.org, 2003/3/18
+   */
 #include <stdio.h>
 #include <string.h>
 #include "collidecharm.h"
@@ -13,91 +13,91 @@ int nElements;
 
 void printCollisionHandler(void *param,int nColl,Collision *colls)
 {
-	CkPrintf("**********************************************\n");
-	CkPrintf("*** Final collision handler called-- %d records:\n",nColl);
-	int nPrint=nColl;
-	const int maxPrint=30;
-	if (nPrint>maxPrint) nPrint=maxPrint;
-	for (int c=0;c<nPrint;c++) {
-		CkPrintf("%d:%d hits %d:%d\n",
-			colls[c].A.chunk,colls[c].A.number,
-			colls[c].B.chunk,colls[c].B.number);
-	}
-	CkPrintf("**********************************************\n");
-	mid.maindone();
+  CkPrintf("**********************************************\n");
+  CkPrintf("*** Final collision handler called-- %d records:\n",nColl);
+  int nPrint=nColl;
+  const int maxPrint=30;
+  if (nPrint>maxPrint) nPrint=maxPrint;
+  for (int c=0;c<nPrint;c++) {
+    CkPrintf("%d:%d hits %d:%d\n",
+        colls[c].A.chunk,colls[c].A.number,
+        colls[c].B.chunk,colls[c].B.number);
+  }
+  CkPrintf("**********************************************\n");
+  mid.maindone();
 }
 
 class main : public CBase_main
 {
-public:
-  main(CkMigrateMessage *m) {}
-  main(CkArgMsg* m)
-  {
-    nElements=5;
-    if(m->argc > 1) nElements = atoi(m->argv[1]);
-    delete m;
-    CkPrintf("Running Hello on %d processors for %d elements\n",
-	     CkNumPes(),nElements);
-    mid = thishandle;
-    
-    CollideGrid3d gridMap(CkVector3d(0,0,0),CkVector3d(2,100,2));
-    CollideHandle collide=CollideCreate(gridMap,
-    	CollideSerialClient(printCollisionHandler,0));
-    
-    arr = CProxy_Hello::ckNew(collide,nElements);
-    
-    arr.DoIt();
-  };
+  public:
+    main(CkMigrateMessage *m) {}
+    main(CkArgMsg* m)
+    {
+      nElements=5;
+      if(m->argc > 1) nElements = atoi(m->argv[1]);
+      delete m;
+      CkPrintf("Running Hello on %d processors for %d elements\n",
+          CkNumPes(),nElements);
+      mid = thishandle;
 
-  void maindone(void)
-  {
-    CkPrintf("All done\n");
-    CkExit();
-  };
+      CollideGrid3d gridMap(CkVector3d(0,0,0),CkVector3d(2,100,2));
+      CollideHandle collide=CollideCreate(gridMap,
+          CollideSerialClient(printCollisionHandler,0));
+
+      arr = CProxy_Hello::ckNew(collide,nElements);
+
+      arr.DoIt();
+    };
+
+    void maindone(void)
+    {
+      CkPrintf("All done\n");
+      CkExit();
+    };
 };
 
 class Hello : public CBase_Hello
 {
-	CollideHandle collide;
-	int nTimes;
-public:
+  CollideHandle collide;
+  int nTimes;
+  public:
   Hello(const CollideHandle &collide_) :collide(collide_)
   {
-	  CkPrintf("Creating element %d on PE %d\n",thisIndex,CkMyPe());
-	  nTimes=0;
-	  CollideRegister(collide,thisIndex);
+    CkPrintf("Creating element %d on PE %d\n",thisIndex,CkMyPe());
+    nTimes=0;
+    CollideRegister(collide,thisIndex);
   }
 
   Hello(CkMigrateMessage *m) : CBase_Hello(m) {}
   void pup(PUP::er &p) {
-     p|collide;
-     if (p.isUnpacking())
-	CollideRegister(collide,thisIndex);
+    p|collide;
+    if (p.isUnpacking())
+      CollideRegister(collide,thisIndex);
   }
   ~Hello() {
-     CollideUnregister(collide,thisIndex);
+    CollideUnregister(collide,thisIndex);
   }
 
   void DoIt(void)
   {
-	CkPrintf("Contributing to reduction %d, element %04d\n",nTimes,thisIndex);
-	CkVector3d o(-6.8,7.9,8.0), x(4.0,0,0), y(0,0.3,0);
-	CkVector3d boxSize(0.2,0.2,0.2);
-	int nBoxes=1000;
-	bbox3d *box=new bbox3d[nBoxes];
-	for (int i=0;i<nBoxes;i++) {
-		CkVector3d c(o+x*thisIndex+y*i);
-		CkVector3d c2(c+boxSize);
-		box[i].empty();
-		box[i].add(c); box[i].add(c2);
-	} 
-	// first box stretches over into next object:
-	box[0].add(o+x*(thisIndex+1.5)+y*2);
-	
-	CollideBoxesPrio(collide,thisIndex,nBoxes,box,NULL);
-	
-	delete[] box;
-	nTimes++;
+    CkPrintf("Contributing to reduction %d, element %04d\n",nTimes,thisIndex);
+    CkVector3d o(-6.8,7.9,8.0), x(4.0,0,0), y(0,0.3,0);
+    CkVector3d boxSize(0.2,0.2,0.2);
+    int nBoxes=1000;
+    bbox3d *box=new bbox3d[nBoxes];
+    for (int i=0;i<nBoxes;i++) {
+      CkVector3d c(o+x*thisIndex+y*i);
+      CkVector3d c2(c+boxSize);
+      box[i].empty();
+      box[i].add(c); box[i].add(c2);
+    }
+    // first box stretches over into next object:
+    box[0].add(o+x*(thisIndex+1.5)+y*2);
+
+    CollideBoxesPrio(collide,thisIndex,nBoxes,box,NULL);
+
+    delete[] box;
+    nTimes++;
   }
 };
 

--- a/examples/collide/collidethread/hello.C
+++ b/examples/collide/collidethread/hello.C
@@ -1,10 +1,10 @@
 /*
-Simple TCharm collision detection test program--
-	Shows no collisions on a single rank,
-	collisions reported for +vp2 and above.
+   Simple TCharm collision detection test program--
+   Shows no collisions on a single rank,
+   collisions reported for +vp2 and above.
 
-Orion Sky Lawlor, olawlor@acm.org, 2003/3/18.  Updated 2012-07-22 (Public Domain)
- */
+   Orion Sky Lawlor, olawlor@acm.org, 2003/3/18.  Updated 2012-07-22 (Public Domain)
+   */
 #include <stdio.h>
 #include <string.h>
 #include "mpi.h"
@@ -13,62 +13,62 @@ Orion Sky Lawlor, olawlor@acm.org, 2003/3/18.  Updated 2012-07-22 (Public Domain
 
 void addObjects(collide_t c,int thisIndex)
 {
-	CkVector3d o(-6.8,7.9,8.0), x(4.0,0,0), y(0,0.3,0);
-	CkVector3d boxSize(0.2,0.2,0.2);
-	int nBoxes=2;
-	bbox3d *box=new bbox3d[nBoxes];
-	for (int i=0;i<nBoxes;i++) {
-		CkVector3d c(o+x*thisIndex+y*i);
-		CkVector3d c2(c+boxSize);
-		box[i].empty();
-		box[i].add(c); box[i].add(c2);
-	} 
-	// first box stretches over into next object:
-	box[0].add(o+x*(thisIndex+1.5)+y*2);
-	
-	COLLIDE_Boxes(c,nBoxes,(const double *)box);
-	
-	delete[] box;
+  CkVector3d o(-6.8,7.9,8.0), x(4.0,0,0), y(0,0.3,0);
+  CkVector3d boxSize(0.2,0.2,0.2);
+  int nBoxes=2;
+  bbox3d *box=new bbox3d[nBoxes];
+  for (int i=0;i<nBoxes;i++) {
+    CkVector3d c(o+x*thisIndex+y*i);
+    CkVector3d c2(c+boxSize);
+    box[i].empty();
+    box[i].add(c); box[i].add(c2);
+  }
+  // first box stretches over into next object:
+  box[0].add(o+x*(thisIndex+1.5)+y*2);
+
+  COLLIDE_Boxes(c,nBoxes,(const double *)box);
+
+  delete[] box;
 }
 
 void printCollisions(int myRank,int nColl,int *colls)
 {
-	printf("**********************************************\n");
-	printf("*** %d final collision-- %d records:\n",myRank,nColl);
-	int nPrint=nColl;
-	const int maxPrint=30;
-	if (nPrint>maxPrint) nPrint=maxPrint;
-	for (int c=0;c<nPrint;c++) {
-		printf("%d:%d hits %d:%d\n",
-			myRank,colls[3*c+0],
-			colls[3*c+1],colls[3*c+2]);
-	}
-	if (nPrint!=nColl) printf("<more collisions omitted>");
-	printf("**********************************************\n");
+  printf("**********************************************\n");
+  printf("*** %d final collision-- %d records:\n",myRank,nColl);
+  int nPrint=nColl;
+  const int maxPrint=30;
+  if (nPrint>maxPrint) nPrint=maxPrint;
+  for (int c=0;c<nPrint;c++) {
+    printf("%d:%d hits %d:%d\n",
+        myRank,colls[3*c+0],
+        colls[3*c+1],colls[3*c+2]);
+  }
+  if (nPrint!=nColl) printf("<more collisions omitted>");
+  printf("**********************************************\n");
 }
 
 int main(int argc,char *argv[]) {
-	MPI_Init(&argc,&argv);
+  MPI_Init(&argc,&argv);
 
-	int myRank, size;
-	MPI_Comm comm=MPI_COMM_WORLD;
-	MPI_Comm_rank(comm,&myRank);
-	MPI_Comm_size(comm,&size);
-	
-	const static double gridStart[3]={0,0,0};
-	const static double gridSize[3]={2,100,2};
-	collide_t c=COLLIDE_Init(comm,gridStart,gridSize);
-	
-	/** Begin a collision step **/
-	addObjects(c,myRank);
-	
-	int nColl=COLLIDE_Count(c);
-	int *colls=new int[3*nColl];
-	COLLIDE_List(c,colls);
-	printCollisions(myRank,nColl,colls);
-	delete[] colls;
+  int myRank, size;
+  MPI_Comm comm=MPI_COMM_WORLD;
+  MPI_Comm_rank(comm,&myRank);
+  MPI_Comm_size(comm,&size);
 
-	MPI_Finalize();
-	return 0;
+  const static double gridStart[3]={0,0,0};
+  const static double gridSize[3]={2,100,2};
+  collide_t c=COLLIDE_Init(comm,gridStart,gridSize);
+
+  /** Begin a collision step **/
+  addObjects(c,myRank);
+
+  int nColl=COLLIDE_Count(c);
+  int *colls=new int[3*nColl];
+  COLLIDE_List(c,colls);
+  printCollisions(myRank,nColl,colls);
+  delete[] colls;
+
+  MPI_Finalize();
+  return 0;
 }
 

--- a/src/libs/ck-libs/collide/Makefile
+++ b/src/libs/ck-libs/collide/Makefile
@@ -1,12 +1,13 @@
 include ../common.mk
 
 HEADERS=collide_util.h bbox.h collide_cfg.h collide_buffers.h \
-	collidecharm.h collidec.h collidef.h collidecharm.decl.h 
-HEADDEP=$(HEADERS) collidecharm_impl.h \
-	collide_serial.h collide_buffers.h collide_cfg.h \
-	collide.decl.h collidecharm.decl.h headers
+  collidecharm.h collidec.h collidef.h collidecharm.decl.h
 
-COBJS=collide_util.o collide_serial.o collidecharm.o collide_buffers.o 
+HEADDEP=$(HEADERS) collidecharm_impl.h \
+  collide_serial.h collide_buffers.h collide_cfg.h \
+  collide.decl.h collidecharm.decl.h headers
+  
+COBJS=collide_util.o collide_serial.o collidecharm.o collide_buffers.o
 CLIB=libmodulecollidecharm
 CDEST=$(LIBDIR)/$(CLIB).a
 
@@ -16,11 +17,11 @@ DEST=$(LIBDIR)/$(LIB).a
 
 all: $(DEST) $(CDEST) headers
 
-$(DEST): $(OBJS) $(COMPAT) 
+$(DEST): $(OBJS) $(COMPAT)
 	$(CHARMC) $(OBJS) $(COMPAT) -o $@
 	cp $(LIB).dep $(LIBDIR)/$(LIB).dep
 
-$(CDEST): $(COBJS) $(COMPAT) 
+$(CDEST): $(COBJS) $(COMPAT)
 	$(CHARMC) $(COBJS) $(COMPAT) -o $@
 #	cp $(CLIB).dep $(LIBDIR)/$(CLIB).dep
 

--- a/src/libs/ck-libs/collide/bbox.h
+++ b/src/libs/ck-libs/collide/bbox.h
@@ -1,10 +1,10 @@
 /*
-Orion's Standard Library
-written by 
-Orion Sky Lawlor, olawlor@acm.org, 7/18/2001
+   Orion's Standard Library
+   written by
+   Orion Sky Lawlor, olawlor@acm.org, 7/18/2001
 
-Rather complete interval and box classes.
-*/
+   Rather complete interval and box classes.
+   */
 #ifndef __OSL_BBOX_H
 #define __OSL_BBOX_H
 
@@ -14,181 +14,181 @@ Rather complete interval and box classes.
 //A closed segment of 1d space-- [min,max]
 template <class T>
 class seg1dT {
-	typedef seg1dT<T> seg1d;
-	T min,max;
-public:
-	seg1dT(void) {}
-	seg1dT(T Nmin,T Nmax) :min(Nmin),max(Nmax) {}
-	
-	void init(T a,T b,T c) {
-		if (a<b) min=a,max=b; else min=b,max=a;
-		if (c<min) min=c;
-		else if (c>max) max=c;
-	}
-	T getMin(void) const {return min;}
-	T getMax(void) const {return max;}
-	void setMin(T m) {min=m;}
-	void setMax(T m) {max=m;}
-	
-	//Set this span to contain no points
-	seg1d &empty(void) {
-		min=2000000000; max=-2000000000; return *this;
-	}
-	//Set this span to contain all points
-	seg1d &infinity(void) {
-		min=-2000000000; max=2000000000; return *this;
-	}
-	
-	bool isEmpty(void) const { return max<min;}
-	//Set this span to contain only this point
-	seg1d &set(T b) {min=max=b; return *this;}
-	//Set this span to contain these two points and everything in between
-	seg1d &set(T a,T b) {
-		if (a<b) {min=a;max=b;}
-		else     {min=b;max=a;}
-		return *this;
-	}
-	//Expand this span to contain this point
-	void expandMin(T b) {if (min>b) min=b;}
-	void expandMax(T b) {if (max<b) max=b;}
-	seg1d &add(T b) {
-		expandMin(b);expandMax(b);
-		return *this;
-	}
-	//Expand this span to contain this span
-	seg1d &add(const seg1d &b) {
-		expandMin(b.min);expandMax(b.max);
-		return *this;
-	}
-	
-	//Return the intersection of this and that seg
-	seg1d getIntersection(const seg1d &b) const {
-		return seg1d(min>b.min?min:b.min, max<b.max?max:b.max);
-	}
-	//Return the union of this and that seg
-	seg1d getUnion(const seg1d &b) const {
-		return seg1d(min<b.min?min:b.min, max>b.max?max:b.max);
-	}
-	
-	//Return true if this seg contains this point
-	// in its interior or boundary (closed interval)
-	bool contains(T b) const {
-		return (min<=b)&&(b<=max);
-	}
-	//Return true if this seg contains this point 
-	// in its interior (open interval)
-	bool containsOpen(T b) const {
-		return (min<b)&&(b<max);
-	}
-	//Return true if this seg contains this point 
-	// in its interior or left endpoint (half-open interval)
-	bool containsHalf(T b) const {
-		return (min<=b)&&(b<max);
-	}
-	//Return true if this seg and that share any points
-	bool intersects(const seg1d &b) const {
-		return contains(b.min)||b.contains(min);
-	}
-	//Return true if this seg and that share any interior points
-	bool intersectsOpen(const seg1d &b) const {
-		return containsHalf(b.min)||b.containsOpen(min);
-	}
-	//Return true if this seg and that share any half-open points
-	bool intersectsHalf(const seg1d &b) const {
-		return containsHalf(b.min)||b.containsHalf(min);
-	}
-	
-	inline void pup(PUP::er &p) {
-		p|min;
-		p|max;
-	}
+  typedef seg1dT<T> seg1d;
+  T min,max;
+  public:
+  seg1dT(void) {}
+  seg1dT(T Nmin,T Nmax) :min(Nmin),max(Nmax) {}
+
+  void init(T a,T b,T c) {
+    if (a<b) min=a,max=b; else min=b,max=a;
+    if (c<min) min=c;
+    else if (c>max) max=c;
+  }
+  T getMin(void) const {return min;}
+  T getMax(void) const {return max;}
+  void setMin(T m) {min=m;}
+  void setMax(T m) {max=m;}
+
+  //Set this span to contain no points
+  seg1d &empty(void) {
+    min=2000000000; max=-2000000000; return *this;
+  }
+  //Set this span to contain all points
+  seg1d &infinity(void) {
+    min=-2000000000; max=2000000000; return *this;
+  }
+
+  bool isEmpty(void) const { return max<min;}
+  //Set this span to contain only this point
+  seg1d &set(T b) {min=max=b; return *this;}
+  //Set this span to contain these two points and everything in between
+  seg1d &set(T a,T b) {
+    if (a<b) {min=a;max=b;}
+    else     {min=b;max=a;}
+    return *this;
+  }
+  //Expand this span to contain this point
+  void expandMin(T b) {if (min>b) min=b;}
+  void expandMax(T b) {if (max<b) max=b;}
+  seg1d &add(T b) {
+    expandMin(b);expandMax(b);
+    return *this;
+  }
+  //Expand this span to contain this span
+  seg1d &add(const seg1d &b) {
+    expandMin(b.min);expandMax(b.max);
+    return *this;
+  }
+
+  //Return the intersection of this and that seg
+  seg1d getIntersection(const seg1d &b) const {
+    return seg1d(min>b.min?min:b.min, max<b.max?max:b.max);
+  }
+  //Return the union of this and that seg
+  seg1d getUnion(const seg1d &b) const {
+    return seg1d(min<b.min?min:b.min, max>b.max?max:b.max);
+  }
+
+  //Return true if this seg contains this point
+  // in its interior or boundary (closed interval)
+  bool contains(T b) const {
+    return (min<=b)&&(b<=max);
+  }
+  //Return true if this seg contains this point
+  // in its interior (open interval)
+  bool containsOpen(T b) const {
+    return (min<b)&&(b<max);
+  }
+  //Return true if this seg contains this point
+  // in its interior or left endpoint (half-open interval)
+  bool containsHalf(T b) const {
+    return (min<=b)&&(b<max);
+  }
+  //Return true if this seg and that share any points
+  bool intersects(const seg1d &b) const {
+    return contains(b.min)||b.contains(min);
+  }
+  //Return true if this seg and that share any interior points
+  bool intersectsOpen(const seg1d &b) const {
+    return containsHalf(b.min)||b.containsOpen(min);
+  }
+  //Return true if this seg and that share any half-open points
+  bool intersectsHalf(const seg1d &b) const {
+    return containsHalf(b.min)||b.containsHalf(min);
+  }
+
+  inline void pup(PUP::er &p) {
+    p|min;
+    p|max;
+  }
 };
 typedef seg1dT<double> rSeg1d;
 typedef seg1dT<int> iSeg1d;
 
 class bbox3d {
-	rSeg1d segs[3];//Spans for x (0), y (1), and z (2)
-public:   
-	bbox3d() {}
-	bbox3d(const rSeg1d &x,const rSeg1d &y,const rSeg1d &z)
-		{segs[0]=x; segs[1]=y; segs[2]=z;}
-	bbox3d(const CkVector3d &a,const CkVector3d &b,const CkVector3d &c)
-	{
-		segs[0].init(a[0],b[0],c[0]);
-		segs[1].init(a[1],b[1],c[1]);
-		segs[2].init(a[2],b[2],c[2]);
-	}
-	
-	void print(const char *desc=NULL) const;
+  rSeg1d segs[3];//Spans for x (0), y (1), and z (2)
+  public:
+  bbox3d() {}
+  bbox3d(const rSeg1d &x,const rSeg1d &y,const rSeg1d &z)
+  {segs[0]=x; segs[1]=y; segs[2]=z;}
+  bbox3d(const CkVector3d &a,const CkVector3d &b,const CkVector3d &c)
+  {
+    segs[0].init(a[0],b[0],c[0]);
+    segs[1].init(a[1],b[1],c[1]);
+    segs[2].init(a[2],b[2],c[2]);
+  }
 
-	rSeg1d &axis(int i) {return segs[i];}
-	const rSeg1d &axis(int i) const {return segs[i];}
-	
-	void add(const CkVector3d &b) {
-		for (int i=0;i<3;i++) segs[i].add(b[i]);
-	}
-	void add(const bbox3d &b) {
-		for (int i=0;i<3;i++) segs[i].add(b.segs[i]);
-	}
-	bbox3d getUnion(const bbox3d &b) {
-		return bbox3d(segs[0].getUnion(b.segs[0]),
-			segs[1].getUnion(b.segs[1]),
-			segs[2].getUnion(b.segs[2]));
-	}
-	bbox3d getIntersection(const bbox3d &b) {
-		return bbox3d(segs[0].getIntersection(b.segs[0]),
-			segs[1].getIntersection(b.segs[1]),
-			segs[2].getIntersection(b.segs[2]));
-	}
-	//Interior or boundary (closed interval)
-	bool intersects(const bbox3d &b) const {
-		for (int i=0;i<3;i++)
-			if (!segs[i].intersects(b.segs[i])) return false;
-		return true;
-	}
-	//Interior only (open interval)
-	bool intersectsOpen(const bbox3d &b) const {
-		for (int i=0;i<3;i++)
-			if (!segs[i].intersectsOpen(b.segs[i])) return false;
-		return true;
-	}
-	//Interior or boundary (closed interval)
-	bool contains(const CkVector3d &b) const {
-		for (int i=0;i<3;i++)
-			if (!segs[i].contains(b[i])) return false;
-		return true;
-	}
-	//Interior only (open interval)
-	bool containsOpen(const CkVector3d &b) const {
-		for (int i=0;i<3;i++)
-			if (!segs[i].containsOpen(b[i])) return false;
-		return true;
-	}
-	//Interior or left endpoint (half-open interval)
-	bool containsHalf(const CkVector3d &b) const {
-		for (int i=0;i<3;i++)
-			if (!segs[i].containsHalf(b[i])) return false;
-		return true;
-	}
-	void empty(void) {
-		for (int i=0;i<3;i++) segs[i].empty();
-	}
-	void infinity(void) {
-		for (int i=0;i<3;i++) segs[i].infinity();
-	}
-	bool isEmpty(void) const {
-		for (int i=0;i<3;i++) if (segs[i].isEmpty()) return true;
-		return false;
-	}
-	CkVector3d getSmallest(void) const 
-	{
-		return CkVector3d(segs[0].getMin(),
-			segs[1].getMin(),
-			segs[2].getMin());
-	}
-	inline void pup(PUP::er &p) {
-		p|segs[0]; p|segs[1]; p|segs[2];
-	}
+  void print(const char *desc=NULL) const;
+
+  rSeg1d &axis(int i) {return segs[i];}
+  const rSeg1d &axis(int i) const {return segs[i];}
+
+  void add(const CkVector3d &b) {
+    for (int i=0;i<3;i++) segs[i].add(b[i]);
+  }
+  void add(const bbox3d &b) {
+    for (int i=0;i<3;i++) segs[i].add(b.segs[i]);
+  }
+  bbox3d getUnion(const bbox3d &b) {
+    return bbox3d(segs[0].getUnion(b.segs[0]),
+        segs[1].getUnion(b.segs[1]),
+        segs[2].getUnion(b.segs[2]));
+  }
+  bbox3d getIntersection(const bbox3d &b) {
+    return bbox3d(segs[0].getIntersection(b.segs[0]),
+        segs[1].getIntersection(b.segs[1]),
+        segs[2].getIntersection(b.segs[2]));
+  }
+  //Interior or boundary (closed interval)
+  bool intersects(const bbox3d &b) const {
+    for (int i=0;i<3;i++)
+      if (!segs[i].intersects(b.segs[i])) return false;
+    return true;
+  }
+  //Interior only (open interval)
+  bool intersectsOpen(const bbox3d &b) const {
+    for (int i=0;i<3;i++)
+      if (!segs[i].intersectsOpen(b.segs[i])) return false;
+    return true;
+  }
+  //Interior or boundary (closed interval)
+  bool contains(const CkVector3d &b) const {
+    for (int i=0;i<3;i++)
+      if (!segs[i].contains(b[i])) return false;
+    return true;
+  }
+  //Interior only (open interval)
+  bool containsOpen(const CkVector3d &b) const {
+    for (int i=0;i<3;i++)
+      if (!segs[i].containsOpen(b[i])) return false;
+    return true;
+  }
+  //Interior or left endpoint (half-open interval)
+  bool containsHalf(const CkVector3d &b) const {
+    for (int i=0;i<3;i++)
+      if (!segs[i].containsHalf(b[i])) return false;
+    return true;
+  }
+  void empty(void) {
+    for (int i=0;i<3;i++) segs[i].empty();
+  }
+  void infinity(void) {
+    for (int i=0;i<3;i++) segs[i].infinity();
+  }
+  bool isEmpty(void) const {
+    for (int i=0;i<3;i++) if (segs[i].isEmpty()) return true;
+    return false;
+  }
+  CkVector3d getSmallest(void) const
+  {
+    return CkVector3d(segs[0].getMin(),
+        segs[1].getMin(),
+        segs[2].getMin());
+  }
+  inline void pup(PUP::er &p) {
+    p|segs[0]; p|segs[1]; p|segs[2];
+  }
 };
 
 #endif //def(thisHeader)

--- a/src/libs/ck-libs/collide/bbox.h
+++ b/src/libs/ck-libs/collide/bbox.h
@@ -111,7 +111,9 @@ class bbox3d {
   public:
   bbox3d() {}
   bbox3d(const rSeg1d &x,const rSeg1d &y,const rSeg1d &z)
-  {segs[0]=x; segs[1]=y; segs[2]=z;}
+  {
+    segs[0]=x; segs[1]=y; segs[2]=z;
+  }
   bbox3d(const CkVector3d &a,const CkVector3d &b,const CkVector3d &c)
   {
     segs[0].init(a[0],b[0],c[0]);

--- a/src/libs/ck-libs/collide/collide_buffers.C
+++ b/src/libs/ck-libs/collide/collide_buffers.C
@@ -1,5 +1,5 @@
 /*
-Ancient, hideous custom memory management classes.
+   Ancient, hideous custom memory management classes.
 FIXME: replace these with something well-tested,
 standard, and modern, like std::vector.
 
@@ -12,9 +12,9 @@ Orion Sky Lawlor, olawlor@acm.org, 2001/2/5
 #include "charm++.h"
 
 /************** MemoryBuffer ****************
-Manages an expandable buffer of bytes.  Like std::vector,
-but typeless.
-*/
+  Manages an expandable buffer of bytes.  Like std::vector,
+  but typeless.
+  */
 
 memoryBuffer::memoryBuffer()//Empty initial buffer
 {

--- a/src/libs/ck-libs/collide/collide_buffers.h
+++ b/src/libs/ck-libs/collide/collide_buffers.h
@@ -1,5 +1,5 @@
 /*
-Ancient, hideous custom memory management classes.
+   Ancient, hideous custom memory management classes.
 FIXME: replace these with something well-tested,
 standard, and modern, like std::vector.
 
@@ -13,55 +13,55 @@ Orion Sky Lawlor, olawlor@acm.org, 2001/2/5
 //A simple extensible untyped chunk of memory.
 //  Lengths are in bytes
 class memoryBuffer {
- public:
-  typedef unsigned int size_t;
- private:
-  void *data;
-  size_t len;//Length of data array above
-  void setData(const void *toData,size_t toLen);//Reallocate and copy
- public:
-  memoryBuffer();//Empty initial buffer
-  memoryBuffer(size_t initLen);//Initial capacity specified
-  ~memoryBuffer();//Deletes heap-allocated buffer
-  memoryBuffer(const memoryBuffer &in) {data=NULL;setData(in.data,in.len);}
-  memoryBuffer &operator=(const memoryBuffer &in) {setData(in.data,in.len); return *this;}
-  
-  size_t length(void) const {return len;}
-  void *getData(void) {return data;}
-  const void *getData(void) const {return data;}
-  void detachBuffer(void) {data=NULL;len=0;}
-  
-  void resize(size_t newlen);//Reallocate, preserving old data
-  void reallocate(size_t newlen);//Free old data, allocate new
+  public:
+    typedef unsigned int size_t;
+  private:
+    void *data;
+    size_t len;//Length of data array above
+    void setData(const void *toData,size_t toLen);//Reallocate and copy
+  public:
+    memoryBuffer();//Empty initial buffer
+    memoryBuffer(size_t initLen);//Initial capacity specified
+    ~memoryBuffer();//Deletes heap-allocated buffer
+    memoryBuffer(const memoryBuffer &in) {data=NULL;setData(in.data,in.len);}
+    memoryBuffer &operator=(const memoryBuffer &in) {setData(in.data,in.len); return *this;}
+
+    size_t length(void) const {return len;}
+    void *getData(void) {return data;}
+    const void *getData(void) const {return data;}
+    void detachBuffer(void) {data=NULL;len=0;}
+
+    void resize(size_t newlen);//Reallocate, preserving old data
+    void reallocate(size_t newlen);//Free old data, allocate new
 };
 
 //Superclass for simple flat memory containers
 template <class T> class bufferT {
   T *data; //Data items in container
   int len; //Index of last valid member + 1
- protected:
+  protected:
   bufferT() :data(NULL),len(0) {}
   bufferT(T *data_,int len_) :data(data_),len(len_) {}
   void set(T *data_,int len_) {data=data_;len=len_;}
   void setData(T *data_) {data=data_;}
   void setLength(int len_) {len=len_;}
   int &getLength(void) {return len;}
- public:
+  public:
   int length(void) const {return len;}
-  
+
   T &operator[](int t) {return data[t];}
   const T &operator[](int t) const {return data[t];}
   T &at(int t) {return data[t];}
   const T &at(int t) const {return data[t];}
-  
+
   T *getData(void) {return (T *)data;}
   const T *getData(void) const {return (T *)data;}
 };
 
 //For preallocated data
 template <class T> class fixedBufferT : public bufferT<T> {
- public:
-  fixedBufferT(T *data_,int len_) :bufferT<T>(data_,len_) {}
+  public:
+    fixedBufferT(T *data_,int len_) :bufferT<T>(data_,len_) {}
 };
 
 //Variable size buffer
@@ -75,15 +75,15 @@ template <class T> class growableBufferT : public bufferT<T> {
   //Don't use these:
   growableBufferT<T>(const growableBufferT<T> &in);
   growableBufferT<T> &operator=(const growableBufferT<T> &in);
- public:
+  public:
   growableBufferT<T>() :buf() {max=0;}
   growableBufferT<T>(size_t Len) :buf(Len*sT) {this->set((T*)buf.getData(),Len);max=Len;}
-    
+
   inline int length(void) const {return super::length();}
   inline int size(void) const {return super::length();}
   inline int &length(void) {return this->getLength();}
   inline int capacity(void) const {return max;}
-  
+
   T *detachBuffer(void) {
     T *ret=(T *)buf.getData();
     buf.detachBuffer();
@@ -104,11 +104,11 @@ template <class T> class growableBufferT : public bufferT<T> {
   void grow(int min) {
     if (min>max) {
       if (min > 1000000) {
-	//printf("COLLIDE: Buffer size %d is getting out of hand, switching to conservative mechanism!\n", min);
-	atLeast(min+(min/4));
+        //printf("COLLIDE: Buffer size %d is getting out of hand, switching to conservative mechanism!\n", min);
+        atLeast(min+(min/4));
       }
       else {
-	resize(min+max+8);
+        resize(min+max+8);
       }
     }
   }

--- a/src/libs/ck-libs/collide/collide_cfg.h
+++ b/src/libs/ck-libs/collide/collide_cfg.h
@@ -1,13 +1,13 @@
 /*
-Configuration flags for Collision detection.
+   Configuration flags for Collision detection.
 
-Orion Sky Lawlor, olawlor@acm.org, 2003/3/19
-*/
+   Orion Sky Lawlor, olawlor@acm.org, 2003/3/19
+   */
 #ifndef __UIUC_CHARM_COLLIDE_CFG_H
 #define __UIUC_CHARM_COLLIDE_CFG_H
 
 /// Statistics collection:
-#ifndef COLLIDE_STATS 
+#ifndef COLLIDE_STATS
 #define COLLIDE_STATS 0
 #endif
 

--- a/src/libs/ck-libs/collide/collide_serial.C
+++ b/src/libs/ck-libs/collide/collide_serial.C
@@ -1,11 +1,11 @@
 /*
-Orion's Standard Library
-written by 
-Orion Sky Lawlor, olawlor@acm.org, 2/5/2001
+   Orion's Standard Library
+   written by
+   Orion Sky Lawlor, olawlor@acm.org, 2/5/2001
 
-Utilities for efficiently determining object intersections,
-given a giant list of objects.
-*/
+   Utilities for efficiently determining object intersections,
+   given a giant list of objects.
+   */
 #include <stdio.h>
 #include <iostream>
 using namespace std;
@@ -15,66 +15,66 @@ using namespace std;
 #define DEBUG_CHECKS 0 //Check invariants
 
 static void print(const rSeg1d &s) {
-	printf("[%.3g,%.3g]",s.getMin(),s.getMax());
+  printf("[%.3g,%.3g]",s.getMin(),s.getMax());
 }
 
 #if 0
 static void print(const vector3d &v) {
-	printf("(%.3g,%.3g,%.3g) ",v.x,v.y,v.z);
+  printf("(%.3g,%.3g,%.3g) ",v.x,v.y,v.z);
 }
 #endif
 void bbox3d::print(const char *desc) const
 {
-	if (desc) printf("%s: ",desc);
-	// for (int i=0;i<3;i++)
-	//	{::print(segs[i]);if (i<2) printf("x");}
-	printf("(%.3g,%.3g,%.3g) - (%.3g,%.3g,%.3g) ",
-		axis(0).getMin(),axis(1).getMin(),axis(2).getMin(),
-		axis(0).getMax(),axis(1).getMax(),axis(2).getMax());
+  if (desc) printf("%s: ",desc);
+  // for (int i=0;i<3;i++)
+  //	{::print(segs[i]);if (i<2) printf("x");}
+  printf("(%.3g,%.3g,%.3g) - (%.3g,%.3g,%.3g) ",
+      axis(0).getMin(),axis(1).getMin(),axis(2).getMin(),
+      axis(0).getMax(),axis(1).getMax(),axis(2).getMax());
 }
 
 void CollideOctant::print(const char *desc) const
 {
-	if (desc) printf("%s: ",desc);
-	printf("%d home, %d boundary; ",nHome,length()-nHome);
-	box.print("\nbbox");
-	printf("\n");
+  if (desc) printf("%s: ",desc);
+  printf("%d home, %d boundary; ",nHome,length()-nHome);
+  box.print("\nbbox");
+  printf("\n");
 }
 
 #if COLLIDE_STATS
-void stats::print(void) 
+void stats::print(void)
 {
-	const char *names[3]={"x","y","z"};//Axis names
-	int i;
-	cout<<"---- Run-time statistics: ---"<<endl;
-	cout<<"objects= "<<objects<<endl;
-	cout<<"gridCells= "<<gridCells<<endl;
-	cout<<"gridAdds= "<<gridAdds<<endl;
-	
-	cout<<"gridSizes (ave)= ";
-	for (i=0;i<3;i++) cout<<(double)gridSizes[i]/objects<<names[i]<<" ";
-	cout<<endl;
-	
-	cout<<"recursiveCalls= "<<recursiveCalls<<endl;
-	cout<<"rejHomo = "<< rejHomo <<endl;
-	cout<<"simpleCalls = "<< simpleCalls <<endl;
-	cout<<"simpleFallbackCalls = "<< simpleFallbackCalls <<endl;
-	
-	cout<<"splits = ";
-	for (i=0;i<3;i++) cout<<splits[i]<<names[i]<<" ";
-	cout<<endl;
-	cout<<"splitFailures = ";
-	for (i=0;i<3;i++) cout<<splitFailures[i]<<names[i]<<" ";
-	cout<<endl;
-	
-	cout<<"pivots = "<< pivots <<endl;
-	cout<<"rejID = "<< rejID <<endl;
-	cout<<"rejBbox = "<< rejBbox <<endl;
-	cout<<"rejTerritory = ";
-	for (i=0;i<3;i++) cout<<rejTerritory[i]<<names[i]<<" ";
-	cout<<endl;
-	cout<<"rejCollide = "<< rejCollide <<endl;
-	cout<<"Collisions = "<< Collisions <<endl;
+  const char *names[3]={"x","y","z"};//Axis names
+  int i;
+  cout<<"---- Run-time statistics: ---"<<endl;
+  cout<<"objects= "<<objects<<endl;
+  cout<<"gridCells= "<<gridCells<<endl;
+  cout<<"gridAdds= "<<gridAdds<<endl;
+
+  cout<<"gridSizes (ave)= ";
+  for (i=0;i<3;i++) cout<<(double)gridSizes[i]/objects<<names[i]<<" ";
+  cout<<endl;
+
+  cout<<"recursiveCalls= "<<recursiveCalls<<endl;
+  cout<<"rejHomo = "<< rejHomo <<endl;
+  cout<<"simpleCalls = "<< simpleCalls <<endl;
+  cout<<"simpleFallbackCalls = "<< simpleFallbackCalls <<endl;
+
+  cout<<"splits = ";
+  for (i=0;i<3;i++) cout<<splits[i]<<names[i]<<" ";
+  cout<<endl;
+  cout<<"splitFailures = ";
+  for (i=0;i<3;i++) cout<<splitFailures[i]<<names[i]<<" ";
+  cout<<endl;
+
+  cout<<"pivots = "<< pivots <<endl;
+  cout<<"rejID = "<< rejID <<endl;
+  cout<<"rejBbox = "<< rejBbox <<endl;
+  cout<<"rejTerritory = ";
+  for (i=0;i<3;i++) cout<<rejTerritory[i]<<names[i]<<" ";
+  cout<<endl;
+  cout<<"rejCollide = "<< rejCollide <<endl;
+  cout<<"Collisions = "<< Collisions <<endl;
 }
 int stats::objects=0;//Total number of objects
 int stats::gridCells=0;//Total number of grid cells
@@ -97,107 +97,107 @@ int stats::Collisions=0;//Number of actual intersections
 //Ensure our constraints hold
 void CollideOctant::check(void) const
 {
-	if (nHome>length()) CkAbort("nHome cannot exceed n");
-	if (nHome<=0) CkAbort("nHome cannot be negative or zero");
-	if (length()<0) CkAbort("n cannot be negative");
-	if (box.isEmpty()) CkAbort("Bbox is empty");
-	int i;
-	for (i=0;i<nHome;i++)
-		if (!box.contains(at(i)->getBbox().getSmallest()))
-			CkAbort("'Home' element not in bbox");
-	for (i=nHome;i<length();i++) {
-		if (!box.intersects(at(i)->getBbox()))
-			CkAbort("contained element does not touch us");
-		vector3d s=at(i)->getBbox().getSmallest();
-		if (box.containsOpen(s))
-			CkAbort("non-home element should be home");
-	}
+  if (nHome>length()) CkAbort("nHome cannot exceed n");
+  if (nHome<=0) CkAbort("nHome cannot be negative or zero");
+  if (length()<0) CkAbort("n cannot be negative");
+  if (box.isEmpty()) CkAbort("Bbox is empty");
+  int i;
+  for (i=0;i<nHome;i++)
+    if (!box.contains(at(i)->getBbox().getSmallest()))
+      CkAbort("'Home' element not in bbox");
+  for (i=nHome;i<length();i++) {
+    if (!box.intersects(at(i)->getBbox()))
+      CkAbort("contained element does not touch us");
+    vector3d s=at(i)->getBbox().getSmallest();
+    if (box.containsOpen(s))
+      CkAbort("non-home element should be home");
+  }
 }
 
 //////////////////////// Octant ///////////////////////////
 
 CollideOctant::~CollideOctant() {}
 void CollideOctant::add(const CollideObjRec *p) {
-	push_back(p);
+  push_back(p);
 }
 
 //Figure out where to divide (about) half this CollideOctant's objs.
 /*Algorithm:
- We do a find-median in place in our array, by repeatedly
- choosing a pivot, partitioning, and then recurse on the proper
- half of the array.
- Expected run time is O(n)-- n*(1 + 1/2 + 1/4 + 1/8 +...); 
- pathological pivots may give O(n^2)
-*/
-template <class T> 
+  We do a find-median in place in our array, by repeatedly
+  choosing a pivot, partitioning, and then recurse on the proper
+  half of the array.
+  Expected run time is O(n)-- n*(1 + 1/2 + 1/4 + 1/8 +...);
+  pathological pivots may give O(n^2)
+  */
+template <class T>
 inline void myswap(T &a,T &b) {T tmp(a);a=b;b=tmp;}
 
 int CollideOctant::splitAt(int alongAxis)
 {
-	CollideOctant &us=*this;
-	
-	//Find our median element in-place by recursive partitioning
-	int target=nHome/2;//Rank of median element
-	int lo=0, hi=nHome-1;//Unsearched values in our array
-	int attempts=0;
-	int l=-1,r=-1;//Elements [0..l] are <pivot; [r..hi] are >pivot
-	STATS(splits[alongAxis]++)
-	while (lo<hi) {
-		attempts++;  STATS(pivots++)
-		//Choose a pivot element and value
-		//int pivot=lo+(rand()&0x7fff)*(hi-lo+1)/0x8000;
-	       int pivot = (lo/2)+(hi/2);	       
+  CollideOctant &us=*this;
+
+  //Find our median element in-place by recursive partitioning
+  int target=nHome/2;//Rank of median element
+  int lo=0, hi=nHome-1;//Unsearched values in our array
+  int attempts=0;
+  int l=-1,r=-1;//Elements [0..l] are <pivot; [r..hi] are >pivot
+  STATS(splits[alongAxis]++)
+    while (lo<hi) {
+      attempts++;  STATS(pivots++)
+        //Choose a pivot element and value
+        //int pivot=lo+(rand()&0x7fff)*(hi-lo+1)/0x8000;
+        int pivot = (lo/2)+(hi/2);
 #define val(x) us[x]->getBbox().axis(alongAxis).getMin()
-		real pval=val(pivot);
-		
-		//Partition elements into those less and greater than pivot
-		l=lo-1, r=hi+1;
-		while (1) {
-			real lval,rval;
-			while ((lval=val(l+1))<pval) l++;
-			while ((rval=val(r-1))>pval) r--;
-			if (!(lval==pval && rval==pval))
-				myswap(us[l+1],us[r-1]);
-			else 
-			{//Both elements are equal to the pivot-- check if done
-				bool finished=true;
-				int i;
-				for (i=l+2;i<=r-2;i++)
-					if (val(i)!=pval) {finished=false;break;}
-				if (finished) break;
-				else myswap(us[l+1],us[i]);
-			}
-		}
+      real pval=val(pivot);
+
+      //Partition elements into those less and greater than pivot
+      l=lo-1, r=hi+1;
+      while (1) {
+        real lval,rval;
+        while ((lval=val(l+1))<pval) l++;
+        while ((rval=val(r-1))>pval) r--;
+        if (!(lval==pval && rval==pval))
+          myswap(us[l+1],us[r-1]);
+        else
+        {//Both elements are equal to the pivot-- check if done
+          bool finished=true;
+          int i;
+          for (i=l+2;i<=r-2;i++)
+            if (val(i)!=pval) {finished=false;break;}
+          if (finished) break;
+          else myswap(us[l+1],us[i]);
+        }
+      }
 #if DEBUG_CHECKS //Check this step of the partitioning
-	//	printf("Partitioned (%d-%d) at %d-- result %d,%d\n",lo,hi,pivot,l,r);
-		if (l+1<0) CkAbort("L negative!\n");
-		if (l>=nHome) CkAbort("L too big!\n");
-		if (r<0) CkAbort("R negative!\n");
-		if (r-1>=nHome) CkAbort("R too big!\n");
-		for (int i=l+1;i<r;i++) if (val(i)!=pval) CkAbort("equals aren't!");
-		for (int i=0;i<=l;i++) if (val(i)>=pval) CkAbort("lesses aren't!");
-		for (int i=r;i<nHome;i++) if (val(i)<=pval) CkAbort("greaters aren't!");
+      //	printf("Partitioned (%d-%d) at %d-- result %d,%d\n",lo,hi,pivot,l,r);
+      if (l+1<0) CkAbort("L negative!\n");
+      if (l>=nHome) CkAbort("L too big!\n");
+      if (r<0) CkAbort("R negative!\n");
+      if (r-1>=nHome) CkAbort("R too big!\n");
+      for (int i=l+1;i<r;i++) if (val(i)!=pval) CkAbort("equals aren't!");
+      for (int i=0;i<=l;i++) if (val(i)>=pval) CkAbort("lesses aren't!");
+      for (int i=r;i<nHome;i++) if (val(i)<=pval) CkAbort("greaters aren't!");
 #endif
-		//Do we need to partition again on a smaller set?
-		if (l<target && target<r) break;
-		else if (target<=l) hi=l;
-		else /*target>=r*/ lo=r;
-	}
+      //Do we need to partition again on a smaller set?
+      if (l<target && target<r) break;
+      else if (target<=l) hi=l;
+      else /*target>=r*/ lo=r;
+    }
 #if DEBUG_CHECKS //Check this step of the partitioning
-//	printf("Took %d tries to split %d (+%d)-element box (%d<%d<%d)\n",
-//		attempts,nHome,(n-nHome),l,target,r);
+  //	printf("Took %d tries to split %d (+%d)-element box (%d<%d<%d)\n",
+  //		attempts,nHome,(n-nHome),l,target,r);
 #endif
 
 #if 1 //Try to split homes into separated (non-overlapping) pieces
-	if (r<nHome) return r;
-	else if (l>0) return l;
-	else {
-		STATS(splitFailures[alongAxis]++);
-		return -1;
-	}
+  if (r<nHome) return r;
+  else if (l>0) return l;
+  else {
+    STATS(splitFailures[alongAxis]++);
+    return -1;
+  }
 #else
-	//Try to split into equal-sized pieces
-	return target;
+  //Try to split into equal-sized pieces
+  return target;
 #endif
 }
 
@@ -205,47 +205,47 @@ int CollideOctant::splitAt(int alongAxis)
 // This CollideOctant shrinks, the new one grows.
 CollideOctant *CollideOctant::divide(int alongAxis)
 {
-	int oStart=nHome,oEnd=length();
-	int i;
-	
-	//Figure out where to divide our elements
-	int div=splitAt(alongAxis);
-	if (div==-1) return NULL;
-	
-	//Make a new element to hold our other half
-	CollideOctant &ret=*(new CollideOctant(length(),territory));
-	CollideOctant &us=*this;
-	
-	//Divide home elements: us<-[0..div-1] and dest<-[div..nHome-1]
-	ret.nHome=ret.length()=nHome-div;
-	for (i=div;i<nHome;i++) ret[i-div]=us[i];
-	us.nHome=us.length()=div;
-	int ret_length=ret.length();//Prevents re-adding our own elements
-	
-	//Update bounding boxes
-	us.box=us.at(0)->getBbox();
-	ret.box=ret.at(0)->getBbox();
-	for (i=length()-1;i>0;i--) us.box.add(us.at(i)->getBbox());
-	for (i=ret_length-1;i>0;i--) ret.box.add(ret.at(i)->getBbox()); 
-	
-	//Find the boundary elements
-	for (i=length()-1;i>=0;i--) 
-		ret.addIfBoundary(at(i)); //We form his boundary
-	for (i=ret_length-1;i>=0;i--) 
-		addIfBoundary(ret.at(i)); //He forms our boundary
-	for (i=oStart;i<oEnd;i++) {//Our old boundary elements are now shared
-		addIfBoundary(at(i));
-		ret.addIfBoundary(at(i));
-	}
-	
-	//The lists are shorter now-- take up the slack
-	//ret.trim();us.trim(); //<- old version could do this
-	
+  int oStart=nHome,oEnd=length();
+  int i;
+
+  //Figure out where to divide our elements
+  int div=splitAt(alongAxis);
+  if (div==-1) return NULL;
+
+  //Make a new element to hold our other half
+  CollideOctant &ret=*(new CollideOctant(length(),territory));
+  CollideOctant &us=*this;
+
+  //Divide home elements: us<-[0..div-1] and dest<-[div..nHome-1]
+  ret.nHome=ret.length()=nHome-div;
+  for (i=div;i<nHome;i++) ret[i-div]=us[i];
+  us.nHome=us.length()=div;
+  int ret_length=ret.length();//Prevents re-adding our own elements
+
+  //Update bounding boxes
+  us.box=us.at(0)->getBbox();
+  ret.box=ret.at(0)->getBbox();
+  for (i=length()-1;i>0;i--) us.box.add(us.at(i)->getBbox());
+  for (i=ret_length-1;i>0;i--) ret.box.add(ret.at(i)->getBbox());
+
+  //Find the boundary elements
+  for (i=length()-1;i>=0;i--)
+    ret.addIfBoundary(at(i)); //We form his boundary
+  for (i=ret_length-1;i>=0;i--)
+    addIfBoundary(ret.at(i)); //He forms our boundary
+  for (i=oStart;i<oEnd;i++) {//Our old boundary elements are now shared
+    addIfBoundary(at(i));
+    ret.addIfBoundary(at(i));
+  }
+
+  //The lists are shorter now-- take up the slack
+  //ret.trim();us.trim(); //<- old version could do this
+
 #if DEBUG_CHECKS //Debugging-- check invariants
-	ret.check();
-	us.check();
+  ret.check();
+  us.check();
 #endif
-	return &ret;
+  return &ret;
 }
 
 /////////////////////////////////////////////////////
@@ -259,68 +259,68 @@ inline T mymin(T a,T b) {if (a<b) return a; return b;}
 //The basic O(n^2) Collision algorithm:
 static void simpleFindCollisions(const CollideOctant &o,CollisionList &dest)
 {
-	STATS(simpleCalls++)
-	int nH=o.getHome(),nI=o.getTotal();
-	int h,i;
-	for (h=0;h<nH;h++)
-		for (i=0;i<nI;i++) {
-			const CollideObjRec &a=*o[h];
-			const CollideObjRec &b=*o[i];
-			if (!a.id.shouldCollide(b.id)) {STATS(rejID++) continue;}
-			const bbox3d &abox=a.getBbox();
-			const bbox3d &bbox=b.getBbox();
-			if (!abox.intersectsOpen(bbox)) {STATS(rejBbox++) continue;}
-			
-			//Territory is used to avoid duplicate intersections 
-			// across different grid cells
-			if (!o.x_inTerritory(mymax(abox.axis(0).getMin(),bbox.axis(0).getMin())))
-				{STATS(rejTerritory[0]++) continue;}
-			if (!o.y_inTerritory(mymax(abox.axis(1).getMin(),bbox.axis(1).getMin())))
-				{STATS(rejTerritory[1]++) continue;}
-			if (!o.z_inTerritory(mymax(abox.axis(2).getMin(),bbox.axis(2).getMin())))
-				{STATS(rejTerritory[2]++) continue;}
-			
-			//	if (!poly3d::collide(a,b)) {STATS(rejCollide++) continue;}
-			STATS(Collisions++)
-			dest.add(a.id,b.id);
-		}
+  STATS(simpleCalls++)
+    int nH=o.getHome(),nI=o.getTotal();
+  int h,i;
+  for (h=0;h<nH;h++)
+    for (i=0;i<nI;i++) {
+      const CollideObjRec &a=*o[h];
+      const CollideObjRec &b=*o[i];
+      if (!a.id.shouldCollide(b.id)) {STATS(rejID++) continue;}
+      const bbox3d &abox=a.getBbox();
+      const bbox3d &bbox=b.getBbox();
+      if (!abox.intersectsOpen(bbox)) {STATS(rejBbox++) continue;}
+
+      //Territory is used to avoid duplicate intersections
+      // across different grid cells
+      if (!o.x_inTerritory(mymax(abox.axis(0).getMin(),bbox.axis(0).getMin())))
+      {STATS(rejTerritory[0]++) continue;}
+      if (!o.y_inTerritory(mymax(abox.axis(1).getMin(),bbox.axis(1).getMin())))
+      {STATS(rejTerritory[1]++) continue;}
+      if (!o.z_inTerritory(mymax(abox.axis(2).getMin(),bbox.axis(2).getMin())))
+      {STATS(rejTerritory[2]++) continue;}
+
+      //	if (!poly3d::collide(a,b)) {STATS(rejCollide++) continue;}
+      STATS(Collisions++)
+        dest.add(a.id,b.id);
+    }
 }
 
 void CollideOctant::findCollisions(int splitAxis,CollisionList &dest)
 {
-	if (getHome()==0) return; /* nothing to do */
+  if (getHome()==0) return; /* nothing to do */
 #if COLLIDE_IS_RECURSIVE
-	STATS(recursiveCalls++)
-	
+  STATS(recursiveCalls++)
+
 #if 1
-	int iprio=at(0)->id.prio, i;//See if it's all the same ID
-	for (i=length()-1;i>0;i--)
-		if (at(i)->id.prio!=iprio)
-			break;
-	if (i==0) {STATS(rejHomo++) return;}//All the same ID
+    int iprio=at(0)->id.prio, i;//See if it's all the same ID
+  for (i=length()-1;i>0;i--)
+    if (at(i)->id.prio!=iprio)
+      break;
+  if (i==0) {STATS(rejHomo++) return;}//All the same ID
 #endif
-	
-	if (getHome()>COLLIDE_RECURSIVE_THRESH) 
-	{//Split the problem once and then recurse
-		CollideOctant *n;
-		int divideCount=0;
-		do {
-			n=divide(splitAxis);
-			splitAxis=(splitAxis+1)%3;
-			divideCount++;
-		} while (n==NULL && divideCount<3);
-		if (n==NULL) 
-		{//Couldn't divide along any axis-- use simple version instead
-			STATS(simpleFallbackCalls++)
-			simpleFindCollisions(*this,dest);
-		} else {//Regular recursive division
-			n->findCollisions(splitAxis,dest);
-			delete n;
-			findCollisions(splitAxis,dest);
-		}
-	} else
+
+  if (getHome()>COLLIDE_RECURSIVE_THRESH)
+  {//Split the problem once and then recurse
+    CollideOctant *n;
+    int divideCount=0;
+    do {
+      n=divide(splitAxis);
+      splitAxis=(splitAxis+1)%3;
+      divideCount++;
+    } while (n==NULL && divideCount<3);
+    if (n==NULL)
+    {//Couldn't divide along any axis-- use simple version instead
+      STATS(simpleFallbackCalls++)
+        simpleFindCollisions(*this,dest);
+    } else {//Regular recursive division
+      n->findCollisions(splitAxis,dest);
+      delete n;
+      findCollisions(splitAxis,dest);
+    }
+  } else
 #endif
-		simpleFindCollisions(*this,dest);
+    simpleFindCollisions(*this,dest);
 }
 
 

--- a/src/libs/ck-libs/collide/collide_serial.h
+++ b/src/libs/ck-libs/collide/collide_serial.h
@@ -1,8 +1,8 @@
 /*
-Serial Collision detection classes.
+   Serial Collision detection classes.
 
-Orion Sky Lawlor, olawlor@acm.org, 2003/3/19
-*/
+   Orion Sky Lawlor, olawlor@acm.org, 2003/3/19
+   */
 #ifndef __UIUC_CHARM_COLLIDE_SERIAL_H
 #define __UIUC_CHARM_COLLIDE_SERIAL_H
 
@@ -10,92 +10,92 @@ Orion Sky Lawlor, olawlor@acm.org, 2003/3/19
 #include "collide_buffers.h"
 #include "collide_cfg.h"
 
-#if !COLLIDE_STATS 
+#if !COLLIDE_STATS
 # define STATS(x) /* empty */
 #else
 # define STATS(x) stats::x;
 //Collision statistics (for measurement-based optimization)
 class stats {public:
-	static int objects;//Total number of objects
-	static int gridCells;//Total number of grid cells
-	static int gridAdds;//Number of additions to grid cells
-	static int gridSizes[3];//Total sizes of grid cells in each dimension
-	static int recursiveCalls;//Number of recursive calls
-	static int simpleCalls;//Number of simple calls
-	static int simpleFallbackCalls;//Number of unsplittable CollideOctants
-	static int splits[3];//Number of divisions along each axis
-	static int splitFailures[3];//Number of failed divisions along each axis
-	static int pivots;//Number of pivot operations (CollideOctant::splitAt)
-	static int rejHomo;//Call rejected for being from one object
-	static int rejID;//Pair rejected for being out-of-order
-	static int rejBbox;//Pair rejected for BBox mismatch
-	static int rejTerritory[3];//Pair rejected for being out of territory
-	static int rejCollide;//Pair rejected by slow intersection algorithm
-	static int Collisions;//Number of actual intersections
-	static void print(void);
+  static int objects;//Total number of objects
+  static int gridCells;//Total number of grid cells
+  static int gridAdds;//Number of additions to grid cells
+  static int gridSizes[3];//Total sizes of grid cells in each dimension
+  static int recursiveCalls;//Number of recursive calls
+  static int simpleCalls;//Number of simple calls
+  static int simpleFallbackCalls;//Number of unsplittable CollideOctants
+  static int splits[3];//Number of divisions along each axis
+  static int splitFailures[3];//Number of failed divisions along each axis
+  static int pivots;//Number of pivot operations (CollideOctant::splitAt)
+  static int rejHomo;//Call rejected for being from one object
+  static int rejID;//Pair rejected for being out-of-order
+  static int rejBbox;//Pair rejected for BBox mismatch
+  static int rejTerritory[3];//Pair rejected for being out of territory
+  static int rejCollide;//Pair rejected by slow intersection algorithm
+  static int Collisions;//Number of actual intersections
+  static void print(void);
 };
 #endif
 
 class CollideObjConsumer {
-public:
-	virtual void add(const CollideObjRec *obj)=0;
+  public:
+    virtual void add(const CollideObjRec *obj)=0;
 };
 
 //A set of objects, organized by the location of the small
 // corner of their bbox.
 // Objects with their smallest bbox corner here are called "home" polys.
-class CollideOctant : public growableBufferT<const CollideObjRec *>, public CollideObjConsumer 
+class CollideOctant : public growableBufferT<const CollideObjRec *>, public CollideObjConsumer
 {
-	typedef growableBufferT<const CollideObjRec *> parent;
-	int nHome;//Number of non-boundary elements
-	bbox3d box;//We need every object that touches this region
-	bbox3d territory;//We are responsible for intersections here
+  typedef growableBufferT<const CollideObjRec *> parent;
+  int nHome;//Number of non-boundary elements
+  bbox3d box;//We need every object that touches this region
+  bbox3d territory;//We are responsible for intersections here
 
-	//Figure out what index to divide our polys at
-	int splitAt(int alongAxis);
-	
-public:
-	CollideOctant(int size,bbox3d myTerritory) 
-		: parent(size),territory(myTerritory)
-	{nHome=0;box.empty();}
-	virtual ~CollideOctant();
-	
-	void setBbox(const bbox3d &b) {box=b;}
-	const bbox3d &getBbox(void) const {return box;}
-	const bbox3d &getTerritory(void) const {return territory;}
-	bool x_inTerritory(real v) const {return territory.axis(0).containsHalf(v);}
-	bool y_inTerritory(real v) const {return territory.axis(1).containsHalf(v);}
-	bool z_inTerritory(real v) const {return territory.axis(2).containsHalf(v);}
-	
-	//Get total count
-	int getTotal(void) const {return length();}
-	//Get home count
-	int getHome(void) const {return nHome;}
-	//Mark 0..h as at home
-	void markHome(int h) {nHome=h;}
-	
-	//Grow to contain this added object (adjusts length if needed)
-	void growTo(const CollideObjRec *b) {
-		box.add(b->getBbox());
-		push_fast(b);
-	}
-	//If needed, add this boundary poly (length must be preallocated)
-	void addIfBoundary(const CollideObjRec *b) {
-		if (box.intersects(b->getBbox())) push_fast(b);
-	}
-	
-	// Divide this CollideOctant along the given axis.
-	// This CollideOctant shrinks, the new one grows.
-	// Respects non-home polys.
-	CollideOctant *divide(int alongAxis);
-	
-	void check(void) const;//Ensure our constraints hold
-	void print(const char *desc=NULL) const;
-	virtual void add(const CollideObjRec *);
-	
-	void findCollisions(int splitAxis,CollisionList &dest);
-	void findCollisions(CollisionList &dest)
-		{findCollisions(0,dest);}
+  //Figure out what index to divide our polys at
+  int splitAt(int alongAxis);
+
+  public:
+  CollideOctant(int size,bbox3d myTerritory)
+    : parent(size),territory(myTerritory)
+  {nHome=0;box.empty();}
+  virtual ~CollideOctant();
+
+  void setBbox(const bbox3d &b) {box=b;}
+  const bbox3d &getBbox(void) const {return box;}
+  const bbox3d &getTerritory(void) const {return territory;}
+  bool x_inTerritory(real v) const {return territory.axis(0).containsHalf(v);}
+  bool y_inTerritory(real v) const {return territory.axis(1).containsHalf(v);}
+  bool z_inTerritory(real v) const {return territory.axis(2).containsHalf(v);}
+
+  //Get total count
+  int getTotal(void) const {return length();}
+  //Get home count
+  int getHome(void) const {return nHome;}
+  //Mark 0..h as at home
+  void markHome(int h) {nHome=h;}
+
+  //Grow to contain this added object (adjusts length if needed)
+  void growTo(const CollideObjRec *b) {
+    box.add(b->getBbox());
+    push_fast(b);
+  }
+  //If needed, add this boundary poly (length must be preallocated)
+  void addIfBoundary(const CollideObjRec *b) {
+    if (box.intersects(b->getBbox())) push_fast(b);
+  }
+
+  // Divide this CollideOctant along the given axis.
+  // This CollideOctant shrinks, the new one grows.
+  // Respects non-home polys.
+  CollideOctant *divide(int alongAxis);
+
+  void check(void) const;//Ensure our constraints hold
+  void print(const char *desc=NULL) const;
+  virtual void add(const CollideObjRec *);
+
+  void findCollisions(int splitAxis,CollisionList &dest);
+  void findCollisions(CollisionList &dest)
+  {findCollisions(0,dest);}
 };
 
 #endif //def(thisHeader)

--- a/src/libs/ck-libs/collide/collide_util.C
+++ b/src/libs/ck-libs/collide/collide_util.C
@@ -1,8 +1,8 @@
 /*
-Simple, basic data types for Collision detection.
+   Simple, basic data types for Collision detection.
 
-Orion Sky Lawlor, olawlor@acm.org, 2003/3/19
-*/
+   Orion Sky Lawlor, olawlor@acm.org, 2003/3/19
+   */
 #include <stdio.h>
 #include "collide_util.h"
 #include "charm.h" /* for CkAbort */
@@ -10,62 +10,62 @@ Orion Sky Lawlor, olawlor@acm.org, 2003/3/19
 
 /************** CollideGrid3d ***********/
 static void testMapping(CollideGrid3d &map,int axis,
-	double origin,double size)
+    double origin,double size)
 {
-	int m1=map.world2grid(axis,rSeg1d(-1.0e20,origin-0.6*size)).getMax();
-	int m2=map.world2grid(axis,rSeg1d(-1.0e20,origin-0.4*size)).getMax();
-	int m3=map.world2grid(axis,rSeg1d(-1.0e20,origin-0.1*size)).getMax();
-	int e1=map.world2grid(axis,rSeg1d(-1.0e20,origin+0.1*size)).getMax();
-	int e2=map.world2grid(axis,rSeg1d(-1.0e20,origin+0.4*size)).getMax();
-	int e3=map.world2grid(axis,rSeg1d(-1.0e20,origin+0.6*size)).getMax();
-	int e4=map.world2grid(axis,rSeg1d(-1.0e20,origin+0.9*size)).getMax();
-	int p1=map.world2grid(axis,rSeg1d(-1.0e20,origin+1.1*size)).getMax();
-	int p2=map.world2grid(axis,rSeg1d(-1.0e20,origin+1.4*size)).getMax();
-	int p3=map.world2grid(axis,rSeg1d(-1.0e20,origin+1.6*size)).getMax();
-	int p4=map.world2grid(axis,rSeg1d(-1.0e20,origin+1.9*size)).getMax();
-	if (m1!=m2 || m1!=m3) 
-		CkAbort("CollideGrid3d::Grid initialization error (m)!\n");
-	if (e1!=e2 || e1!=e3 || e1!=e4) 
-		CkAbort("CollideGrid3d::Grid initialization error (e)!\n");
-	if (p1!=p2 || p1!=p3 || p1!=p4) 
-		CkAbort("CollideGrid3d::Grid initialization error (p)!\n");
+  int m1=map.world2grid(axis,rSeg1d(-1.0e20,origin-0.6*size)).getMax();
+  int m2=map.world2grid(axis,rSeg1d(-1.0e20,origin-0.4*size)).getMax();
+  int m3=map.world2grid(axis,rSeg1d(-1.0e20,origin-0.1*size)).getMax();
+  int e1=map.world2grid(axis,rSeg1d(-1.0e20,origin+0.1*size)).getMax();
+  int e2=map.world2grid(axis,rSeg1d(-1.0e20,origin+0.4*size)).getMax();
+  int e3=map.world2grid(axis,rSeg1d(-1.0e20,origin+0.6*size)).getMax();
+  int e4=map.world2grid(axis,rSeg1d(-1.0e20,origin+0.9*size)).getMax();
+  int p1=map.world2grid(axis,rSeg1d(-1.0e20,origin+1.1*size)).getMax();
+  int p2=map.world2grid(axis,rSeg1d(-1.0e20,origin+1.4*size)).getMax();
+  int p3=map.world2grid(axis,rSeg1d(-1.0e20,origin+1.6*size)).getMax();
+  int p4=map.world2grid(axis,rSeg1d(-1.0e20,origin+1.9*size)).getMax();
+  if (m1!=m2 || m1!=m3)
+    CkAbort("CollideGrid3d::Grid initialization error (m)!\n");
+  if (e1!=e2 || e1!=e3 || e1!=e4)
+    CkAbort("CollideGrid3d::Grid initialization error (e)!\n");
+  if (p1!=p2 || p1!=p3 || p1!=p4)
+    CkAbort("CollideGrid3d::Grid initialization error (p)!\n");
 }
 
 void CollideGrid3d::init(const vector3d &Norigin,//Grid voxel corner 0,0,0
-                const vector3d &desiredSize)//Size of each voxel
+    const vector3d &desiredSize)//Size of each voxel
 {
-	origin=Norigin;
-        for (int i=0;i<3;i++) {
+  origin=Norigin;
+  for (int i=0;i<3;i++) {
 #if COLLIDE_USE_FLOAT_HACK
-                //Compute gridhack shift-- round grid size down 
-                //  to nearest smaller power of two
-                double s=(1<<20);
-                while (s>(1.25*desiredSize[i])) s*=0.5;
-                ((double*)sizes)[i]=s;
-                hakShift[i]=(1.5*(1<<23)-0.5)*s-((double*)origin)[i];
-                float o=(float)(hakShift[i]);
-                hakStart[i]=*(int *)&o;
+    //Compute gridhack shift-- round grid size down
+    //  to nearest smaller power of two
+    double s=(1<<20);
+    while (s>(1.25*desiredSize[i])) s*=0.5;
+    ((double*)sizes)[i]=s;
+    hakShift[i]=(1.5*(1<<23)-0.5)*s-((double*)origin)[i];
+    float o=(float)(hakShift[i]);
+    hakStart[i]=*(int *)&o;
 #else
-                sizes[i]=desiredSize[i];
+    sizes[i]=desiredSize[i];
 #endif
-                ((double *)scales)[i]=1.0/((double *)sizes)[i];
-                testMapping(*this,i,((double *)origin)[i],((double *)sizes)[i]);
-        }
-        
+    ((double *)scales)[i]=1.0/((double *)sizes)[i];
+    testMapping(*this,i,((double *)origin)[i],((double *)sizes)[i]);
+  }
+
 }
 
 void CollideGrid3d::pup(PUP::er &p) {
-	p|origin; p|scales; p|sizes;
+  p|origin; p|scales; p|sizes;
 #if COLLIDE_USE_FLOAT_HACK
-	p(hakShift,3);
-	p(hakStart,3);
+  p(hakShift,3);
+  p(hakStart,3);
 #endif
 }
 
 void CollideGrid3d::print(const CollideLoc3d &g) {
 #if !COLLIDE_USE_FLOAT_HACK
-	const static int hakStart[3]={0,0,0};
+  const static int hakStart[3]={0,0,0};
 #endif
-	printf("%d,%d,%d",g.x-hakStart[0],g.y-hakStart[1],g.z-hakStart[2]);	
+  printf("%d,%d,%d",g.x-hakStart[0],g.y-hakStart[1],g.z-hakStart[2]);
 }
 

--- a/src/libs/ck-libs/collide/collide_util.h
+++ b/src/libs/ck-libs/collide/collide_util.h
@@ -1,8 +1,8 @@
 /*
-Simple, basic data types for Collision detection.
+   Simple, basic data types for Collision detection.
 
-Orion Sky Lawlor, olawlor@acm.org, 2003/3/19
-*/
+   Orion Sky Lawlor, olawlor@acm.org, 2003/3/19
+   */
 #ifndef __UIUC_CHARM_COLLIDE_UTIL_H
 #define __UIUC_CHARM_COLLIDE_UTIL_H
 
@@ -17,128 +17,128 @@ typedef double real;
 
 //Identifies an object across the machine
 struct CollideObjID {
-	int chunk;//Source chunk
-	int number;//Chunk-local number
-	int prio; //Collision "priority"--objects with same priority won't collide
-	int pe; //Processor chunk was last living on
-	CollideObjID(int chunk_,int number_,int prio_,int pe_) 
-		:chunk(chunk_),number(number_),prio(prio_),pe(pe_) {}
-	
-	/**
- 	 * Return true if we should be collided with b.
-	 * This ends up comparing Collision priorities.
-	 */
-	inline int shouldCollide(const CollideObjID &b) const {
-		if (prio<b.prio) return 1; //First check priority
-		return 0;
-	}
+  int chunk;//Source chunk
+  int number;//Chunk-local number
+  int prio; //Collision "priority"--objects with same priority won't collide
+  int pe; //Processor chunk was last living on
+  CollideObjID(int chunk_,int number_,int prio_,int pe_)
+    :chunk(chunk_),number(number_),prio(prio_),pe(pe_) {}
+
+  /**
+   * Return true if we should be collided with b.
+   * This ends up comparing Collision priorities.
+   */
+  inline int shouldCollide(const CollideObjID &b) const {
+    if (prio<b.prio) return 1; //First check priority
+    return 0;
+  }
 };
 
 //Records a single pair of intersecting objects
 class Collision {
-public:
-	CollideObjID A,B;
-	Collision(const CollideObjID &A_, const CollideObjID &B_) :A(A_),B(B_) { }
+  public:
+    CollideObjID A,B;
+    Collision(const CollideObjID &A_, const CollideObjID &B_) :A(A_),B(B_) { }
 };
 
 class CollisionList : public growableBufferT<Collision> {
-public:
-	CollisionList() {}
-	void add(const CollideObjID &A, const CollideObjID &B) {
-		push_back(Collision(A,B));
-	}
+  public:
+    CollisionList() {}
+    void add(const CollideObjID &A, const CollideObjID &B) {
+      push_back(Collision(A,B));
+    }
 };
 
 
 //An object sent to another processor
 struct CollideObjRec {
-	CollideObjID id;
-	bbox3d box;
-	CollideObjRec(const CollideObjID &id_,const bbox3d &box_)
-		:id(id_),box(box_) {}
+  CollideObjID id;
+  bbox3d box;
+  CollideObjRec(const CollideObjID &id_,const bbox3d &box_)
+    :id(id_),box(box_) {}
 
-	const bbox3d &getBbox(void) const {return box;}
+  const bbox3d &getBbox(void) const {return box;}
 };
 
 //Identifies a Collision voxel in the problem domain
 class CollideLoc3d {
-	//Circular-left-shift x by n bits
-	static inline int cls(int x,unsigned int n) {
-		const unsigned int intBits=8*sizeof(int);
-		n&=(intBits-1);//Modulo intBits
-		return (x<<n)|(x>>(intBits-n));
-	}
-public:
-	int x,y,z;
-	CollideLoc3d(int Nx,int Ny,int Nz) {x=Nx;y=Ny;z=Nz;}
-	CollideLoc3d() {}
-	int getX() const {return x;}
-	int getY() const {return y;}
-	int getZ() const {return z;}
-	inline unsigned int  hash(void) const {
-		return cls(x,6)+cls(y,17)+cls(z,28);
-		//return (x<<8)+(y<<17)+cls(z,28);
-	}
-	static unsigned int staticHash(const void *key,size_t ignored) {
-		return ((const CollideLoc3d *)key)->hash();
-	}
-	inline int compare(const CollideLoc3d &b) const {
-		return x==b.x && y==b.y && z==b.z;
-	}
-	static int staticCompare(const void *k1,const void *k2,size_t ignored) {
-		return ((const CollideLoc3d *)k1)->compare(*(const CollideLoc3d *)k2);
-	}
+  //Circular-left-shift x by n bits
+  static inline int cls(int x,unsigned int n) {
+    const unsigned int intBits=8*sizeof(int);
+    n&=(intBits-1);//Modulo intBits
+    return (x<<n)|(x>>(intBits-n));
+  }
+  public:
+  int x,y,z;
+  CollideLoc3d(int Nx,int Ny,int Nz) {x=Nx;y=Ny;z=Nz;}
+  CollideLoc3d() {}
+  int getX() const {return x;}
+  int getY() const {return y;}
+  int getZ() const {return z;}
+  inline unsigned int  hash(void) const {
+    return cls(x,6)+cls(y,17)+cls(z,28);
+    //return (x<<8)+(y<<17)+cls(z,28);
+  }
+  static unsigned int staticHash(const void *key,size_t ignored) {
+    return ((const CollideLoc3d *)key)->hash();
+  }
+  inline int compare(const CollideLoc3d &b) const {
+    return x==b.x && y==b.y && z==b.z;
+  }
+  static int staticCompare(const void *k1,const void *k2,size_t ignored) {
+    return ((const CollideLoc3d *)k1)->compare(*(const CollideLoc3d *)k2);
+  }
 };
 
 
 /// Map real world (x,y,z) coordinates to integer (i,j,k) grid indices
 class CollideGrid3d {
-	vector3d origin,scales,sizes;//Convert world->grid coordinates
-	#if COLLIDE_USE_FLOAT_HACK
-	double hakShift[3]; //For bitwise float rounding hack
-	int hakStart[3];
-	#endif
-public:
-	CollideGrid3d() {}
-	CollideGrid3d(const vector3d &Norigin,const vector3d &desiredSize) {
-		init(Norigin,desiredSize);
-	}
-	void pup(PUP::er &p);
-	
-	void init(const vector3d &Norigin,//Grid cell corner 0,0,0
-		const vector3d &desiredSize);//Size of each cell
-	
-	real world2grid(int axis,real x) const {
-		return (x-origin[axis])*scales[axis];
-	}
-	iSeg1d world2grid(int axis,const rSeg1d &s) const {
-	#if COLLIDE_USE_FLOAT_HACK
-	 //Bizarre bitwise hack:
-		float fl=(float)(hakShift[axis]+s.getMin());
-		int lo=*(int *)&fl;
-		float fh=(float)(hakShift[axis]+s.getMax());
-		int hi=1+*(int *)&fh;
-	#else
-		int lo=(int)floor(world2grid(axis,s.getMin()));
-		int hi=(int)ceil(world2grid(axis,s.getMax()));
-	#endif
-		return iSeg1d(lo,hi);
-	}
-	//Map grid coordinates->world coordinates
-	real grid2world(int axis,real val) const {
-	#if COLLIDE_USE_FLOAT_HACK
-		return (val-hakStart[axis])
-	#else
-		return val
-	#endif
-		/*continued*/  *sizes[axis]+origin[axis];
-	}
-	rSeg1d grid2world(int axis,rSeg1d src) const {
-		return rSeg1d(grid2world(axis,src.getMin()),
-		              grid2world(axis,src.getMax()));
-	}
-	//Print this location nicely
-	void print(const CollideLoc3d &g);
+  vector3d origin,scales,sizes;//Convert world->grid coordinates
+#if COLLIDE_USE_FLOAT_HACK
+  double hakShift[3]; //For bitwise float rounding hack
+  int hakStart[3];
+#endif
+  public:
+  CollideGrid3d() {}
+  CollideGrid3d(const vector3d &Norigin,const vector3d &desiredSize) {
+    init(Norigin,desiredSize);
+  }
+  void pup(PUP::er &p);
+
+  void init(const vector3d &Norigin,//Grid cell corner 0,0,0
+      const vector3d &desiredSize);//Size of each cell
+
+  real world2grid(int axis,real x) const {
+    return (x-origin[axis])*scales[axis];
+  }
+  iSeg1d world2grid(int axis,const rSeg1d &s) const {
+#if COLLIDE_USE_FLOAT_HACK
+    //Bizarre bitwise hack:
+    float fl=(float)(hakShift[axis]+s.getMin());
+    int lo=*(int *)&fl;
+    float fh=(float)(hakShift[axis]+s.getMax());
+    int hi=1+*(int *)&fh;
+#else
+    int lo=(int)floor(world2grid(axis,s.getMin()));
+    int hi=(int)ceil(world2grid(axis,s.getMax()));
+#endif
+    return iSeg1d(lo,hi);
+  }
+  //Map grid coordinates->world coordinates
+  real grid2world(int axis,real val) const {
+#if COLLIDE_USE_FLOAT_HACK
+    return (val-hakStart[axis])
+#else
+      return val
+#endif
+      /*continued*/  *sizes[axis]+origin[axis];
+  }
+  rSeg1d grid2world(int axis,rSeg1d src) const {
+    return rSeg1d(grid2world(axis,src.getMin()),
+        grid2world(axis,src.getMax()));
+  }
+  //Print this location nicely
+  void print(const CollideLoc3d &g);
 };
 
 

--- a/src/libs/ck-libs/collide/collidec.h
+++ b/src/libs/ck-libs/collide/collidec.h
@@ -1,7 +1,7 @@
 /**
-Threaded C interface to 
-Charm++ Collision detection subsystem
-*/
+  Threaded C interface to
+  Charm++ Collision detection subsystem
+  */
 #ifndef __UIUC_CHARM_COLLIDEC_H_
 #define __UIUC_CHARM_COLLIDEC_H_
 
@@ -9,64 +9,64 @@ Charm++ Collision detection subsystem
 extern "C" {
 #endif
 
-/**
-A collide_t is a handle to a single collision detection grid.
-*/
-typedef int collide_t;
+  /**
+    A collide_t is a handle to a single collision detection grid.
+    */
+  typedef int collide_t;
 
-/**
-Create a new Collision grid. 
+  /**
+    Create a new Collision grid.
 
-This collective creation call must be made from all the threads of 
-a TCHARM array.  
+    This collective creation call must be made from all the threads of
+    a TCHARM array.
 
-  @param mpi_comm is the MPI communicator, or 0 if not using MPI.
-  @param gridSize gives the size of one voxel, which should
-   be several times larger than the size of the average object.
-  @param gridStart gives the origin of the voxel array--the corner
-   of the voxel (0,0,0).  For best performance, if possible you should
-   align the voxel array so most objects lie in exactly one voxel.
-*/
-collide_t COLLIDE_Init(int mpi_comm,
-	const double *gridStart,const double *gridSize);
+    @param mpi_comm is the MPI communicator, or 0 if not using MPI.
+    @param gridSize gives the size of one voxel, which should
+    be several times larger than the size of the average object.
+    @param gridStart gives the origin of the voxel array--the corner
+    of the voxel (0,0,0).  For best performance, if possible you should
+    align the voxel array so most objects lie in exactly one voxel.
+    */
+  collide_t COLLIDE_Init(int mpi_comm,
+      const double *gridStart,const double *gridSize);
 
-/**
-Collide these boxes (boxes[0..6*nBox]).
-This is a collective call--all registered chunks should make this call.
-Unliked CollideClassed, below, no Collisions are ignored; or
-equivalently, every box lies in its own Collision class.
-  @param nBoxes number of independent objects to collide.
-  @param boxes an array of nBox 3d bounding boxes, stored as 
-     x-min, x-max, y-min, y-max, z-min, z-max.
-*/
-void COLLIDE_Boxes(collide_t c,int nBox,const double *boxes);
+  /**
+    Collide these boxes (boxes[0..6*nBox]).
+    This is a collective call--all registered chunks should make this call.
+    Unliked CollideClassed, below, no Collisions are ignored; or
+    equivalently, every box lies in its own Collision class.
+    @param nBoxes number of independent objects to collide.
+    @param boxes an array of nBox 3d bounding boxes, stored as
+    x-min, x-max, y-min, y-max, z-min, z-max.
+    */
+  void COLLIDE_Boxes(collide_t c,int nBox,const double *boxes);
 
-/**
-Collide these boxes (boxes[0..6*nBox]), using the given box
-priorities (prio[0..nBox]).
-*/
-void COLLIDE_Boxes_prio(int chunkNo,int nBox,const double *boxes, 
-	const int *prio);
+  /**
+    Collide these boxes (boxes[0..6*nBox]), using the given box
+    priorities (prio[0..nBox]).
+    */
+  void COLLIDE_Boxes_prio(int chunkNo,int nBox,const double *boxes,
+      const int *prio);
 
-/**
-Immediately after a Collision, get the number of Collision records.
-This value is normally used to allocate the array passed to COLLIDE_List.
-*/
-int COLLIDE_Count(collide_t c);
+  /**
+    Immediately after a Collision, get the number of Collision records.
+    This value is normally used to allocate the array passed to COLLIDE_List.
+    */
+  int COLLIDE_Count(collide_t c);
 
-/**
-Immediately after a Collision, get the colliding records into 
-   Collisions[0..3*nColl].
-   Collisions[3*c+0] lists the number of box A, which is always from my chunk
-   Collisions[3*c+1] lists the source chunk of box B (possibly my own chunk)
-   Collisions[3*c+2] lists the number of box B on its source chunk
-*/
-void COLLIDE_List(collide_t c,int *Collisions3);
+  /**
+    Immediately after a Collision, get the colliding records into
+    Collisions[0..3*nColl].
+    Collisions[3*c+0] lists the number of box A, which is always from my chunk
+    Collisions[3*c+1] lists the source chunk of box B (possibly my own chunk)
+    Collisions[3*c+2] lists the number of box B on its source chunk
+    */
+  void COLLIDE_List(collide_t c,int *Collisions3);
 
-/**
-Destroy this Collision grid.
-*/
-void COLLIDE_Destroy(collide_t c);
+  /**
+    Destroy this Collision grid.
+    */
+  void COLLIDE_Destroy(collide_t c);
 
 #ifdef __cplusplus
 }

--- a/src/libs/ck-libs/collide/collidecharm.C
+++ b/src/libs/ck-libs/collide/collidecharm.C
@@ -11,9 +11,9 @@
 #  define SRM_STATUS(x) ckout<<"["<<CkMyPe()<<"] C.Sync> "<<x<<endl;
 #  define CM_STATUS(x) ckout<<"["<<CkMyPe()<<"] C.Mgr> "<<x<<endl;
 #  define CC_STATUS(x) { \
-	char buf[100]; \
-	voxName(thisIndex,buf); \
-	ckout<<"["<<CkMyPe()<<"] "<<buf<<" Voxel> "<<x<<endl; \
+  char buf[100]; \
+  voxName(thisIndex,buf); \
+  ckout<<"["<<CkMyPe()<<"] "<<buf<<" Voxel> "<<x<<endl; \
 }
 
 #  define COL_STATUS(x) ckout<<"["<<CkMyPe()<<"] Collide> "<<x<<endl;
@@ -26,132 +26,132 @@
 #endif
 
 /*************** Charm++ User External Interface ********
-Implementation of collide.h routines.
-*/
+  Implementation of collide.h routines.
+  */
 
 /// Call this on processor 0 to build a Collision client that
 ///  just calls this serial routine on processor 0 with the final,
 ///  complete Collision list.
 CkGroupID CollideSerialClient(CollisionClientFn clientFn,void *clientParam)
 {
-	CProxy_serialCollideClient cl=CProxy_serialCollideClient::ckNew();
-	cl.ckLocalBranch()->setClient(clientFn,clientParam);
-	return cl;
+  CProxy_serialCollideClient cl=CProxy_serialCollideClient::ckNew();
+  cl.ckLocalBranch()->setClient(clientFn,clientParam);
+  return cl;
 }
 
 
-/// Create a collider group to contribute objects to.  
+/// Create a collider group to contribute objects to.
 ///  Should be called on processor 0.
 CollideHandle CollideCreate(const CollideGrid3d &gridMap,
-	CkGroupID clientGroupID)
+    CkGroupID clientGroupID)
 {
-	CProxy_collideVoxel voxels=CProxy_collideVoxel::ckNew();
-	voxels.doneInserting();
-	CProxy_collideClient client(clientGroupID);
-	return CProxy_collideMgr::ckNew(gridMap,client,voxels);
+  CProxy_collideVoxel voxels=CProxy_collideVoxel::ckNew();
+  voxels.doneInserting();
+  CProxy_collideClient client(clientGroupID);
+  return CProxy_collideMgr::ckNew(gridMap,client,voxels);
 }
 
 /// Register with this collider group.
 void CollideRegister(CollideHandle h,int chunkNo) {
-	CProxy_collideMgr mgr(h);
-	mgr.ckLocalBranch()->registerContributor(chunkNo);
+  CProxy_collideMgr mgr(h);
+  mgr.ckLocalBranch()->registerContributor(chunkNo);
 }
 /// Unregister with this collider group.
 void CollideUnregister(CollideHandle h,int chunkNo) {
-	CProxy_collideMgr mgr(h);
-	mgr.ckLocalBranch()->unregisterContributor(chunkNo);
+  CProxy_collideMgr mgr(h);
+  mgr.ckLocalBranch()->unregisterContributor(chunkNo);
 }
 
 /// Send these objects off to be collided.
 /// The results go the collisionClient group
 /// registered at creation time.
 void CollideBoxesPrio(CollideHandle h,int chunkNo,
-	int nBox,const bbox3d *boxes,const int *prio) 
+    int nBox,const bbox3d *boxes,const int *prio)
 {
-	CProxy_collideMgr mgr(h);
-	mgr.ckLocalBranch()->contribute(chunkNo,nBox,boxes,prio);
+  CProxy_collideMgr mgr(h);
+  mgr.ckLocalBranch()->contribute(chunkNo,nBox,boxes,prio);
 }
 
 /******************** objListMsg **********************/
 objListMsg::objListMsg(
-		int n_,CollideObjRec *obj_, 
-		const returnReceipt &receipt_) 
-	:isHeapAllocated(true),receipt(receipt_),
-	 n(n_),obj(obj_)
+    int n_,CollideObjRec *obj_,
+    const returnReceipt &receipt_)
+  :isHeapAllocated(true),receipt(receipt_),
+  n(n_),obj(obj_)
 {}
 
 void objListMsg::freeHeapAllocated()
 {
-	if (!isHeapAllocated) return;
-	free(obj);obj=NULL;
+  if (!isHeapAllocated) return;
+  free(obj);obj=NULL;
 }
 
 //This gives the byte offsets & sizes needed by each field
 #define objListMsg_OFFSETS \
-	int offM=0; \
-	int cntM=sizeof(objListMsg); \
-	int offB=offM+ALIGN8(cntM); \
-	int cntB=sizeof(CollideObjRec)*m->n;\
+  int offM=0; \
+int cntM=sizeof(objListMsg); \
+int offB=offM+ALIGN8(cntM); \
+int cntB=sizeof(CollideObjRec)*m->n;\
 
 void *objListMsg::pack(objListMsg *m)
 {
-	objListMsg_OFFSETS
-	int offEnd=offB+cntB;
-	//Allocate a new message buffer and copy our fields into it
-	void *buf = CkAllocBuffer(m, offEnd);
-	char *cbuf=(char *)buf;
-	memcpy(cbuf+offM,m,cntM);
-	memcpy(cbuf+offB,m->obj,cntB);
-	delete m;
-	return buf;
+  objListMsg_OFFSETS
+    int offEnd=offB+cntB;
+  //Allocate a new message buffer and copy our fields into it
+  void *buf = CkAllocBuffer(m, offEnd);
+  char *cbuf=(char *)buf;
+  memcpy(cbuf+offM,m,cntM);
+  memcpy(cbuf+offB,m->obj,cntB);
+  delete m;
+  return buf;
 }
 
 objListMsg *objListMsg::unpack(void *buf)
 {
-	//Unpack ourselves in-place from the buffer; with
-	// our arrays pointing into the allocated message data.
-	objListMsg *m = new (buf) objListMsg;
-	char *cbuf=(char *)buf;
-	objListMsg_OFFSETS
-	m->obj=(CollideObjRec *)(cbuf+offB);
-	return m;
+  //Unpack ourselves in-place from the buffer; with
+  // our arrays pointing into the allocated message data.
+  objListMsg *m = new (buf) objListMsg;
+  char *cbuf=(char *)buf;
+  objListMsg_OFFSETS
+    m->obj=(CollideObjRec *)(cbuf+offB);
+  return m;
 }
 
 /*************** hashCache ***************
-Speeds up hashtable lookup via caching.
-*/
+  Speeds up hashtable lookup via caching.
+  */
 #if 0 //A 2-element cache is actually slower than the 1-element case below
 //Hashtable cache
 template <int n>
 class hashCache {
-	typedef CollideLoc3d KEY;
-	typedef cellAggregator *OBJ;
-	KEY keys[n];
-	OBJ objs[n];
-	int lastFound;
-public:
-	hashCache(const KEY &invalidKey) {
-		for (int i=0;i<n;i++) keys[i]=invalidKey;
-		lastFound=0;
-	}
-	inline OBJ lookup(const KEY &k) {
-		if (k.compare(keys[lastFound]))
-			return objs[lastFound];
-		for (int i=0;i<n;i++)
-			if (i!=lastFound)
-				if (k.compare(keys[i]))
-				{
-					lastFound=i;
-					return objs[i];
-				}
-		return OBJ(0);
-	}
-	void add(const KEY &k,const OBJ &o) {
-		int doomed=lastFound+1;
-		if (doomed>=n) doomed-=n;
-		keys[doomed]=k;
-		objs[doomed]=o;
-	}
+  typedef CollideLoc3d KEY;
+  typedef cellAggregator *OBJ;
+  KEY keys[n];
+  OBJ objs[n];
+  int lastFound;
+  public:
+  hashCache(const KEY &invalidKey) {
+    for (int i=0;i<n;i++) keys[i]=invalidKey;
+    lastFound=0;
+  }
+  inline OBJ lookup(const KEY &k) {
+    if (k.compare(keys[lastFound]))
+      return objs[lastFound];
+    for (int i=0;i<n;i++)
+      if (i!=lastFound)
+        if (k.compare(keys[i]))
+        {
+          lastFound=i;
+          return objs[i];
+        }
+    return OBJ(0);
+  }
+  void add(const KEY &k,const OBJ &o) {
+    int doomed=lastFound+1;
+    if (doomed>=n) doomed-=n;
+    keys[doomed]=k;
+    objs[doomed]=o;
+  }
 };
 #endif
 
@@ -159,85 +159,85 @@ public:
 //  (partial specialization isn't well supported, so this is manual.)
 template <class KEY,class OBJ>
 class hashCache1 {
-	KEY key;
-	OBJ obj;
-public:
-	hashCache1(const KEY &invalidKey) {
-		key=invalidKey;
-	}
-	inline OBJ lookup(const KEY &k) {
-		if (k.compare(key)) return obj;
-		else return OBJ(0);
-	}
-	inline void add(const KEY &k,const OBJ &o) {
-		key=k;
-		obj=o;
-	}
+  KEY key;
+  OBJ obj;
+  public:
+  hashCache1(const KEY &invalidKey) {
+    key=invalidKey;
+  }
+  inline OBJ lookup(const KEY &k) {
+    if (k.compare(key)) return obj;
+    else return OBJ(0);
+  }
+  inline void add(const KEY &k,const OBJ &o) {
+    key=k;
+    obj=o;
+  }
 };
 
 /************* voxelAggregator ***********
-Accumulates lists of objects for one voxel until 
-there are enough to send off.  Private class of CollisionAggregator.
-*/
+  Accumulates lists of objects for one voxel until
+  there are enough to send off.  Private class of CollisionAggregator.
+  */
 class voxelAggregator {
-private:
-	//Accumulates objects for the current message
-	growableBufferT<CollideObjRec> obj;
-	CollideLoc3d destination;
-	collideMgr *mgr;
-public:
-	voxelAggregator(const CollideLoc3d &dest,collideMgr *mgr_)
-	  :destination(dest),mgr(mgr_) { }
-	
-	//Add this object to the packList
-	inline void add(const CollideObjRec &o) {
-		obj.push_back(o);
-	}
-	
-	//Send off all accumulated objects.
-	void send(void);
+  private:
+    //Accumulates objects for the current message
+    growableBufferT<CollideObjRec> obj;
+    CollideLoc3d destination;
+    collideMgr *mgr;
+  public:
+    voxelAggregator(const CollideLoc3d &dest,collideMgr *mgr_)
+      :destination(dest),mgr(mgr_) { }
+
+    //Add this object to the packList
+    inline void add(const CollideObjRec &o) {
+      obj.push_back(o);
+    }
+
+    //Send off all accumulated objects.
+    void send(void);
 };
 
 //Send off any accumulated triangles.
 void voxelAggregator::send(void) {
-	if (obj.length()>0) {
-		//Detach accumulated data and send it off
-		CollideObjRec *o=obj.getData(); int n=obj.length();
-		obj.detachBuffer();
-		mgr->sendVoxelMessage(destination,n,o);
-	}
+  if (obj.length()>0) {
+    //Detach accumulated data and send it off
+    CollideObjRec *o=obj.getData(); int n=obj.length();
+    obj.detachBuffer();
+    mgr->sendVoxelMessage(destination,n,o);
+  }
 }
 
 
 /************* CollisionAggregator ***************
-Receives lists of points and triangles from the sources
-on a particular machine.  Determines which voxels each
-triangle spans, and adds the triangle to each voxelAggregator.
-Maintains a sparse hashtable voxels.
-*/
+  Receives lists of points and triangles from the sources
+  on a particular machine.  Determines which voxels each
+  triangle spans, and adds the triangle to each voxelAggregator.
+  Maintains a sparse hashtable voxels.
+  */
 CollisionAggregator::CollisionAggregator(const CollideGrid3d &gridMap_,collideMgr *mgr_)
-	 :gridMap(gridMap_),voxels(17,0.25),mgr(mgr_)
+  :gridMap(gridMap_),voxels(17,0.25),mgr(mgr_)
 {}
 CollisionAggregator::~CollisionAggregator()
 {
-	compact();
+  compact();
 }
 
 //Add a new accumulator to the hashtable
 voxelAggregator *CollisionAggregator::addAccum(const CollideLoc3d &dest)
 {
-	voxelAggregator *ret=new voxelAggregator(dest,mgr);
-	voxels.put(dest)=ret;
-	return ret;
+  voxelAggregator *ret=new voxelAggregator(dest,mgr);
+  voxels.put(dest)=ret;
+  return ret;
 }
 
 //Add this chunk's triangles
-void CollisionAggregator::aggregate(int pe, int chunk, int n, 
-				    const bbox3d *boxes, const int *prio)
+void CollisionAggregator::aggregate(int pe, int chunk, int n,
+    const bbox3d *boxes, const int *prio)
 {
   hashCache1<CollideLoc3d,voxelAggregator *>
     cache(CollideLoc3d(-1000000000,-1000000000,-1000000000));
-  
+
   //Add each object to its corresponding voxelAggregators
   for (int i=0;i<n;i++) {
     //Compute bbox. and location
@@ -247,29 +247,29 @@ void CollisionAggregator::aggregate(int pe, int chunk, int n,
     CollideObjRec obj(CollideObjID(chunk,i,oPrio,pe),bbox);
 
     iSeg1d sx(gridMap.world2grid(0,bbox.axis(0))),
-      sy(gridMap.world2grid(1,bbox.axis(1))),
-      sz(gridMap.world2grid(2,bbox.axis(2)));
+           sy(gridMap.world2grid(1,bbox.axis(1))),
+           sz(gridMap.world2grid(2,bbox.axis(2)));
     STATS(objects++)
-    STATS(gridSizes[0]+=sx.getMax()-sx.getMin())
-    STATS(gridSizes[1]+=sy.getMax()-sy.getMin())
-    STATS(gridSizes[2]+=sz.getMax()-sz.getMin())
-      
-    //Loop over all grid voxels touched by this object
-    CollideLoc3d g;
+      STATS(gridSizes[0]+=sx.getMax()-sx.getMin())
+      STATS(gridSizes[1]+=sy.getMax()-sy.getMin())
+      STATS(gridSizes[2]+=sz.getMax()-sz.getMin())
+
+      //Loop over all grid voxels touched by this object
+      CollideLoc3d g;
     g.z=sz.getMin();
-    do { 
+    do {
       g.y=sy.getMin();
-      do { 
-	g.x=sx.getMin();
-	do {
-	  voxelAggregator *c=cache.lookup(g);
-	  if (c==NULL) { /* First object for this voxel: add record */
-	    c=voxels.get(g);
-	    if (c==NULL) c=addAccum(g);
-	    cache.add(g,c);
-	  }
-	  c->add(obj);
-	} while (++g.x<sx.getMax());
+      do {
+        g.x=sx.getMin();
+        do {
+          voxelAggregator *c=cache.lookup(g);
+          if (c==NULL) { /* First object for this voxel: add record */
+            c=voxels.get(g);
+            if (c==NULL) c=addAccum(g);
+            cache.add(g,c);
+          }
+          c->add(obj);
+        } while (++g.x<sx.getMax());
       } while (++g.y<sy.getMax());
     } while (++g.z<sz.getMax());
   }
@@ -278,98 +278,98 @@ void CollisionAggregator::aggregate(int pe, int chunk, int n,
 //Send off all accumulated messages
 void CollisionAggregator::send(void)
 {
-	CkHashtableIterator *it=voxels.iterator();
-	void *c;
-	while (NULL!=(c=it->next())) (*(voxelAggregator **)c)->send();
-	delete it;
+  CkHashtableIterator *it=voxels.iterator();
+  void *c;
+  while (NULL!=(c=it->next())) (*(voxelAggregator **)c)->send();
+  delete it;
 }
 
 //Delete all cached accumulators
 void CollisionAggregator::compact(void)
 {
-	CkHashtableIterator *it=voxels.iterator();
-	void *c;
-	while (NULL!=(c=it->next())) delete *(voxelAggregator **)c;
-	delete it;
-	voxels.empty();
+  CkHashtableIterator *it=voxels.iterator();
+  void *c;
+  while (NULL!=(c=it->next())) delete *(voxelAggregator **)c;
+  delete it;
+  voxels.empty();
 }
 
 /********************* syncReductionMgr ******************/
 syncReductionMgr::syncReductionMgr()
   :thisproxy(thisgroup)
 {
-	stepCount=-1;
-	stepFinished=true;
-	localFinished=false;
-	
-	//Set up the reduction tree
-	onPE=CkMyPe();
-	if (onPE==0) treeParent=-1;
-	else treeParent=(onPE-1)/TREE_WID;
-	treeChildStart=(onPE*TREE_WID)+1;
-	treeChildEnd=treeChildStart+TREE_WID;
-	if (treeChildStart>CkNumPes()) treeChildStart=CkNumPes();
-	if (treeChildEnd>CkNumPes()) treeChildEnd=CkNumPes();
-	nChildren=treeChildEnd-treeChildStart;
+  stepCount=-1;
+  stepFinished=true;
+  localFinished=false;
+
+  //Set up the reduction tree
+  onPE=CkMyPe();
+  if (onPE==0) treeParent=-1;
+  else treeParent=(onPE-1)/TREE_WID;
+  treeChildStart=(onPE*TREE_WID)+1;
+  treeChildEnd=treeChildStart+TREE_WID;
+  if (treeChildStart>CkNumPes()) treeChildStart=CkNumPes();
+  if (treeChildEnd>CkNumPes()) treeChildEnd=CkNumPes();
+  nChildren=treeChildEnd-treeChildStart;
 }
 void syncReductionMgr::startStep(int stepNo,bool withProd)
 {
-	SRM_STATUS("syncReductionMgr::startStep");
-	if (stepNo<1+stepCount) return;//Already started
-	if (stepNo>1+stepCount) CkAbort("Tried to start SRMgr step from future\n");
-	stepCount++;
-	stepFinished=false;
-	localFinished=false;
-	childrenCount=0;
-	if (nChildren>0)
-	  for (int i=0;i<TREE_WID;i++) 
-	    if (treeChildStart+i<CkNumPes())
-	      thisproxy[treeChildStart+i].childProd(stepCount);
-	if (withProd)
-		pleaseAdvance();//Advise subclass to advance
+  SRM_STATUS("syncReductionMgr::startStep");
+  if (stepNo<1+stepCount) return;//Already started
+  if (stepNo>1+stepCount) CkAbort("Tried to start SRMgr step from future\n");
+  stepCount++;
+  stepFinished=false;
+  localFinished=false;
+  childrenCount=0;
+  if (nChildren>0)
+    for (int i=0;i<TREE_WID;i++)
+      if (treeChildStart+i<CkNumPes())
+        thisproxy[treeChildStart+i].childProd(stepCount);
+  if (withProd)
+    pleaseAdvance();//Advise subclass to advance
 }
 
 void syncReductionMgr::advance(void)
 {
-	SRM_STATUS("syncReductionMgr::advance");
-	if (stepFinished) startStep(stepCount+1,false);
-	localFinished=true;
-	tryFinish();
+  SRM_STATUS("syncReductionMgr::advance");
+  if (stepFinished) startStep(stepCount+1,false);
+  localFinished=true;
+  tryFinish();
 }
 
 void syncReductionMgr::pleaseAdvance(void)
-	{ /*Child advisory only*/ }
+{ /*Child advisory only*/ }
 
 //This is called on PE 0 once the reduction is finished
 void syncReductionMgr::reductionFinished(void)
-	{ /*Child use only */ }
+{ /*Child use only */ }
 
 void syncReductionMgr::tryFinish(void) //Try to finish reduction
 {
-	SRM_STATUS("syncReductionMgr::tryFinish");
-	if (localFinished && (!stepFinished) && childrenCount==nChildren) 
-	{
-		stepFinished=true;
-		if (treeParent!=-1)
-			thisproxy[treeParent].childDone(stepCount);
-		else
-			reductionFinished();
-	}
+  SRM_STATUS("syncReductionMgr::tryFinish");
+  if (localFinished && (!stepFinished) && childrenCount==nChildren)
+  {
+    stepFinished=true;
+    if (treeParent!=-1)
+      thisproxy[treeParent].childDone(stepCount);
+    else
+      reductionFinished();
+  }
 }
 //Called by parent-- will you contribute?
 void syncReductionMgr::childProd(int stepCount)
 {
-	SRM_STATUS("syncReductionMgr::childProd");
-	if (stepFinished) startStep(stepCount,true);
-	tryFinish();
+  SRM_STATUS("syncReductionMgr::childProd");
+  if (stepFinished) startStep(stepCount,true);
+  tryFinish();
 }
 //Called by tree children-- me and my children are finished
 void syncReductionMgr::childDone(int stepCount)
 {
-	SRM_STATUS("syncReductionMgr::childDone");
-	if (stepFinished) startStep(stepCount,true);
-	childrenCount++;
-	tryFinish();
+  SRM_STATUS("syncReductionMgr::childDone");
+  if (stepFinished) startStep(stepCount,true);
+  childrenCount++;
+  tryFinish();
 }
 
 
@@ -378,49 +378,49 @@ void syncReductionMgr::childDone(int stepCount)
 // this is the IEEE floating-point mantissa used as a grid index
 static int low23(unsigned int src)
 {
-	unsigned int loMask=0x007fFFffu;//Low 23 bits set
-	unsigned int offset=0x00400000u;
-	return (src&loMask)-offset;
+  unsigned int loMask=0x007fFFffu;//Low 23 bits set
+  unsigned int offset=0x00400000u;
+  return (src&loMask)-offset;
 }
 static const char * voxName(int ix,int iy,int iz,char *buf) {
-	int x=low23(ix);
-	int y=low23(iy);
-	int z=low23(iz);
-	sprintf(buf,"(%d,%d,%d)",x,y,z);
-	return buf;
+  int x=low23(ix);
+  int y=low23(iy);
+  int z=low23(iz);
+  sprintf(buf,"(%d,%d,%d)",x,y,z);
+  return buf;
 }
 static const char * voxName(const CkIndex3D &idx,char *buf) {
-	return voxName(idx.x,idx.y,idx.z,buf);
+  return voxName(idx.x,idx.y,idx.z,buf);
 }
 
 
 collideMgr::collideMgr(const CollideGrid3d &gridMap_,
-		const CProxy_collideClient &client_,
-		const CProxy_collideVoxel &voxels)
-	:thisproxy(thisgroup), voxelProxy(voxels), 
-	 gridMap(gridMap_), client(client_), aggregator(gridMap,this) 
+    const CProxy_collideClient &client_,
+    const CProxy_collideVoxel &voxels)
+  :thisproxy(thisgroup), voxelProxy(voxels),
+  gridMap(gridMap_), client(client_), aggregator(gridMap,this)
 {
-	steps=0;
-	nContrib=0;
-	contribCount=0;
-	msgsSent=msgsRecvd=0;
+  steps=0;
+  nContrib=0;
+  contribCount=0;
+  msgsSent=msgsRecvd=0;
 }
 
 //Maintain contributor registration count
-void collideMgr::registerContributor(int chunkNo) 
+void collideMgr::registerContributor(int chunkNo)
 {
-	nContrib++;
-	CM_STATUS("Contributor register: now "<<nContrib);
+  nContrib++;
+  CM_STATUS("Contributor register: now "<<nContrib);
 }
-void collideMgr::unregisterContributor(int chunkNo) 
+void collideMgr::unregisterContributor(int chunkNo)
 {
-	nContrib--;
-	CM_STATUS("Contributor unregister: now "<<nContrib);
+  nContrib--;
+  CM_STATUS("Contributor unregister: now "<<nContrib);
 }
 
 //Clients call this to contribute their triangle lists
 void collideMgr::contribute(int chunkNo,
-	int n,const bbox3d *boxes,const int *prio)
+    int n,const bbox3d *boxes,const int *prio)
 {
   //printf("[%d] Receiving contribution from %d\n",CkMyPe(), chunkNo);
   CM_STATUS("collideMgr::contribute "<<n<<" boxes from "<<chunkNo);
@@ -429,223 +429,223 @@ void collideMgr::contribute(int chunkNo,
   if (++contribCount==nContrib) { //That's everybody
     //aggregator.send(); //Deliver all outgoing messages
     //if (getStepCount()%8==7)
-      aggregator.compact();//Blow away all the old voxels (saves memory)
+    aggregator.compact();//Blow away all the old voxels (saves memory)
     tryAdvance();
   }
   //printf("[%d] DONE receiving contribution from %d\n",CkMyPe(), chunkNo);
 }
 
-inline CkArrayIndex3D buildIndex(const CollideLoc3d &l) 
-	{return CkArrayIndex3D(l.x,l.y,l.z);}
+inline CkArrayIndex3D buildIndex(const CollideLoc3d &l)
+{return CkArrayIndex3D(l.x,l.y,l.z);}
 
 //voxelAggregators deliver messages to voxels via this bottleneck
 void collideMgr::sendVoxelMessage(const CollideLoc3d &dest,
-	int n,CollideObjRec *obj)
+    int n,CollideObjRec *obj)
 {
-	char destName[200];
-	CM_STATUS("collideMgr::sendVoxelMessage to "<<voxName(dest.x,dest.y,dest.z,destName));
-	msgsSent++;
-	objListMsg *msg=new objListMsg(n,obj,
-			objListMsg::returnReceipt(thisgroup,CkMyPe()));
-	voxelProxy[buildIndex(dest)].add(msg);
+  char destName[200];
+  CM_STATUS("collideMgr::sendVoxelMessage to "<<voxName(dest.x,dest.y,dest.z,destName));
+  msgsSent++;
+  objListMsg *msg=new objListMsg(n,obj,
+      objListMsg::returnReceipt(thisgroup,CkMyPe()));
+  voxelProxy[buildIndex(dest)].add(msg);
 }
 
 void objListMsg::returnReceipt::send(void)
 {
-	CProxy_collideMgr p(gid);
-	if (onPE==CkMyPe()) //Just send directly to the local branch
-		p.ckLocalBranch()->voxelMessageRecvd();
-	else //Deliver via the network
-		p[onPE].voxelMessageRecvd();
+  CProxy_collideMgr p(gid);
+  if (onPE==CkMyPe()) //Just send directly to the local branch
+    p.ckLocalBranch()->voxelMessageRecvd();
+  else //Deliver via the network
+    p[onPE].voxelMessageRecvd();
 }
 
 //collideVoxels send a return receipt here
 void collideMgr::voxelMessageRecvd(void)
 {
-	msgsRecvd++;
-	CM_STATUS("collideMgr::voxelMessageRecvd: "<<msgsRecvd<<" of "<<msgsSent);
-	//All the voxels we send messages to have received them--
-	tryAdvance();
+  msgsRecvd++;
+  CM_STATUS("collideMgr::voxelMessageRecvd: "<<msgsRecvd<<" of "<<msgsSent);
+  //All the voxels we send messages to have received them--
+  tryAdvance();
 }
 
 //Check if we're barren-- if so, advance now
 void collideMgr::pleaseAdvance(void)
 {
-	CM_STATUS("collideMgr::pleaseAdvance");
-	tryAdvance();
+  CM_STATUS("collideMgr::pleaseAdvance");
+  tryAdvance();
 }
 
 //Attempt to finish the voxel send/recv step
 void collideMgr::tryAdvance(void)
 {
-	CM_STATUS("tryAdvance: "<<nContrib-contribCount<<" contrib, "<<msgsSent-msgsRecvd<<" msg")
-	if ((contribCount==nContrib) && (msgsSent==msgsRecvd)) {
-		CM_STATUS("advancing");
-		advance();
-		steps++;
-		contribCount=0;
-		msgsSent=msgsRecvd=0;
-	}
+  CM_STATUS("tryAdvance: "<<nContrib-contribCount<<" contrib, "<<msgsSent-msgsRecvd<<" msg")
+    if ((contribCount==nContrib) && (msgsSent==msgsRecvd)) {
+      CM_STATUS("advancing");
+      advance();
+      steps++;
+      contribCount=0;
+      msgsSent=msgsRecvd=0;
+    }
 }
 
 //This is called on PE 0 once the voxel send/recv reduction is finished
 void collideMgr::reductionFinished(void)
 {
-	CM_STATUS("collideMgr::reductionFinished");
-	//Broadcast Collision start:
-	voxelProxy.startCollision(steps,gridMap,client);
+  CM_STATUS("collideMgr::reductionFinished");
+  //Broadcast Collision start:
+  voxelProxy.startCollision(steps,gridMap,client);
 }
 
 
 /********************** collideVoxel *********************/
 
 iSeg1d collideVoxel_extents[3]={
-	iSeg1d(100,-100),iSeg1d(100,-100),iSeg1d(100,-100)};
+  iSeg1d(100,-100),iSeg1d(100,-100),iSeg1d(100,-100)};
 
 
 //Print debugging state information
 void collideVoxel::status(const char *msg)
 {
-	int x=low23(thisIndex.x);
-	int y=low23(thisIndex.y);
-	int z=low23(thisIndex.z);
-	CkPrintf("Pe %d, voxel (%d,%d,%d)> %s\n",CkMyPe(),x,y,z,msg);
+  int x=low23(thisIndex.x);
+  int y=low23(thisIndex.y);
+  int z=low23(thisIndex.z);
+  CkPrintf("Pe %d, voxel (%d,%d,%d)> %s\n",CkMyPe(),x,y,z,msg);
 }
 void collideVoxel::emptyMessages()
 {
-	for (int i=0;i<msgs.length();i++) delete msgs[i];
-	msgs.length()=0;
+  for (int i=0;i<msgs.length();i++) delete msgs[i];
+  msgs.length()=0;
 }
 
-/* CollideVoxel is created using [createhere], so 
+/* CollideVoxel is created using [createhere], so
    its constructor can't take any arguments: */
 collideVoxel::collideVoxel(void)
 {
-	CC_STATUS("created");
-	collideVoxel_extents[0].add(low23(thisIndex.x));
-	collideVoxel_extents[1].add(low23(thisIndex.y));
-	collideVoxel_extents[2].add(low23(thisIndex.z));
+  CC_STATUS("created");
+  collideVoxel_extents[0].add(low23(thisIndex.x));
+  collideVoxel_extents[1].add(low23(thisIndex.y));
+  collideVoxel_extents[2].add(low23(thisIndex.z));
 }
 collideVoxel::collideVoxel(CkMigrateMessage *m)
 {
-	CC_STATUS("arrived from migration");
+  CC_STATUS("arrived from migration");
 }
 collideVoxel::~collideVoxel()
 {
-	emptyMessages();
-	CC_STATUS("deleted. (migration depart)");
+  emptyMessages();
+  CC_STATUS("deleted. (migration depart)");
 }
 void collideVoxel::pup(PUP::er &p) {
-	if (msgs.length()!=0) {
-		status("Error!  Cannot migrate voxels with messages in tow!\n");
-		CkAbort("collideVoxel::pup cannot handle message case");
-	}
+  if (msgs.length()!=0) {
+    status("Error!  Cannot migrate voxels with messages in tow!\n");
+    CkAbort("collideVoxel::pup cannot handle message case");
+  }
 }
 void collideVoxel::add(objListMsg *msg)
 {
-	CC_STATUS("add message from "<<msg->getSource());
-	msg->sendReceipt();
-	msgs.push_back(msg);
+  CC_STATUS("add message from "<<msg->getSource());
+  msg->sendReceipt();
+  msgs.push_back(msg);
 }
 
 void collideVoxel::collide(const bbox3d &territory,CollisionList &dest)
 {
-	int m;
-	
+  int m;
+
 #if 0  //Check if all the priorities are identical-- early exit if so
-	CC_STATUS("      early-exit (all prio. identical) test");
-	int firstPrio=msgs[0]->tri(0).id.prio;
-	bool allIdentical=true;
-	for (m=0;allIdentical && m<msgs.length();m++)
-		for (int i=0;i<msgs[m]->getNtris();i++)
-			if (msgs[m]->tri(i).id.prio!=firstPrio)
-			{ allIdentical=false; break;}
-	if (allIdentical) {CC_STATUS("      early-exit used!");return;}
+  CC_STATUS("      early-exit (all prio. identical) test");
+  int firstPrio=msgs[0]->tri(0).id.prio;
+  bool allIdentical=true;
+  for (m=0;allIdentical && m<msgs.length();m++)
+    for (int i=0;i<msgs[m]->getNtris();i++)
+      if (msgs[m]->tri(i).id.prio!=firstPrio)
+      { allIdentical=false; break;}
+  if (allIdentical) {CC_STATUS("      early-exit used!");return;}
 #endif
-	//Figure out how many objects we have total
-	int n=0;
-	for (m=0;m<msgs.length();m++) n+=msgs[m]->getObjects();
-	CollideOctant o(n,territory);
-	o.length()=0;
-	bbox3d big;big.infinity();
-	o.setBbox(big);
-	
-	CC_STATUS("      creating bbox, etc. for polys");
+  //Figure out how many objects we have total
+  int n=0;
+  for (m=0;m<msgs.length();m++) n+=msgs[m]->getObjects();
+  CollideOctant o(n,territory);
+  o.length()=0;
+  bbox3d big;big.infinity();
+  o.setBbox(big);
+
+  CC_STATUS("      creating bbox, etc. for polys");
 #if COLLIDE_TRACE
-	bbox3d oBox; oBox.empty();
+  bbox3d oBox; oBox.empty();
 #endif
-	//Create records for each referenced poly
-	for (m=0;m<msgs.length();m++) {
-		const objListMsg &msg=*(msgs[m]);
-		for (int i=0;i<msg.getObjects();i++) {
-			o.push_fast(&msg.getObj(i));
+  //Create records for each referenced poly
+  for (m=0;m<msgs.length();m++) {
+    const objListMsg &msg=*(msgs[m]);
+    for (int i=0;i<msg.getObjects();i++) {
+      o.push_fast(&msg.getObj(i));
 #if COLLIDE_TRACE
-			oBox.add(msg.getObj(i).getBbox());
+      oBox.add(msg.getObj(i).getBbox());
 #endif
-		}
-	}
-	o.markHome(o.length());
-	COL_STATUS("    colliding polys");
-	COL_STATUS("\t\t\tXXX "<<o.length()<<" polys, "<<msgs.length()<<" msgs")
+    }
+  }
+  o.markHome(o.length());
+  COL_STATUS("    colliding polys");
+  COL_STATUS("\t\t\tXXX "<<o.length()<<" polys, "<<msgs.length()<<" msgs")
 #if COLLIDE_TRACE
-	territory.print("Voxel territory: ");
-	oBox.print(" Voxel objects: ");
-	CkPrintf("\n");
+    territory.print("Voxel territory: ");
+  oBox.print(" Voxel objects: ");
+  CkPrintf("\n");
 #endif
-	o.findCollisions(dest);
+  o.findCollisions(dest);
 }
 
 
 void collideVoxel::startCollision(int step,
-		const CollideGrid3d &gridMap,
-		const CProxy_collideClient &client)
+    const CollideGrid3d &gridMap,
+    const CProxy_collideClient &client)
 {
-	CC_STATUS("startCollision "<<step<<" on "<<msgs.length()<<" messages {");
-	
-	bbox3d territory(gridMap.grid2world(0,rSeg1d(thisIndex.x,thisIndex.x+1)),
-		gridMap.grid2world(1,rSeg1d(thisIndex.y,thisIndex.y+1)),
-		gridMap.grid2world(2,rSeg1d(thisIndex.z,thisIndex.z+1))
-	);
-	CollisionList colls;
-	collide(territory,colls);
-	client.ckLocalBranch()->collisions(this,step,colls);
-	
-	emptyMessages();
-	CC_STATUS("} startCollision");
+  CC_STATUS("startCollision "<<step<<" on "<<msgs.length()<<" messages {");
+
+  bbox3d territory(gridMap.grid2world(0,rSeg1d(thisIndex.x,thisIndex.x+1)),
+      gridMap.grid2world(1,rSeg1d(thisIndex.y,thisIndex.y+1)),
+      gridMap.grid2world(2,rSeg1d(thisIndex.z,thisIndex.z+1))
+      );
+  CollisionList colls;
+  collide(territory,colls);
+  client.ckLocalBranch()->collisions(this,step,colls);
+
+  emptyMessages();
+  CC_STATUS("} startCollision");
 }
 
 collideClient::~collideClient() {}
 
 /********************** serialCollideClient *****************/
 serialCollideClient::serialCollideClient(void) {
-	clientFn=NULL;
-	clientParam=NULL;
+  clientFn=NULL;
+  clientParam=NULL;
 }
 
 /// Call this client function on processor 0:
 void serialCollideClient::setClient(CollisionClientFn clientFn_,void *clientParam_) {
-	clientFn=clientFn_; 
-	clientParam=clientParam_;
+  clientFn=clientFn_;
+  clientParam=clientParam_;
 }
 
 void serialCollideClient::collisions(ArrayElement *src,
-	int step,CollisionList &colls) 
+    int step,CollisionList &colls)
 {
-	CkCallback cb(CkIndex_serialCollideClient::reductionDone(0),0,thisgroup);
-	src->contribute(colls.length()*sizeof(Collision),colls.getData(),
-		CkReduction::concat,cb);
+  CkCallback cb(CkIndex_serialCollideClient::reductionDone(0),0,thisgroup);
+  src->contribute(colls.length()*sizeof(Collision),colls.getData(),
+      CkReduction::concat,cb);
 }
 
 //This is called after the collideVoxel Collision reduction completes
 void serialCollideClient::reductionDone(CkReductionMsg *msg)
 {
-	int nColl=msg->getSize()/sizeof(Collision);
-	CM_STATUS("serialCollideClient with "<<nColl<<" collisions");
-	if (clientFn!=NULL) //User wants Collisions on node 0
-	  (clientFn)(clientParam,nColl,(Collision *)msg->getData());
-	else //FIXME: never registered a client
-	  CkAbort("Forgot to call serialCollideClient::setClient!\n");
-	delete msg;
+  int nColl=msg->getSize()/sizeof(Collision);
+  CM_STATUS("serialCollideClient with "<<nColl<<" collisions");
+  if (clientFn!=NULL) //User wants Collisions on node 0
+    (clientFn)(clientParam,nColl,(Collision *)msg->getData());
+  else //FIXME: never registered a client
+    CkAbort("Forgot to call serialCollideClient::setClient!\n");
+  delete msg;
 }
 
 

--- a/src/libs/ck-libs/collide/collidecharm.ci
+++ b/src/libs/ck-libs/collide/collidecharm.ci
@@ -1,13 +1,13 @@
 module collidecharm {
   message objListMsg;
-  
+
   group collideClient {
-  };  
+  };
   group serialCollideClient : collideClient {
     entry serialCollideClient();
     entry void reductionDone(CkReductionMsg *m);
   };
-  
+
   group syncReductionMgr {
     entry syncReductionMgr();
     entry void childProd(int stepCount);
@@ -15,17 +15,17 @@ module collidecharm {
   };
   group collideMgr : syncReductionMgr {
     entry collideMgr(CollideGrid3d gridMap,
-    	CProxy_collideClient client,
-	CkArrayID cells);
+        CProxy_collideClient client,
+        CkArrayID cells);
     entry void voxelMessageRecvd(void);
   };
 
   array [3D] collideVoxel {
     entry collideVoxel(void);
     entry [createhere] void add(objListMsg *);
-//    entry [createhome] void add(objListMsg *);
+    //    entry [createhome] void add(objListMsg *);
     entry void startCollision(int step,
-		CollideGrid3d gridMap,
-		CProxy_collideClient client);
+        CollideGrid3d gridMap,
+        CProxy_collideClient client);
   };
 };

--- a/src/libs/ck-libs/collide/collidecharm.h
+++ b/src/libs/ck-libs/collide/collidecharm.h
@@ -10,26 +10,26 @@
 #include "collidecharm.decl.h"
 
 /********************** collideClient *****************
-A place for the assembled Collision lists to go.
-Each voxel calls this "Collisions" method with their 
-lists of Collisions.  Because there can be many voxels per 
-processor, the canonical implementation does some kind 
-of reduction over the voxels array--this way you know
-when all voxels have reported their Collisions.
+  A place for the assembled Collision lists to go.
+  Each voxel calls this "Collisions" method with their
+  lists of Collisions.  Because there can be many voxels per
+  processor, the canonical implementation does some kind
+  of reduction over the voxels array--this way you know
+  when all voxels have reported their Collisions.
 
-If you just want the Collisions collected onto one processor, 
-use the serialCollisionClient interface below.
-*/
+  If you just want the Collisions collected onto one processor,
+  use the serialCollisionClient interface below.
+  */
 class collideClient : public Group {
-public:
-	virtual ~collideClient();
-	virtual void collisions(ArrayElement *src,
-		int step,CollisionList &colls) =0;
+  public:
+    virtual ~collideClient();
+    virtual void collisions(ArrayElement *src,
+        int step,CollisionList &colls) =0;
 };
 
 /********************** serialCollideClient *****************
-Reduces the Collision list down to processor 0.
-*/
+  Reduces the Collision list down to processor 0.
+  */
 /// This client function is called on PE 0 with a Collision list
 typedef void (*CollisionClientFn)(void *param,int nColl,Collision *colls);
 
@@ -41,10 +41,10 @@ CkGroupID CollideSerialClient(CollisionClientFn clientFn,void *clientParam);
 /****************** Collision Interface ******************/
 typedef CkGroupID CollideHandle;
 
-/// Create a collider group to contribute objects to.  
+/// Create a collider group to contribute objects to.
 ///  Should be called on processor 0.
 CollideHandle CollideCreate(const CollideGrid3d &gridMap,
-	CkGroupID clientGroupID);
+    CkGroupID clientGroupID);
 
 /// Register with this collider group. (Call on creation/arrival)
 void CollideRegister(CollideHandle h,int chunkNo);
@@ -55,6 +55,6 @@ void CollideUnregister(CollideHandle h,int chunkNo);
 /// The results go the collisionClient group
 /// registered at creation time.
 void CollideBoxesPrio(CollideHandle h,int chunkNo,
-	int nBox,const bbox3d *boxes,const int *prio=NULL);
+    int nBox,const bbox3d *boxes,const int *prio=NULL);
 
 #endif

--- a/src/libs/ck-libs/collide/collidecharm_impl.h
+++ b/src/libs/ck-libs/collide/collidecharm_impl.h
@@ -11,48 +11,48 @@
 #include "collidecharm.h"
 
 /******************** objListMsg *********************
-A pile of objects sent to a Collision voxel.
-Declared as a "packed" message
-type, which converts the message to a flat byte array
-only when needed (for sending across processors).
-*/
+  A pile of objects sent to a Collision voxel.
+  Declared as a "packed" message
+  type, which converts the message to a flat byte array
+  only when needed (for sending across processors).
+  */
 class objListMsg : public CMessage_objListMsg
 {
-public:
-	class returnReceipt {
-		CkGroupID gid;
-	public:
-		int onPE;
-		returnReceipt() {}
-		returnReceipt(CkGroupID gid_,int onPE_) :gid(gid_),onPE(onPE_) {}
-		void send(void);
-	};
-private:
-	bool isHeapAllocated;
-	returnReceipt receipt;
-	
-	int n;
-	CollideObjRec *obj; //Bounding boxes & IDs
-	
-	void freeHeapAllocated();
-public:
-	objListMsg() :isHeapAllocated(false) {}
-	
-	//Hand control of these arrays over to this message,
-	// which will delete them when appropriate.
-	objListMsg(int n_,CollideObjRec *obj_,
-		const returnReceipt &receipt_);
-	~objListMsg() {freeHeapAllocated();}
-	
-	int getSource(void) {return receipt.onPE;}
-	void sendReceipt(void) {receipt.send();}
-	
-	int getObjects(void) const {return n;}
-	const CollideObjRec &getObj(int i) const {return obj[i];}
-	const bbox3d &bbox(int i) const {return obj[i].box;}
-	
-	static void *pack(objListMsg *m);
-	static objListMsg *unpack(void *m);
+  public:
+    class returnReceipt {
+      CkGroupID gid;
+      public:
+      int onPE;
+      returnReceipt() {}
+      returnReceipt(CkGroupID gid_,int onPE_) :gid(gid_),onPE(onPE_) {}
+      void send(void);
+    };
+  private:
+    bool isHeapAllocated;
+    returnReceipt receipt;
+
+    int n;
+    CollideObjRec *obj; //Bounding boxes & IDs
+
+    void freeHeapAllocated();
+  public:
+    objListMsg() :isHeapAllocated(false) {}
+
+    //Hand control of these arrays over to this message,
+    // which will delete them when appropriate.
+    objListMsg(int n_,CollideObjRec *obj_,
+        const returnReceipt &receipt_);
+    ~objListMsg() {freeHeapAllocated();}
+
+    int getSource(void) {return receipt.onPE;}
+    void sendReceipt(void) {receipt.send();}
+
+    int getObjects(void) const {return n;}
+    const CollideObjRec &getObj(int i) const {return obj[i];}
+    const bbox3d &bbox(int i) const {return obj[i].box;}
+
+    static void *pack(objListMsg *m);
+    static objListMsg *unpack(void *m);
 };
 
 
@@ -66,179 +66,179 @@ class voxelAggregator;
  * headed out to each voxel.  It is implemented as a group.
  */
 class CollisionAggregator {
-	CollideGrid3d gridMap;
-	CkHashtableT<CollideLoc3d,voxelAggregator *> voxels;
-	collideMgr *mgr;
-	
-	//Add a new accumulator to the hashtable
-	voxelAggregator *addAccum(const CollideLoc3d &dest);
-public:
-	CollisionAggregator(const CollideGrid3d &gridMap_,collideMgr *mgr_);
-	~CollisionAggregator();
-	
-	//Add this chunk's triangles
-	void aggregate(int pe,int chunk,
-		int n,const bbox3d *boxes,const int *prio);
-	
-	//Send off all accumulated voxel messages
-	void send(void);
-	
-	//Delete all cached aggregators
-	void compact(void);
+  CollideGrid3d gridMap;
+  CkHashtableT<CollideLoc3d,voxelAggregator *> voxels;
+  collideMgr *mgr;
+
+  //Add a new accumulator to the hashtable
+  voxelAggregator *addAccum(const CollideLoc3d &dest);
+  public:
+  CollisionAggregator(const CollideGrid3d &gridMap_,collideMgr *mgr_);
+  ~CollisionAggregator();
+
+  //Add this chunk's triangles
+  void aggregate(int pe,int chunk,
+      int n,const bbox3d *boxes,const int *prio);
+
+  //Send off all accumulated voxel messages
+  void send(void);
+
+  //Delete all cached aggregators
+  void compact(void);
 };
 
 /********************* syncReductionMgr *****************
-A group to synchronize on some event across the machine.
-Maintains a reduction tree and waits for the "advance"
-method to be called from each processor.  To handle 
-non-autonomous cases, calls "pleaseAdvance" when an advance
-is first expected from that PE.
-*/
+  A group to synchronize on some event across the machine.
+  Maintains a reduction tree and waits for the "advance"
+  method to be called from each processor.  To handle
+  non-autonomous cases, calls "pleaseAdvance" when an advance
+  is first expected from that PE.
+  */
 class syncReductionMgr : public CBase_syncReductionMgr
 {
-	CProxy_syncReductionMgr thisproxy;
-	void status(const char *msg) {
-		CkPrintf("SRMgr pe %d> %s\n",CkMyPe(),msg);
-	}
-	//Describes the reduction tree
-	int onPE;
-	enum {TREE_WID=4};
-	int treeParent;//Parent in reduction tree
-	int treeChildStart,treeChildEnd;//First and last+1 child
-	int nChildren;//Number of children in the reduction tree
-	void startStep(int stepNo,bool withProd);
-	
-	//State data
-	int stepCount;//Increments by one every reduction, from zero
-	bool stepFinished;//prior step complete
-	bool localFinished;//Local advance called
-	int childrenCount;//Number of tree children in delivered state
-	void tryFinish(void);//Try to finish reduction
+  CProxy_syncReductionMgr thisproxy;
+  void status(const char *msg) {
+    CkPrintf("SRMgr pe %d> %s\n",CkMyPe(),msg);
+  }
+  //Describes the reduction tree
+  int onPE;
+  enum {TREE_WID=4};
+  int treeParent;//Parent in reduction tree
+  int treeChildStart,treeChildEnd;//First and last+1 child
+  int nChildren;//Number of children in the reduction tree
+  void startStep(int stepNo,bool withProd);
 
-protected:
-	//This is called by subclasses
-	void advance(void);
-	//This is offered for subclasses's optional use
-	virtual void pleaseAdvance(void);
-	//This is called on PE 0 once the reduction is finished
-	virtual void reductionFinished(void);
-public:
-	int getStepCount(void) const {return stepCount;}
-	syncReductionMgr();
-	
-	//Called by parent-- will you contribute?
-	void childProd(int stepCount);
-	//Called by tree children-- me and my children are finished
-	void childDone(int stepCount);
+  //State data
+  int stepCount;//Increments by one every reduction, from zero
+  bool stepFinished;//prior step complete
+  bool localFinished;//Local advance called
+  int childrenCount;//Number of tree children in delivered state
+  void tryFinish(void);//Try to finish reduction
+
+  protected:
+  //This is called by subclasses
+  void advance(void);
+  //This is offered for subclasses's optional use
+  virtual void pleaseAdvance(void);
+  //This is called on PE 0 once the reduction is finished
+  virtual void reductionFinished(void);
+  public:
+  int getStepCount(void) const {return stepCount;}
+  syncReductionMgr();
+
+  //Called by parent-- will you contribute?
+  void childProd(int stepCount);
+  //Called by tree children-- me and my children are finished
+  void childDone(int stepCount);
 };
 
 /*********************** collideMgr **********************
-A group that synchronizes the Collision detection process.
-A single Collision operation consists of:
-	-collect contributions from clients (contribute)
-	-aggregate the contributions
-	-send off triangle lists to voxels
-	-wait for replies from the voxels indicating sucessful delivery
-	-collideMgr reduction to make sure everybody's messages are delivered
-	-root broadcasts startCollision to collideVoxel array
-	-client group accepts the CollisionLists
-*/
+  A group that synchronizes the Collision detection process.
+  A single Collision operation consists of:
+  -collect contributions from clients (contribute)
+  -aggregate the contributions
+  -send off triangle lists to voxels
+  -wait for replies from the voxels indicating sucessful delivery
+  -collideMgr reduction to make sure everybody's messages are delivered
+  -root broadcasts startCollision to collideVoxel array
+  -client group accepts the CollisionLists
+  */
 
 class collideMgr : public CBase_collideMgr
 {
-	CProxy_collideMgr thisproxy;
-private:
-	void status(const char *msg) {
-		CkPrintf("CMgr pe %d> %s\n",CkMyPe(),msg);
-	}
-	int steps; //Number of separate Collision operations
-	CProxy_collideVoxel voxelProxy;
-	CollideGrid3d gridMap; //Shape of 3D voxel grid
-	CProxy_collideClient client; //Collision client group
-	
-	int nContrib;//Number of registered contributors
-	int contribCount;//Number of contribute calls given this step
-	
-	CollisionAggregator aggregator;
-	int msgsSent;//Messages sent out to voxels
-	int msgsRecvd;//Return-receipt messages received from voxels
-	void tryAdvance(void);
-protected:
-	//Check if we're barren-- if so, advance now
-	virtual void pleaseAdvance(void);
-	//This is called on PE 0 once the voxel send reduction is finished
-	virtual void reductionFinished(void);
-public:
-	collideMgr(const CollideGrid3d &gridMap,
-		const CProxy_collideClient &client,
-		const CProxy_collideVoxel &voxels);
-	
-	//Maintain contributor registration count
-	void registerContributor(int chunkNo);
-	void unregisterContributor(int chunkNo);
-	
-	//Clients call this to contribute their objects
-	void contribute(int chunkNo,
-		int n,const bbox3d *boxes,const int *prio);
-	
-	//voxelAggregators deliver messages to voxels via this bottleneck
-	void sendVoxelMessage(const CollideLoc3d &dest,
-		int n,CollideObjRec *obj);
-	
-	//collideVoxels send a return receipt here
-	void voxelMessageRecvd(void);
+  CProxy_collideMgr thisproxy;
+  private:
+  void status(const char *msg) {
+    CkPrintf("CMgr pe %d> %s\n",CkMyPe(),msg);
+  }
+  int steps; //Number of separate Collision operations
+  CProxy_collideVoxel voxelProxy;
+  CollideGrid3d gridMap; //Shape of 3D voxel grid
+  CProxy_collideClient client; //Collision client group
+
+  int nContrib;//Number of registered contributors
+  int contribCount;//Number of contribute calls given this step
+
+  CollisionAggregator aggregator;
+  int msgsSent;//Messages sent out to voxels
+  int msgsRecvd;//Return-receipt messages received from voxels
+  void tryAdvance(void);
+  protected:
+  //Check if we're barren-- if so, advance now
+  virtual void pleaseAdvance(void);
+  //This is called on PE 0 once the voxel send reduction is finished
+  virtual void reductionFinished(void);
+  public:
+  collideMgr(const CollideGrid3d &gridMap,
+      const CProxy_collideClient &client,
+      const CProxy_collideVoxel &voxels);
+
+  //Maintain contributor registration count
+  void registerContributor(int chunkNo);
+  void unregisterContributor(int chunkNo);
+
+  //Clients call this to contribute their objects
+  void contribute(int chunkNo,
+      int n,const bbox3d *boxes,const int *prio);
+
+  //voxelAggregators deliver messages to voxels via this bottleneck
+  void sendVoxelMessage(const CollideLoc3d &dest,
+      int n,CollideObjRec *obj);
+
+  //collideVoxels send a return receipt here
+  void voxelMessageRecvd(void);
 };
 
 /********************** collideVoxel ********************
-A sparse 3D array that represents a region of space where
-Collisions may occur.  Each step it accumulates triangle
-lists and then computes their intersection
-*/
+  A sparse 3D array that represents a region of space where
+  Collisions may occur.  Each step it accumulates triangle
+  lists and then computes their intersection
+  */
 
 class collideVoxel : public CBase_collideVoxel
 {
-	growableBufferT<objListMsg *> msgs;
-	void status(const char *msg);
-	void emptyMessages();
-	void collide(const bbox3d &territory,CollisionList &dest);
-public:
-	collideVoxel(void);
-	collideVoxel(CkMigrateMessage *m);
-	~collideVoxel();
-	void pup(PUP::er &p);
-	
-	void add(objListMsg *msg);
-	void startCollision(int step,
-		const CollideGrid3d &gridMap,
-		const CProxy_collideClient &client);
+  growableBufferT<objListMsg *> msgs;
+  void status(const char *msg);
+  void emptyMessages();
+  void collide(const bbox3d &territory,CollisionList &dest);
+  public:
+  collideVoxel(void);
+  collideVoxel(CkMigrateMessage *m);
+  ~collideVoxel();
+  void pup(PUP::er &p);
+
+  void add(objListMsg *msg);
+  void startCollision(int step,
+      const CollideGrid3d &gridMap,
+      const CProxy_collideClient &client);
 };
 
 
 /********************** serialCollideClient *****************
-Reduces the Collision list down to processor 0.
-*/
+  Reduces the Collision list down to processor 0.
+  */
 class serialCollideClient : public collideClient {
-	CollisionClientFn clientFn;
-	void *clientParam;
-public:
-	serialCollideClient(void);
-	
-	/// Call this client function on processor 0:
-	void setClient(CollisionClientFn clientFn,void *clientParam);
-	
-	/// Called by voxel array on each processor:
-	virtual void collisions(ArrayElement *src,
-		int step,CollisionList &colls);
-	
-	/// Called after the reduction is complete:
-	virtual void reductionDone(CkReductionMsg *m);
+  CollisionClientFn clientFn;
+  void *clientParam;
+  public:
+  serialCollideClient(void);
+
+  /// Call this client function on processor 0:
+  void setClient(CollisionClientFn clientFn,void *clientParam);
+
+  /// Called by voxel array on each processor:
+  virtual void collisions(ArrayElement *src,
+      int step,CollisionList &colls);
+
+  /// Called after the reduction is complete:
+  virtual void reductionDone(CkReductionMsg *m);
 };
 
 #if CMK_TRACE_ENABLED
 // List of COLLIDE functions to trace:
 static const char *funclist[] = {"COLLIDE_Init", "COLLIDE_Boxes",
- "COLLIDE_Boxes_prio", "COLLIDE_Count", "COLLIDE_List",
- "COLLIDE_Destroy"};
+  "COLLIDE_Boxes_prio", "COLLIDE_Count", "COLLIDE_List",
+  "COLLIDE_Destroy"};
 
 #endif // CMK_TRACE_ENABLED
 

--- a/src/libs/ck-libs/collide/threadCollide.C
+++ b/src/libs/ck-libs/collide/threadCollide.C
@@ -10,7 +10,7 @@
 
 #define COLLIDE_TRACE 0
 #if COLLIDE_TRACE
-  define TRACE(x) ckout<<"["<<CkMyPe()<<"] "<<x<<endl;
+define TRACE(x) ckout<<"["<<CkMyPe()<<"] "<<x<<endl;
 #else
 #  define TRACE(x) /* empty */
 #endif
@@ -21,246 +21,246 @@
 class threadCollide;
 
 /**
-Collision message: just a list of collisions.
-*/
+  Collision message: just a list of collisions.
+  */
 class threadCollisions : public CMessage_threadCollisions {
-public:
-	int src; /* processor number of source group */
-	int nColls; /* number of collision records below */
-	Collision *colls; /* points into message body */
+  public:
+    int src; /* processor number of source group */
+    int nColls; /* number of collision records below */
+    Collision *colls; /* points into message body */
 };
 
 /**
-Threaded collision group--collects collisions as they come
-from voxels, and sends the collisions to the source chunks.
-*/
+  Threaded collision group--collects collisions as they come
+  from voxels, and sends the collisions to the source chunks.
+  */
 class threadCollideMgr : public CBase_threadCollideMgr
 {
-	//Map chunk number to contributor (big, but fast indexing scheme)
-	CkVec<threadCollide *> contrib;
-	inline threadCollide *lookup(int chunkNo) {
-		threadCollide *ret=contrib[chunkNo];
+  //Map chunk number to contributor (big, but fast indexing scheme)
+  CkVec<threadCollide *> contrib;
+  inline threadCollide *lookup(int chunkNo) {
+    threadCollide *ret=contrib[chunkNo];
 #if CMK_ERROR_CHECKING
-		if (ret==NULL) CkAbort("threadCollideMgr can't find contributor");
+    if (ret==NULL) CkAbort("threadCollideMgr can't find contributor");
 #endif
-		return ret;
-	}
-	
-	//Temporarily store collisions to be sent to each processor:
-	CkVec<CollisionList> toPE;
-	
-	//Temporarily store collisions sent in from each processor:
-	CkVec<threadCollisions *> fromPE;
-	
-	//Counter for collisions from remote processors:
-	int nRemote;
-	
-	//Cached version of CkMyPe
-	int myPe;
-	
-public:
-	threadCollideMgr(void) 
-		:toPE(CkNumPes()), fromPE(CkNumPes())
-	{
-		for (int p=0;p<CkNumPes();p++) fromPE[p]=0;
-		nRemote=0;
-		myPe=CkMyPe();
-	}
-	
-	/// Maintain contributor lists:
-	void registerContributor(threadCollide *chunk,int chunkNo) 
-	{
-		while (contrib.size()<=chunkNo) contrib.push_back(0);
-		contrib[chunkNo]=chunk;
-	}
-	void unregisterContributor(int chunkNo) {
-		contrib[chunkNo]=NULL;
-	}
-	
-	/// collideClient interface (called by voxels)
-	/// Splits up collisions by destination PE
-	void collisions(ArrayElement *src,int step,CollisionList &colls);
-	
-	/// All voxels have now reported their collisions:
-	///  Send off the accumulated collisions to each destination PE
-	void sendRemote(CkReductionMsg *m);
-	
-	/// Accept and buffer these remote collisions
-	void remoteCollisions(threadCollisions *m);
-	
-	/// Add these remote collisions to each local chunk
-	void sift(int nColl,const Collision *colls);
+    return ret;
+  }
+
+  //Temporarily store collisions to be sent to each processor:
+  CkVec<CollisionList> toPE;
+
+  //Temporarily store collisions sent in from each processor:
+  CkVec<threadCollisions *> fromPE;
+
+  //Counter for collisions from remote processors:
+  int nRemote;
+
+  //Cached version of CkMyPe
+  int myPe;
+
+  public:
+  threadCollideMgr(void)
+    :toPE(CkNumPes()), fromPE(CkNumPes())
+  {
+    for (int p=0;p<CkNumPes();p++) fromPE[p]=0;
+    nRemote=0;
+    myPe=CkMyPe();
+  }
+
+  /// Maintain contributor lists:
+  void registerContributor(threadCollide *chunk,int chunkNo)
+  {
+    while (contrib.size()<=chunkNo) contrib.push_back(0);
+    contrib[chunkNo]=chunk;
+  }
+  void unregisterContributor(int chunkNo) {
+    contrib[chunkNo]=NULL;
+  }
+
+  /// collideClient interface (called by voxels)
+  /// Splits up collisions by destination PE
+  void collisions(ArrayElement *src,int step,CollisionList &colls);
+
+  /// All voxels have now reported their collisions:
+  ///  Send off the accumulated collisions to each destination PE
+  void sendRemote(CkReductionMsg *m);
+
+  /// Accept and buffer these remote collisions
+  void remoteCollisions(threadCollisions *m);
+
+  /// Add these remote collisions to each local chunk
+  void sift(int nColl,const Collision *colls);
 };
 
 /**
-Threaded collision client array--provides interface between
-threadCollideMgr and API routines.
-*/
+  Threaded collision client array--provides interface between
+  threadCollideMgr and API routines.
+  */
 class threadCollide : public TCharmClient1D {
-	typedef TCharmClient1D super;
-	// Outgoing collision requests:
-	CollideHandle collide;
-	// Incoming collision lists:
-	CProxy_threadCollideMgr mgr;
-protected:
-	virtual void setupThreadPrivate(CthThread th) {}
-public:
-	growableBufferT<Collision> colls; //Accumulated Collisions
-	
-	threadCollide(const CProxy_TCharm &threads,
-		const CProxy_threadCollideMgr &mgr_,
-    		const CollideHandle &collide_) 
-		:super(threads), collide(collide_), mgr(mgr_)
-	{
-		arriving();
-		/// Wake up the blocked thread in COLLIDE_Init
-		thread->semaPut(COLLIDE_TCHARM_SEMAID,this);
-	}
-	threadCollide(CkMigrateMessage *m) :super(m) {}
-	
-	void arriving(void) {
-		CollideRegister(collide,thisIndex);
-		mgr.ckLocalBranch()->registerContributor(this,thisIndex);
-	}
-	void pup(PUP::er &p) {
-		super::pup(p);
-		p|mgr;
-		p|collide;
-	}
-	void ckJustMigrated(void) {
-		super::ckJustMigrated();
-		arriving();
-	}
-	void leaving(void) {
-		CollideUnregister(collide,thisIndex);
-		mgr.ckLocalBranch()->unregisterContributor(thisIndex);
-	}
-	~threadCollide() {
-		leaving();
-	}
-	inline const CkArrayID &getArrayID(void) const {return thisArrayID;}
-	
-	
-	/// Contribute to Collision and suspend the caller
-	void contribute(int n,const bbox3d *boxes,const int *prio) 
-	{
-		CollideBoxesPrio(collide,thisIndex,n,boxes,prio);
-		TCharm * unused = thread->suspend(); //Will be resumed by call to resultsDone()
-	}
-	
-	/// No more collisions will arrive this step.
-	void resultsDone(void) {
-		thread->resume();
-	}
+  typedef TCharmClient1D super;
+  // Outgoing collision requests:
+  CollideHandle collide;
+  // Incoming collision lists:
+  CProxy_threadCollideMgr mgr;
+  protected:
+  virtual void setupThreadPrivate(CthThread th) {}
+  public:
+  growableBufferT<Collision> colls; //Accumulated Collisions
+
+  threadCollide(const CProxy_TCharm &threads,
+      const CProxy_threadCollideMgr &mgr_,
+      const CollideHandle &collide_)
+    :super(threads), collide(collide_), mgr(mgr_)
+  {
+    arriving();
+    /// Wake up the blocked thread in COLLIDE_Init
+    thread->semaPut(COLLIDE_TCHARM_SEMAID,this);
+  }
+  threadCollide(CkMigrateMessage *m) :super(m) {}
+
+  void arriving(void) {
+    CollideRegister(collide,thisIndex);
+    mgr.ckLocalBranch()->registerContributor(this,thisIndex);
+  }
+  void pup(PUP::er &p) {
+    super::pup(p);
+    p|mgr;
+    p|collide;
+  }
+  void ckJustMigrated(void) {
+    super::ckJustMigrated();
+    arriving();
+  }
+  void leaving(void) {
+    CollideUnregister(collide,thisIndex);
+    mgr.ckLocalBranch()->unregisterContributor(thisIndex);
+  }
+  ~threadCollide() {
+    leaving();
+  }
+  inline const CkArrayID &getArrayID(void) const {return thisArrayID;}
+
+
+  /// Contribute to Collision and suspend the caller
+  void contribute(int n,const bbox3d *boxes,const int *prio)
+  {
+    CollideBoxesPrio(collide,thisIndex,n,boxes,prio);
+    TCharm * unused = thread->suspend(); //Will be resumed by call to resultsDone()
+  }
+
+  /// No more collisions will arrive this step.
+  void resultsDone(void) {
+    thread->resume();
+  }
 };
 
 
 /// collideClient interface (called by voxels)
 /// Splits up collisions by destination PE
 void threadCollideMgr::collisions(ArrayElement *src,int step,
-				  CollisionList &colls) {
+    CollisionList &colls) {
   // Do a fake reduction, so we'll know when all voxels have reported:
   src->contribute(0,0,CkReduction::sum_int,
-		  CkCallback(CkIndex_threadCollideMgr::sendRemote(0),thisProxy));
-  
+      CkCallback(CkIndex_threadCollideMgr::sendRemote(0),thisProxy));
+
   // Split out this voxel's contribution
   int i=0, n=colls.size();
   static int count=0;
-  
+
   TRACE("Voxel contributes "<<n<<" collisions")
-    
+
     //printf("COLLIDE: Total collisions contributed so far: %d\n", count+=n);
     for (i=0;i<n;i++) {
       const Collision &c=colls[i];
       toPE[c.A.pe].push_back(c);
       if (c.B.pe!=c.A.pe) { //Report collision to both processors
-	Collision cB(c.B,c.A); //Swap so B is listed first
-	toPE[c.B.pe].push_back(cB);
+        Collision cB(c.B,c.A); //Swap so B is listed first
+        toPE[c.B.pe].push_back(cB);
       }
     }
 }
 
 /// Destroy this collision list, and create a message
 /// from it.
-threadCollisions *listToMessage(CollisionList &l) 
+threadCollisions *listToMessage(CollisionList &l)
 {
-	int n=l.size();
-	Collision *c=l.detachBuffer();
-	threadCollisions *m=new (n,0) threadCollisions;
-	m->nColls=n;
-	for (int i=0;i<n;i++) m->colls[i]=c[i];
-	free(c);
-	return m;
+  int n=l.size();
+  Collision *c=l.detachBuffer();
+  threadCollisions *m=new (n,0) threadCollisions;
+  m->nColls=n;
+  for (int i=0;i<n;i++) m->colls[i]=c[i];
+  free(c);
+  return m;
 }
 
 /// All voxels have now reported their collisions:
 ///  Send off the accumulated collisions to each destination PE
 void threadCollideMgr::sendRemote(CkReductionMsg *m) {
-	// FIXME: optimize this all-to-all
-	int p,n=CkNumPes();
-	for (p=0;p<n;p++) { // Loop over destination processors:
-		TRACE("Sending "<<toPE[p].size()<<" collisions to "<<p)
-		threadCollisions *m=listToMessage(toPE[p]);
-		m->src=myPe;
-		if (p==myPe) /* local */
-			remoteCollisions(m);
-		else /* remote */
-			thisProxy[p].remoteCollisions(m);
-	}
+  // FIXME: optimize this all-to-all
+  int p,n=CkNumPes();
+  for (p=0;p<n;p++) { // Loop over destination processors:
+    TRACE("Sending "<<toPE[p].size()<<" collisions to "<<p)
+      threadCollisions *m=listToMessage(toPE[p]);
+    m->src=myPe;
+    if (p==myPe) /* local */
+      remoteCollisions(m);
+    else /* remote */
+      thisProxy[p].remoteCollisions(m);
+  }
 }
 
 /// Accept these remote collisions
 void threadCollideMgr::remoteCollisions(threadCollisions *m) {
-	/*
-	Subtle: to guarantee that matching collisions are presented 
-	in the same order everywhere, we order each chunk's collisions
-	by reporting (source) processor.  We do this without a sort by
-	buffering, then "sifting" each collision in the proper order.
-	*/
-	
-	// Just buffer this message 
-	// (FIXME: if it's the one we're waiting for, sift it right away)
-	if (fromPE[m->src]!=NULL) 
-		CkAbort("threadCollideMgr::remoteCollisions unexpected message");
-	fromPE[m->src]=m;
-	
-	// See if we're done yet
-	if (++nRemote==CkNumPes()) 
-	{	
-		// Sift out our collisions to each array element
-		TRACE("Sifting collisions out to each array element")
-		int p,n=CkNumPes();
-		for (p=0;p<n;p++) {
-			sift(fromPE[p]->nColls,fromPE[p]->colls);
-			delete fromPE[p]; fromPE[p]=NULL;
-		}
-		
-		// Get ready for the next step
-		nRemote=0;
-		
-		// Tell all our array elements that the results are now in
-		for (int i=0;i<contrib.size();i++)
-			if (contrib[i])
-				contrib[i]->resultsDone();
-	}
+  /*
+Subtle: to guarantee that matching collisions are presented
+in the same order everywhere, we order each chunk's collisions
+by reporting (source) processor.  We do this without a sort by
+buffering, then "sifting" each collision in the proper order.
+*/
+
+  // Just buffer this message
+  // (FIXME: if it's the one we're waiting for, sift it right away)
+  if (fromPE[m->src]!=NULL)
+    CkAbort("threadCollideMgr::remoteCollisions unexpected message");
+  fromPE[m->src]=m;
+
+  // See if we're done yet
+  if (++nRemote==CkNumPes())
+  {
+    // Sift out our collisions to each array element
+    TRACE("Sifting collisions out to each array element")
+      int p,n=CkNumPes();
+    for (p=0;p<n;p++) {
+      sift(fromPE[p]->nColls,fromPE[p]->colls);
+      delete fromPE[p]; fromPE[p]=NULL;
+    }
+
+    // Get ready for the next step
+    nRemote=0;
+
+    // Tell all our array elements that the results are now in
+    for (int i=0;i<contrib.size();i++)
+      if (contrib[i])
+        contrib[i]->resultsDone();
+  }
 }
 
 /// Add these remote collisions to each local chunk
-void threadCollideMgr::sift(int nColl,const Collision *colls) 
+void threadCollideMgr::sift(int nColl,const Collision *colls)
 {
-	for (int i=0;i<nColl;i++) {
-		const Collision &c=colls[i];
+  for (int i=0;i<nColl;i++) {
+    const Collision &c=colls[i];
 #if CMK_ERROR_CHECKING
-		if (c.A.pe!=myPe) CkAbort("Should only have local collisions now");
+    if (c.A.pe!=myPe) CkAbort("Should only have local collisions now");
 #endif
-		lookup(c.A.chunk)->colls.push_back(c);
-		if (c.A.pe==c.B.pe && c.A.chunk!=c.B.chunk) 
-		{ //Report this collision to both local chunks:
-			Collision cB(c.B,c.A); //Swap so B is listed first
-			lookup(c.B.chunk)->colls.push_back(cB);
-		}
-			
-	}
+    lookup(c.A.chunk)->colls.push_back(c);
+    if (c.A.pe==c.B.pe && c.A.chunk!=c.B.chunk)
+    { //Report this collision to both local chunks:
+      Collision cB(c.B,c.A); //Swap so B is listed first
+      lookup(c.B.chunk)->colls.push_back(cB);
+    }
+
+  }
 }
 
 /*************** API Routines *****************/
@@ -269,109 +269,109 @@ void threadCollideMgr::sift(int nColl,const Collision *colls)
 
 
 int TCHARMLIB_Get_rank(TCharm *tc,int mpi_comm) {
-	// FIXME: call AMPI_Get_rank if given a real AMPI communicator
-	return tc->getElement();
+  // FIXME: call AMPI_Get_rank if given a real AMPI communicator
+  return tc->getElement();
 }
 CkArrayOptions TCHARMLIB_Bound_array(TCharm *tc,int mpi_comm) {
-	// FIXME: bind to AMPI if given a real AMPI communicator
-	CkArrayOptions opts(tc->getNumElements());
-	opts.bindTo(tc->getProxy());
-	return opts;
+  // FIXME: bind to AMPI if given a real AMPI communicator
+  CkArrayOptions opts(tc->getNumElements());
+  opts.bindTo(tc->getProxy());
+  return opts;
 }
 
 CLINKAGE collide_t COLLIDE_Init(int mpi_comm,
-	const double *gridStart,const double *gridSize)
+    const double *gridStart,const double *gridSize)
 {
-	COLLIDEAPI("COLLIDE_Init");
-	TCharm *tc=TCharm::get();
-	if (tc==NULL) CkAbort("Must call COLLIDE_Init from driver");
-	int rank=TCHARMLIB_Get_rank(tc,mpi_comm);
-	if (rank==0) { // I am the master: I must create the array
-	  CkArrayOptions opts(TCHARMLIB_Bound_array(tc,mpi_comm));
-	  CProxy_threadCollideMgr client=
-	    CProxy_threadCollideMgr::ckNew();
-	  CollideGrid3d gridMap(*(vector3d *)gridStart, *(vector3d *)gridSize);
-	  CollideHandle collide=
-	    CollideCreate(gridMap,client);
-	  CProxy_threadCollide::ckNew(tc->getProxy(),client,collide,opts);
-	  // As array elements are created, they will
-	  //  do tc->semaPut(COLLIDE_TCHARM_SEMAID,this);
-	}
-	// Block until the collision objects are all created:
-	threadCollide *coll=(threadCollide *)tc->semaGet(COLLIDE_TCHARM_SEMAID);
-	// hideous: extract the groupID's "idx" to use as a "collide_t"
-	CkGroupID g=coll->getArrayID();
-	collide_t c=g.idx;
-	return c;
+  COLLIDEAPI("COLLIDE_Init");
+  TCharm *tc=TCharm::get();
+  if (tc==NULL) CkAbort("Must call COLLIDE_Init from driver");
+  int rank=TCHARMLIB_Get_rank(tc,mpi_comm);
+  if (rank==0) { // I am the master: I must create the array
+    CkArrayOptions opts(TCHARMLIB_Bound_array(tc,mpi_comm));
+    CProxy_threadCollideMgr client=
+      CProxy_threadCollideMgr::ckNew();
+    CollideGrid3d gridMap(*(vector3d *)gridStart, *(vector3d *)gridSize);
+    CollideHandle collide=
+      CollideCreate(gridMap,client);
+    CProxy_threadCollide::ckNew(tc->getProxy(),client,collide,opts);
+    // As array elements are created, they will
+    //  do tc->semaPut(COLLIDE_TCHARM_SEMAID,this);
+  }
+  // Block until the collision objects are all created:
+  threadCollide *coll=(threadCollide *)tc->semaGet(COLLIDE_TCHARM_SEMAID);
+  // hideous: extract the groupID's "idx" to use as a "collide_t"
+  CkGroupID g=coll->getArrayID();
+  collide_t c=g.idx;
+  return c;
 }
 FORTRAN_AS_C_RETURN(int,COLLIDE_INIT,COLLIDE_Init,collide_init,
-	(int *comm,double *s,double *e), (*comm,s,e))
+    (int *comm,double *s,double *e), (*comm,s,e))
 
-threadCollide *COLLIDE_Lookup(collide_t c) {
-	CkGroupID g; g.idx=c;
-	CProxy_threadCollide coll(g);
-	threadCollide *ret=coll[TCharm::get()->getElement()].ckLocal();
+  threadCollide *COLLIDE_Lookup(collide_t c) {
+    CkGroupID g; g.idx=c;
+    CProxy_threadCollide coll(g);
+    threadCollide *ret=coll[TCharm::get()->getElement()].ckLocal();
 #if CMK_ERROR_CHECKING
-	if (ret==NULL) CkAbort("COLLIDE can't find its collision array element.");
-#endif	
-	return ret;
-}
+    if (ret==NULL) CkAbort("COLLIDE can't find its collision array element.");
+#endif
+    return ret;
+  }
 
 CLINKAGE void COLLIDE_Boxes(collide_t c,int nBox,const double *boxes)
 {
-	COLLIDEAPI("COLLIDE_Boxes");
-	COLLIDE_Lookup(c)->contribute(nBox,(const bbox3d *)boxes,NULL);
+  COLLIDEAPI("COLLIDE_Boxes");
+  COLLIDE_Lookup(c)->contribute(nBox,(const bbox3d *)boxes,NULL);
 }
 FORTRAN_AS_C(COLLIDE_BOXES,COLLIDE_Boxes,collide_boxes,
-	(int *c,int *n,double *box),(*c,*n,box))
+    (int *c,int *n,double *box),(*c,*n,box))
 
 CLINKAGE void COLLIDE_Boxes_prio(collide_t c,int nBox,const double *boxes,const int *prio)
 {
-	COLLIDEAPI("COLLIDE_Boxes_prio");
-	COLLIDE_Lookup(c)->contribute(nBox,(const bbox3d *)boxes,prio);
+  COLLIDEAPI("COLLIDE_Boxes_prio");
+  COLLIDE_Lookup(c)->contribute(nBox,(const bbox3d *)boxes,prio);
 }
 FORTRAN_AS_C(COLLIDE_BOXES_PRIO,COLLIDE_Boxes_prio,collide_boxes_prio,
-	(int *c,int *n,double *box,int *prio),(*c,*n,box,prio))
+    (int *c,int *n,double *box,int *prio),(*c,*n,box,prio))
 
-CLINKAGE int COLLIDE_Count(collide_t c) {
-	COLLIDEAPI("COLLIDE_Count");
-	return COLLIDE_Lookup(c)->colls.size();
-}
+  CLINKAGE int COLLIDE_Count(collide_t c) {
+    COLLIDEAPI("COLLIDE_Count");
+    return COLLIDE_Lookup(c)->colls.size();
+  }
 FORTRAN_AS_C_RETURN(int,COLLIDE_COUNT,COLLIDE_Count,collide_count,
-	(int *c),(*c))
+    (int *c),(*c))
 
-static void getCollisionList(collide_t c,int *out,int indexBase) {
-	growableBufferT<Collision> &colls=COLLIDE_Lookup(c)->colls;
-	int i,n=colls.size();
-	Collision *in=colls.detachBuffer();
-	for (i=0;i<n;i++) {
-		out[3*i+0]=in[i].A.number+indexBase;
-		out[3*i+1]=in[i].B.chunk+indexBase;
-		out[3*i+2]=in[i].B.number+indexBase;
-	}
-	free(in);
-}
+  static void getCollisionList(collide_t c,int *out,int indexBase) {
+    growableBufferT<Collision> &colls=COLLIDE_Lookup(c)->colls;
+    int i,n=colls.size();
+    Collision *in=colls.detachBuffer();
+    for (i=0;i<n;i++) {
+      out[3*i+0]=in[i].A.number+indexBase;
+      out[3*i+1]=in[i].B.chunk+indexBase;
+      out[3*i+2]=in[i].B.number+indexBase;
+    }
+    free(in);
+  }
 
 CLINKAGE void COLLIDE_List(collide_t c,int *out) {
-	COLLIDEAPI("COLLIDE_List");
-	getCollisionList(c,out,0);
+  COLLIDEAPI("COLLIDE_List");
+  getCollisionList(c,out,0);
 }
 FLINKAGE void FTN_NAME(COLLIDE_LIST,collide_list)(collide_t *c,int *out) {
-	COLLIDEAPI("COLLIDE_List");
-	getCollisionList(*c,out,1);
+  COLLIDEAPI("COLLIDE_List");
+  getCollisionList(*c,out,1);
 }
 
 CLINKAGE void COLLIDE_Destroy(collide_t c) {
-	COLLIDEAPI("COLLIDE_Destroy");
-	/* FIXME: delete entire array */
+  COLLIDEAPI("COLLIDE_Destroy");
+  /* FIXME: delete entire array */
 }
 FORTRAN_AS_C(COLLIDE_DESTROY,COLLIDE_Destroy,collide_destroy,
-	(int *c),(*c))
+    (int *c),(*c))
 
 
 #if CMK_TRACE_ENABLED
 #include "register.h" // for _chareTable, _entryTable
-CsvExtern(funcmap*, tcharm_funcmap);
+  CsvExtern(funcmap*, tcharm_funcmap);
 #endif
 
 static void collideNodeInit(void)

--- a/src/libs/ck-libs/collide/threadCollide.ci
+++ b/src/libs/ck-libs/collide/threadCollide.ci
@@ -13,8 +13,8 @@ module collide {
   };
   array[1D] threadCollide {
     entry threadCollide(CProxy_TCharm threads,
-	CProxy_threadCollideMgr tmgr,
-    	CollideHandle cmgr);
+        CProxy_threadCollideMgr tmgr,
+        CollideHandle cmgr);
     entry void resultsDone(void);
   };
 };


### PR DESCRIPTION
Ran two vim commands on all files:

1. gg=G (Fix indentation and remove tabs)
2. %s/\s\+$//e (To remove trailing whitespaces)