### PR TITLE
Zcpy Bcast API: Implement one-level acking

### DIFF
--- a/src/ck-core/ckrdma.h
+++ b/src/ck-core/ckrdma.h
@@ -275,8 +275,6 @@ struct NcpyBcastRootAckInfo : public NcpyBcastAckInfo {
 
 struct NcpyBcastInterimAckInfo : public NcpyBcastAckInfo {
   void *msg;
-  void *parentBcastAckInfo;
-  int origPe;
   bool isRecv;
   bool isArray;
 };


### PR DESCRIPTION
Previously, the acking scheme was botton-up with intermediate nodes
sending an ack message to their parent nodes when all the nodes below them
had completed performing rgets. With this commit, intermediate nodes
send an ack message to their parent nodes when their immediate child
nodes have completed performing rgets. This makes acking more
optimized resulting in earlier consumption of the intermediate node
message and earlier execution of the root node's callback allowing it to
reuse/free the source buffer pointer at an earlier point in time.