### PR TITLE
buildold: Never run autoconf for hwloc or ROMIO

### DIFF
--- a/src/libs/ck-libs/ampi/Makefile
+++ b/src/libs/ck-libs/ampi/Makefile
@@ -78,8 +78,6 @@ all: $(MAJOR_TARGETS) $(COMPATLIB) $(ROMIO)
 # is done, in order to prevent ROMIO recompilation when AMPI changes.
 $(ROMIO): | $(MAJOR_TARGETS)
 	@echo "Building ROMIO"
-# update timestamps on these files so that ROMIO's Makefile does not run configure a second time
-	@touch romio/aclocal.m4 romio/Makefile.in romio/configure romio/config.status
 	cd romio &&                                                                  \
 		MPI_IMPL="ampi" FROM_MPICH="no" FROM_LAM="no" FROM_OMPI="no"         \
 		MPI_LIB=""                                                           \
@@ -96,7 +94,7 @@ $(ROMIO): | $(MAJOR_TARGETS)
 		--srcdir=`pwd`
 
 	cp romio/include/mpio.h romio/include/mpiof.h romio/include/mpio_functions.h $(CDIR)/include
-	$(MAKE) -C romio
+	$(MAKE) -C romio AUTOCONF=: AUTOHEADER=: AUTOMAKE=: ACLOCAL=:
 	cp romio/.libs/libromio.a $@
 ifneq ($(ROMIOLIBSHARED),)
 	cp romio/.libs/libromio.$(CMK_SHARED_SUF) $(ROMIOLIBSHARED)

--- a/src/scripts/Makefile
+++ b/src/scripts/Makefile
@@ -489,7 +489,7 @@ cpuaffinity.o $(L)/libhwloc_embedded.a $(INC)/hwloc.h $(INC)/hwloc/autogen/confi
 $(INC)/hwloc/helper.h $(INC)/hwloc/inlines.h $(INC)/hwloc/diff.h $(INC)/hwloc/deprecated.h $(INC)/hwloc/export.h $(INC)/hwloc/distances.h : hwloc-target
 
 hwloc-target:  conv-autoconfig.h
-	( $(MAKE) -C hwloc )
+	( $(MAKE) -C hwloc AUTOCONF=: AUTOHEADER=: AUTOMAKE=: ACLOCAL=: )
 	( test -e hwloc/hwloc/.libs/libhwloc_embedded.lib && cp -f hwloc/hwloc/.libs/libhwloc_embedded.lib hwloc/hwloc/.libs/libhwloc_embedded.a ) || true
 	( cp -f hwloc/hwloc/.libs/libhwloc_embedded.a $(L) )
 	( cp -f hwloc/include/hwloc.h $(INC) )


### PR DESCRIPTION
Followup from #2853 
Followup from #2856 