### PR TITLE
cmake: arbitrary destination and out-of-source build dirs

### DIFF
--- a/build
+++ b/build
@@ -1,4 +1,7 @@
 #!/bin/bash
 
-./buildcmake "$@"
+# Determine the location of this script
+my_srcdir="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+$my_srcdir/buildcmake "$@"
 exit $?

--- a/build
+++ b/build
@@ -3,5 +3,5 @@
 # Determine the location of this script
 my_srcdir="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-$my_srcdir/buildcmake "$@"
+"$my_srcdir"/buildcmake "$@"
 exit $?

--- a/buildcmake
+++ b/buildcmake
@@ -4,21 +4,23 @@
 
 set -o errexit -o nounset
 
-# Check that CMake is available and that the version is sufficiently new
+# Determine the location of this script
+my_srcdir="$(cd -P "$( dirname "${BASH_SOURCE[0]}" )" && pwd)"
 
+# Check that CMake is available and that the version is sufficiently new
 command -v cmake >/dev/null 2>&1 && rc=$? || rc=$?
 
 if [[ $rc -ne 0 ]]; then
   echo "Warning: CMake unavailable, running ./buildold instead."
   sleep 2
-  ./buildold "$@"
+  $my_srcdir/buildold "$@"
   exit $?
 fi
 
 if [[ $(uname) == "MSYS"* || $(uname) == "MINGW"* ]]; then
   echo "Warning: CMake build is not supported under MSYS, running ./buildold instead."
   sleep 2
-  ./buildold "$@"
+  $my_srcdir/buildold "$@"
   exit $?
 fi
 
@@ -30,7 +32,7 @@ cmake_version_full=$(cmake --version | head -1 | cut -f 3 -d' ')
 if [[ $cmake_version_major -lt 3 || ($cmake_version_major -eq 3 && $cmake_version_minor -lt 4) ]]; then
   echo "Warning: The CMake version on your system is too old (needed: 3.4.0 or later; available: $cmake_version_full), running ./buildold instead."
   sleep 2
-  ./buildold "$@"
+  $my_srcdir/buildold "$@"
   exit $?
 fi
 
@@ -44,7 +46,7 @@ usage()
 
 help()
 {
-  ./buildold --help
+  $my_srcdir/buildold --help
   exit 0
 }
 
@@ -401,19 +403,18 @@ else
 fi
 
 my_os=$(echo "$triplet" | cut -d '-' -f2)
-my_dir=$(dirname "$0")
 
 if [[ $opt_network == "mpi" && $my_os == "win" ]]; then
   echo "Warning: CMake build is not supported with MPI on Windows, running ./buildold instead."
   sleep 2
-  ./buildold "$@"
+  $my_srcdir/buildold "$@"
   exit $?
 fi
 
 # Special handling for Windows compiler
 if [[ $my_os == "win" && ( -z $opt_CC || $opt_CC == "msvc" ) ]]; then
   # Need to use unix2nt_cc on Windows/Cygwin
-  opt_CC=$(realpath "$my_dir")/src/arch/win/unix2nt_cc
+  opt_CC=$(realpath "$my_src_dir")/src/arch/win/unix2nt_cc
   opt_CXX=$opt_CC
   opt_FC=
 fi
@@ -440,6 +441,7 @@ for c in $opt_lrts_pmi $opt_compiler; do
 done
 
 if [[ -n $opt_destination ]]; then
+  # Note that $builddir_extra is intentionally ignored here
   builddir=$opt_destination$opt_suffix
 else
   builddir=$triplet$builddir_extra$opt_suffix
@@ -462,7 +464,7 @@ if [[ -n $opt_incdir ]]; then
   echo "USER_OPTS_CXX='$opt_incdir'" >> include/conv-mach-pre.sh
 fi
 
-CC=$opt_CC CXX=$opt_CXX FC=$opt_FC cmake .. \
+CC=$opt_CC CXX=$opt_CXX FC=$opt_FC cmake $my_srcdir \
   -G "Unix Makefiles" \
   -DCMAKE_BUILD_TYPE="$opt_production" \
   -DCMK_AMPI_ONLY="$opt_ampi_only" \

--- a/buildcmake
+++ b/buildcmake
@@ -13,14 +13,14 @@ command -v cmake >/dev/null 2>&1 && rc=$? || rc=$?
 if [[ $rc -ne 0 ]]; then
   echo "Warning: CMake unavailable, running ./buildold instead."
   sleep 2
-  $my_srcdir/buildold "$@"
+  "$my_srcdir"/buildold "$@"
   exit $?
 fi
 
 if [[ $(uname) == "MSYS"* || $(uname) == "MINGW"* ]]; then
   echo "Warning: CMake build is not supported under MSYS, running ./buildold instead."
   sleep 2
-  $my_srcdir/buildold "$@"
+  "$my_srcdir"/buildold "$@"
   exit $?
 fi
 
@@ -32,7 +32,7 @@ cmake_version_full=$(cmake --version | head -1 | cut -f 3 -d' ')
 if [[ $cmake_version_major -lt 3 || ($cmake_version_major -eq 3 && $cmake_version_minor -lt 4) ]]; then
   echo "Warning: The CMake version on your system is too old (needed: 3.4.0 or later; available: $cmake_version_full), running ./buildold instead."
   sleep 2
-  $my_srcdir/buildold "$@"
+  "$my_srcdir"/buildold "$@"
   exit $?
 fi
 
@@ -46,7 +46,7 @@ usage()
 
 help()
 {
-  $my_srcdir/buildold --help
+  "$my_srcdir"/buildold --help
   exit 0
 }
 
@@ -407,14 +407,14 @@ my_os=$(echo "$triplet" | cut -d '-' -f2)
 if [[ $opt_network == "mpi" && $my_os == "win" ]]; then
   echo "Warning: CMake build is not supported with MPI on Windows, running ./buildold instead."
   sleep 2
-  $my_srcdir/buildold "$@"
+  "$my_srcdir"/buildold "$@"
   exit $?
 fi
 
 # Special handling for Windows compiler
 if [[ $my_os == "win" && ( -z $opt_CC || $opt_CC == "msvc" ) ]]; then
   # Need to use unix2nt_cc on Windows/Cygwin
-  opt_CC=$(realpath "$my_src_dir")/src/arch/win/unix2nt_cc
+  opt_CC=$(realpath "$my_srcdir")/src/arch/win/unix2nt_cc
   opt_CXX=$opt_CC
   opt_FC=
 fi
@@ -464,7 +464,7 @@ if [[ -n $opt_incdir ]]; then
   echo "USER_OPTS_CXX='$opt_incdir'" >> include/conv-mach-pre.sh
 fi
 
-CC=$opt_CC CXX=$opt_CXX FC=$opt_FC cmake $my_srcdir \
+CC=$opt_CC CXX=$opt_CXX FC=$opt_FC cmake "$my_srcdir" \
   -G "Unix Makefiles" \
   -DCMAKE_BUILD_TYPE="$opt_production" \
   -DCMK_AMPI_ONLY="$opt_ampi_only" \


### PR DESCRIPTION
- No need to run ./build inside charm/
- No need for the --destination dir to be inside charm/

Followup of #3047.
Fixes https://github.com/spack/spack/issues/18460