### PR TITLE
CkLocMgr: Bound number of hops that messages can take

### DIFF
--- a/src/ck-core/cklocation.C
+++ b/src/ck-core/cklocation.C
@@ -2536,6 +2536,11 @@ int CkLocMgr::deliverMsg(CkArrayMessage *msg, CkArrayID mgr, CmiUInt8 id, const 
       }
 #endif
       msg->array_hops()++;
+      // If we are hopping more than twice, we've discovered a stale chain
+      // of cache entries. Just route through home instead.
+      if (msg->array_hops() > 2 && CkMyPe() != homePe(id)) {
+        destPE = homePe(id);
+      }
       CkArrayManagerDeliver(destPE,msg,opts);
       return true;
     }


### PR DESCRIPTION
In cases with frequent load balancing, chains of stale location table entries
can cause messages with extremely high numbers of hops to reach their
destination. This change limits the impact of these chains by routing messages
through the home PE as soon as a potential chain (hops > 2) is detected.
Further work should also go towards clearing out location tables to remove
the existence of these chains entirely.

#2060