### PR TITLE
Doc: specify maximum allowed number of outstanding futures per PE

### DIFF
--- a/doc/charm++/manual.rst
+++ b/doc/charm++/manual.rst
@@ -5862,7 +5862,7 @@ The maximum number of outstanding futures a PE may have is limited by the size o
 *CMK_REFNUM_TYPE*. Specifically, no more than :math:`2^{SIZE}-1`, where :math:`SIZE`
 is the size of *CMK_REFNUM_TYPE* in bits, may be outstanding at any time.
 Waiting on more futures will cause a fatal error in non-production builds,
-and will cause the program to hang in production builds. To overcome this limit,
+and will cause the program to hang in production builds. To increase this limit,
 build Charm++ with a larger *CMK_REFNUM_TYPE*, e.g., specifying
 ``--with-refnum-type=uint`` when building Charm++.
 

--- a/doc/charm++/manual.rst
+++ b/doc/charm++/manual.rst
@@ -5859,7 +5859,7 @@ a future. *CkProbeFuture* tests whether the future has already finished
 computing the value of the expression.
 
 The maximum number of outstanding futures a PE may have is limited by the size of
-*CMK_REFNUM_TYPE*. Specifically, no more than :math:`2^{SIZE}-1`, where :math:`SIZE`
+*CMK_REFNUM_TYPE*. Specifically, no more than :math:`2^{SIZE}-1` futures, where :math:`SIZE`
 is the size of *CMK_REFNUM_TYPE* in bits, may be outstanding at any time.
 Waiting on more futures will cause a fatal error in non-production builds,
 and will cause the program to hang in production builds. The default *CMK_REFNUM_TYPE*

--- a/doc/charm++/manual.rst
+++ b/doc/charm++/manual.rst
@@ -5865,7 +5865,7 @@ Waiting on more futures will cause a fatal error in non-production builds,
 and will cause the program to hang in production builds. The default *CMK_REFNUM_TYPE*
 is ``unsigned short``, limiting each PE to 65,535 outstanding futures.
 To increase this limit, build Charm++ with a larger *CMK_REFNUM_TYPE*, e.g. specifying
-``--with-refnum-type=uint`` when building Charm++.
+``--with-refnum-type=uint`` to use ``unsigned int`` when building Charm++.
 
 
 The Converse version of future functions can be found in the :ref:`conv-futures`

--- a/doc/charm++/manual.rst
+++ b/doc/charm++/manual.rst
@@ -5858,6 +5858,15 @@ Other functions complete the API for futures. *CkReleaseFuture* destroys
 a future. *CkProbeFuture* tests whether the future has already finished
 computing the value of the expression.
 
+The maximum number of outstanding futures a PE may have is limited by the size of
+*CMK_REFNUM_TYPE*. Specifically, no more than :math:`2^{SIZE}-1`, where :math:`SIZE`
+is the size of *CMK_REFNUM_TYPE* in bits, may be outstanding at any time.
+Waiting on more futures will cause a fatal error in non-production builds,
+and will cause the program to hang in production builds. To overcome this limit,
+build Charm++ with a larger *CMK_REFNUM_TYPE*, e.g., specifying
+``--with-refnum-type=uint`` when building Charm++.
+
+
 The Converse version of future functions can be found in the :ref:`conv-futures`
 section.
 

--- a/doc/charm++/manual.rst
+++ b/doc/charm++/manual.rst
@@ -5862,8 +5862,9 @@ The maximum number of outstanding futures a PE may have is limited by the size o
 *CMK_REFNUM_TYPE*. Specifically, no more than :math:`2^{SIZE}-1`, where :math:`SIZE`
 is the size of *CMK_REFNUM_TYPE* in bits, may be outstanding at any time.
 Waiting on more futures will cause a fatal error in non-production builds,
-and will cause the program to hang in production builds. To increase this limit,
-build Charm++ with a larger *CMK_REFNUM_TYPE*, e.g., specifying
+and will cause the program to hang in production builds. The default *CMK_REFNUM_TYPE*
+is ``unsigned short``, limiting each PE to 65,535 outstanding futures.
+To increase this limit, build Charm++ with a larger *CMK_REFNUM_TYPE*, e.g., specifying
 ``--with-refnum-type=uint`` when building Charm++.
 
 

--- a/doc/charm++/manual.rst
+++ b/doc/charm++/manual.rst
@@ -5864,7 +5864,7 @@ is the size of *CMK_REFNUM_TYPE* in bits, may be outstanding at any time.
 Waiting on more futures will cause a fatal error in non-production builds,
 and will cause the program to hang in production builds. The default *CMK_REFNUM_TYPE*
 is ``unsigned short``, limiting each PE to 65,535 outstanding futures.
-To increase this limit, build Charm++ with a larger *CMK_REFNUM_TYPE*, e.g., specifying
+To increase this limit, build Charm++ with a larger *CMK_REFNUM_TYPE*, e.g. specifying
 ``--with-refnum-type=uint`` when building Charm++.
 
 


### PR DESCRIPTION
Documented the limits on the number of outstanding futures per PE. Feel free to make suggestions on language, clarity, etc.