### PR TITLE
Remove unistd.h header file from mpibench.c

### DIFF
--- a/benchmarks/ampi/alltoall/mpibench.c
+++ b/benchmarks/ampi/alltoall/mpibench.c
@@ -1,7 +1,6 @@
 #include "mpi.h"
 #include <stdio.h>
 #include <stdlib.h>
-#include <unistd.h>
 
 #define NUMTIMES 1
 #define REPS 2000


### PR DESCRIPTION
`unistd.h` was required previously and I don't see why it should be included now.

This fixes the windows autobuild issue seen in mpi-win-x86_64{-smp}. 
```

make -C alltoall test OPTS='-optimize -production ' TESTOPTS=''
make[2]: Entering directory '/home/nikhil/autobuild/mpi-win-x86_64/charm/mpi-win-x86_64/benchmarks/ampi/alltoall'
../../../bin/ampicc -c mpibench.c -optimize -production 
mpibench.c
mpibench.c(4): fatal error C1083: Cannot open include file: 'unistd.h': No such file or directory
Fatal Error by charmc in directory /home/nikhil/autobuild/mpi-win-x86_64/charm/mpi-win-x86_64/benchmarks/ampi/alltoall
```

http://charm.cs.illinois.edu/autobuild/old.2020_08_18__01_05/mpi-win-x86_64.txt