### PR TITLE
romio: do not build MPI_Type_size_x and MPI_Status_set_elements_x

### DIFF
--- a/src/libs/ck-libs/ampi/romio/README.AMPI
+++ b/src/libs/ck-libs/ampi/romio/README.AMPI
@@ -36,6 +36,9 @@ ROMIO integrated into AMPI:
   order to provide MPI_File_{get,set}_errhandler. See mpi-io/Makefile.mk.
 * PMPI function declarations in mpio_functions.h have been disabled.
   This does not affect PMPI functionality.
+* MPI_Type_size_x and MPI_Status_set_elements_x in large_count.c are ifdef'd
+  out, since they are provided by AMPI, but the ROMIO configure check for their
+  presence is faulty.
 
 
 Variable privatization

--- a/src/libs/ck-libs/ampi/romio/mpi-io/glue/large_count.c
+++ b/src/libs/ck-libs/ampi/romio/mpi-io/glue/large_count.c
@@ -6,6 +6,8 @@
 
 #include "mpioimpl.h"
 
+#ifndef AMPI
+
 #ifndef HAVE_MPI_TYPE_SIZE_X
 int MPI_Type_size_x(MPI_Datatype datatype, MPI_Count *size)
 {
@@ -24,3 +26,5 @@ int MPI_Status_set_elements_x(MPI_Status *status, MPI_Datatype datatype,
     return MPI_Status_set_elements(status, datatype, count_int);
 }
 #endif
+
+#endif /* !AMPI */

--- a/src/libs/ck-libs/ampi/romio/mpi-io/glue/large_count.c
+++ b/src/libs/ck-libs/ampi/romio/mpi-io/glue/large_count.c
@@ -7,6 +7,8 @@
 #include "mpioimpl.h"
 
 #ifndef AMPI
+// The two functions in this file are provided by AMPI, but the ROMIO configure check
+// for their presence is faulty, which is why these functions are ifdef'd out for AMPI.
 
 #ifndef HAVE_MPI_TYPE_SIZE_X
 int MPI_Type_size_x(MPI_Datatype datatype, MPI_Count *size)


### PR DESCRIPTION
cc https://github.com/spack/spack/issues/18460