### PR TITLE
Doc: Check for program existence using POSIX standard "command" instead of "which"

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -29,7 +29,7 @@ clean:
 	rm -rf pdf html
 
 check-sphinx:
-	@command -v sphinx-build || { echo "Sphinx (http://www.sphinx-doc.org) not found. Install it with 'pip install sphinx'."; exit 1; }
+	@command -v sphinx-build > /dev/null 2>&1 || { echo "Sphinx (http://www.sphinx-doc.org) not found. Install it with 'pip install sphinx'."; exit 1; }
 
 check-latex: check-sphinx
-	@command -v pdflatex || { echo "Warning: Pdflatex not found. Exiting."; exit 1; }
+	@command -v pdflatex > /dev/null 2>&1 || { echo "Warning: Pdflatex not found. Exiting."; exit 1; }

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -29,7 +29,7 @@ clean:
 	rm -rf pdf html
 
 check-sphinx:
-	@which -s sphinx-build || { echo "Sphinx (http://www.sphinx-doc.org) not found. Install it with 'pip install sphinx'."; exit 1; }
+	@command -v sphinx-build || { echo "Sphinx (http://www.sphinx-doc.org) not found. Install it with 'pip install sphinx'."; exit 1; }
 
 check-latex: check-sphinx
-	@which -s pdflatex || { echo "Warning: Pdflatex not found. Exiting."; exit 1; }
+	@command -v pdflatex || { echo "Warning: Pdflatex not found. Exiting."; exit 1; }


### PR DESCRIPTION
`which -s` is broken, my local version of `which` has no support for the `-s` flag (and I can't find what it's supposed to mean, either). Using the POSIX standard `command` command fixes this for me and will be more compatible in general.