### PR TITLE
AMPI: Remove NOIMPL declarations of MPI_File symbols provided by ROMIO

### DIFF
--- a/src/libs/ck-libs/ampi/ampi.h
+++ b/src/libs/ck-libs/ampi/ampi.h
@@ -1056,14 +1056,6 @@ typedef void (*MPI_MigrateFn)(void);
 
 #define  MPI_CONVERSION_FN_NULL  AMPI_CONVERSION_FN_NULL
 #define PMPI_CONVERSION_FN_NULL APMPI_CONVERSION_FN_NULL
-#define  MPI_File_iread_all  AMPI_File_iread_all
-#define PMPI_File_iread_all APMPI_File_iread_all
-#define  MPI_File_iread_at_all  AMPI_File_iread_at_all
-#define PMPI_File_iread_at_all APMPI_File_iread_at_all
-#define  MPI_File_iwrite_all  AMPI_File_iwrite_all
-#define PMPI_File_iwrite_all APMPI_File_iwrite_all
-#define  MPI_File_iwrite_at_all  AMPI_File_iwrite_at_all
-#define PMPI_File_iwrite_at_all APMPI_File_iwrite_at_all
 
 #define  MPI_Status_f082f  AMPI_Status_f082f
 #define PMPI_Status_f082f APMPI_Status_f082f

--- a/src/libs/ck-libs/ampi/ampi_functions.h
+++ b/src/libs/ck-libs/ampi/ampi_functions.h
@@ -694,11 +694,6 @@ AMPI_FUNC_NOIMPL(int, MPI_Win_sync, MPI_Win win)
 /* A.2.11 I/O C Bindings */
 
 AMPI_FUNC_NOIMPL(int, MPI_CONVERSION_FN_NULL, void *userbuf, MPI_Datatype datatype, int count, void *filebuf, MPI_Offset position, void *extra_state)
-AMPI_FUNC_NOIMPL(int, MPI_File_iread_all, MPI_File fh, void *buf, int count, MPI_Datatype datatype, MPI_Request *request)
-AMPI_FUNC_NOIMPL(int, MPI_File_iread_at_all, MPI_File fh, MPI_Offset offset, void *buf, int count, MPI_Datatype datatype, MPI_Request *request)
-AMPI_FUNC_NOIMPL(int, MPI_File_iwrite_all, MPI_File fh, const void *buf, int count, MPI_Datatype datatype, MPI_Request *request)
-AMPI_FUNC_NOIMPL(int, MPI_File_iwrite_at_all, MPI_File fh, MPI_Offset offset, const void *buf, int count, MPI_Datatype datatype, MPI_Request *request)
-// AMPI_FUNC_NOIMPL(int, MPI_Register_datarep, const char *datarep, MPI_Datarep_conversion_function *read_conversion_fn, MPI_Datarep_conversion_function *write_conversion_fn, MPI_Datarep_extent_function *dtype_file_extent_fn, void *extra_state) //Provided by ROMIO
 
 
 /* A.2.12 Language Bindings C Bindings */


### PR DESCRIPTION
Provided by:
- mpi-io/iread_all.c
- mpi-io/iread_atall.c
- mpi-io/iwrite_all.c
- mpi-io/iwrite_atall.c
- mpi-io/register_datarep.c