### PR TITLE
build: make sure we can link executables

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -861,6 +861,12 @@ if(${TARGET} STREQUAL "charm4py")
   add_dependencies(charm hwloc)
 endif()
 
+# Check that we are able to build and link an executable
+add_executable(hello ${CMAKE_SOURCE_DIR}/tests/charm++/simplearrayhello/hello.C)
+add_dependencies(hello ck ldb-rand memory-default threads-default conv-static
+  conv-core ckmain conv-machine conv-util conv-partition conv-ldb ckqt
+  moduleNDMeshStreamer modulecompletion tmgr)
+
 # Create conv-mach-opt.sh
 set(optfile_sh ${CMAKE_BINARY_DIR}/include/conv-mach-opt.sh)
 

--- a/cmake/ci-files.cmake
+++ b/cmake/ci-files.cmake
@@ -1,6 +1,8 @@
 # List all *.ci files in src/
 file(GLOB_RECURSE ci-files ${CMAKE_SOURCE_DIR}/src/*.ci)
 
+list(APPEND ci-files ${CMAKE_SOURCE_DIR}/tests/charm++/simplearrayhello/hello.ci)
+
 foreach(in_f ${ci-files})
 
     # Special handling for ci files whose filename is not the same as the module name

--- a/src/libs/ck-libs/ampi/CMakeLists.txt
+++ b/src/libs/ck-libs/ampi/CMakeLists.txt
@@ -193,7 +193,7 @@ if(${CMK_AMPI_WITH_ROMIO})
     add_dependencies(romio moduleampi ampi-compat ck modulecompletion
         conv-partition conv-util hwloc conv-static conv-core ldb-rand
         memory-os-isomalloc memory-default threads-default ckmain moduletcharmmain
-        conv-machine tmgr conv-ldb ckqt tcharm-compat moduleNDMeshStreamer)
+        conv-machine tmgr conv-ldb ckqt tcharm-compat moduleNDMeshStreamer hello)
     if(${CMK_CAN_LINK_FORTRAN})
         add_dependencies(romio moduleampif conv-utilf)
     endif()


### PR DESCRIPTION
Makes build errors such as https://github.com/UIUC-PPL/charm/pull/3024 a bit easier to find and debug.