### PR TITLE
build: Detect repeated invocations and warn users

### DIFF
--- a/buildcmake
+++ b/buildcmake
@@ -421,7 +421,17 @@ then
   if [[ $FORCE -eq 0 ]]
   then
     echo "To attempt a partial rebuild, run 'make' in \"$builddir\"."
-    echo "To remove the existing data and run configure again, run this script with --force."
+    echo "To remove the existing data and reconfigure, run this script again with --force."
+    exit 1
+  else
+    echo "Removing existing data and starting over. (--force)"
+  fi
+elif [[ -e "$builddir" ]]
+then
+  echo "\"$builddir\" already exists but is in an inconsistent state."
+  if [[ $FORCE -eq 0 ]]
+  then
+    echo "To remove the existing data and reconfigure, run this script again with --force."
     exit 1
   else
     echo "Removing existing data and starting over. (--force)"

--- a/buildcmake
+++ b/buildcmake
@@ -129,6 +129,7 @@ opt_compiler=""
 # Misc options
 VERBOSE=0
 ONLY_CONFIGURE=0
+FORCE=0
 
 processArgs() {
 
@@ -340,6 +341,10 @@ while [[ $# -gt 0 ]]; do
       # Run only cmake, not make
       ONLY_CONFIGURE=1
       ;;
+    --force)
+      # Overwrite existing configuration
+      FORCE=1
+      ;;
     -j)
       opt_parallel="$arg"
       if [[ $# -gt 0 && $1 == [0-9]* ]]; then
@@ -378,12 +383,55 @@ eval processArgs "$@"
 ############ End option parsing
 
 
+# Make adjustments to $target if necessary
+
 if [[ "$target" = "${target%AMPI-only}AMPI-only" ]]; then
     opt_ampi_only=1
 
     # strip "-only" suffix from AMPI target
     target="${target%AMPI-only}AMPI"
+fi
 
+
+# Determine the build directory name
+
+# Append certain features and compilers to the end of $builddir
+builddir_extra=""
+for flag in opt_omp opt_smp opt_tcp opt_pthreads opt_pxshm opt_syncft opt_ooc opt_persistent opt_cuda; do
+  [[ $flag -eq 1 ]] && builddir_extra+="-${flag/opt_/}"
+done
+
+for c in $opt_lrts_pmi $opt_compiler; do
+  [[ -n $c ]] &&  builddir_extra+="-${c}"
+done
+
+if [[ -n $opt_destination ]]; then
+  # Note that $builddir_extra is intentionally ignored here
+  builddir=$opt_destination$opt_suffix
+else
+  builddir=$triplet$builddir_extra$opt_suffix
+fi
+
+
+# Check whether configure step has already taken place
+
+if [[ -f "$builddir/Makefile" ]]
+then
+  echo "The configure step has already taken place for the specified build."
+  if [[ $FORCE -eq 0 ]]
+  then
+    echo "To attempt a partial rebuild, run make in \"$builddir\"."
+    echo "To remove the existing data and run configure again, run this script with --force."
+    exit 1
+  else
+    echo "Removing existing data and starting over. (--force)"
+  fi
+fi
+
+
+# Build option setup
+
+if [[ $opt_ampi_only -eq 1 ]]; then
     # AMPI doesn't use Charm-MPI interop or msg priorities of any kind.
     # AMPI creates O(NumVirtualRanks) chare arrays by default (for MPI_COMM_SELF),
     # so we bump up the number of bits reserved for the collection in the objid.
@@ -430,22 +478,8 @@ if [[ $VERBOSE -eq 1 ]]; then
   done
 fi
 
-# Append certain features and compilers to the end of the build directory name
-builddir_extra=""
-for flag in opt_omp opt_smp opt_tcp opt_pthreads opt_pxshm opt_syncft opt_ooc opt_persistent opt_cuda; do
-  [[ $flag -eq 1 ]] && builddir_extra+="-${flag/opt_/}"
-done
 
-for c in $opt_lrts_pmi $opt_compiler; do
-  [[ -n $c ]] &&  builddir_extra+="-${c}"
-done
-
-if [[ -n $opt_destination ]]; then
-  # Note that $builddir_extra is intentionally ignored here
-  builddir=$opt_destination$opt_suffix
-else
-  builddir=$triplet$builddir_extra$opt_suffix
-fi
+# Create builddir and its contents
 
 rm -rf "$builddir"
 
@@ -463,6 +497,9 @@ if [[ -n $opt_incdir ]]; then
   echo "USER_OPTS_CC='$opt_incdir'" >> include/conv-mach-pre.sh
   echo "USER_OPTS_CXX='$opt_incdir'" >> include/conv-mach-pre.sh
 fi
+
+
+# Run configure step
 
 CC=$opt_CC CXX=$opt_CXX FC=$opt_FC cmake "$my_srcdir" \
   -G "Unix Makefiles" \
@@ -506,6 +543,9 @@ CC=$opt_CC CXX=$opt_CXX FC=$opt_FC cmake "$my_srcdir" \
   -DTRACING="$opt_tracing" \
   -DTRACING_COMMTHREAD="$opt_tracing_commthread" \
   -DZLIB="$opt_zlib"
+
+
+# Run build step
 
 [[ $ONLY_CONFIGURE -eq 1 ]] && exit 0
 

--- a/buildcmake
+++ b/buildcmake
@@ -342,7 +342,7 @@ while [[ $# -gt 0 ]]; do
       ONLY_CONFIGURE=1
       ;;
     --force)
-      # Overwrite existing configuration
+      # Overwrite existing build directory
       FORCE=1
       ;;
     -j)
@@ -420,7 +420,7 @@ then
   echo "The configure step has already taken place for the specified build."
   if [[ $FORCE -eq 0 ]]
   then
-    echo "To attempt a partial rebuild, run make in \"$builddir\"."
+    echo "To attempt a partial rebuild, run 'make' in \"$builddir\"."
     echo "To remove the existing data and run configure again, run this script with --force."
     exit 1
   else

--- a/buildold
+++ b/buildold
@@ -231,6 +231,7 @@ TAU_MAKEFILE=""
 QUIET=""
 BUILD_OMP=0
 ONLY_CONFIGURE=
+FORCE=
 AMPI_ONLY=
 
 [ "$1" = '--help' -o "$1" = '-h' ] && more=1 && syntax | ( less || more ) && exit 1
@@ -420,6 +421,10 @@ do
     ;;
     --only-configure)
     ONLY_CONFIGURE="true"
+    shift
+    ;;
+    --force)
+    FORCE='1'
     shift
     ;;
     --enable-tracing|--enable-tracing=*)
@@ -699,14 +704,29 @@ then
   esac
 fi
 
+if [[ "$PROGRAM" = "${PROGRAM%AMPI-only}AMPI-only" ]]
+then
+  # strip "-only" suffix from AMPI target
+  PROGRAM="${PROGRAM%-only}"
+  AMPI_ONLY='1'
+fi
+
 # ===================================================
 # ---------- begin file structure creation ----------
 # ===================================================
 
 if [ -f "$DESTINATION/tmp/basics" ]
 then
-  Echo "File structure already created; skipping directly to make"
-else
+  Echo "The configure step has already taken place for the specified build."
+  if [ -z "$FORCE" ]
+  then
+    Echo "To attempt a partial rebuild, run make in \"$DESTINATION/tmp\"."
+    Echo "To remove the existing data and run configure again, run this script again with --force."
+    exit 1
+  else
+    Echo "Removing existing data and starting over. (--force)"
+  fi
+fi
 
 for d in benchmarks bin examples include lib lib_so tests tmp; do
   rm -rf "$DESTINATION/$d"
@@ -841,6 +861,8 @@ if test  "$BUILD_SHARED"  = "-build-shared"
 then
     echo "CMK_NO_BUILD_SHARED=false" >> $ConvSh
     echo "CMK_NO_BUILD_SHARED:=false" >> $ConvMak
+
+    OPTS="$OPTS $BUILD_SHARED"
 else
     echo "CMK_NO_BUILD_SHARED=true" >> $ConvSh
     echo "CMK_NO_BUILD_SHARED:=true" >> $ConvMak
@@ -857,17 +879,12 @@ else
     echo '#define CMK_AMPI_WITH_ROMIO 0' >> $ConvHeader
 fi
 
-if [[ -n "$AMPI_ONLY" || "$PROGRAM" = "${PROGRAM%AMPI-only}AMPI-only" ]]
+if [[ -n "$AMPI_ONLY" ]]
 then
     echo "CMK_AMPI_ONLY=\"1\"" >> $ConvSh
     echo "CMK_AMPI_ONLY:=1" >> $ConvMak
     echo '#define CMK_AMPI_ONLY 1' >> $ConvHeader
 
-    if [[ "$PROGRAM" = "${PROGRAM%AMPI-only}AMPI-only" ]]
-    then
-      # strip "-only" suffix from AMPI target
-      PROGRAM="${PROGRAM%-only}"
-    fi
     # AMPI doesn't use Charm-MPI interop or msg priorities of any kind.
     # AMPI creates O(NumVirtualRanks) chare arrays by default (for MPI_COMM_SELF),
     # so we bump up the number of bits reserved for the collection in the objid.
@@ -916,8 +933,6 @@ echo "OPTS=\"$OPTS\"" >> "$DESTINATION/tmp/config_opts.sh"
 chmod +x "$DESTINATION/tmp/config_opts.sh"
 echo "OPTSATBUILDTIME:=$OPTS" >> $ConvMak
 
-fi
-
 # ===================================================
 # ----------- end file structure creation -----------
 # ===================================================
@@ -934,7 +949,7 @@ printError()
 
 Echo "Performing '$MAKE $MAKEOPTS basics OPTS="$OPTS" QUIET="$QUIET" CONFIG_OPTS="$CONFIG_OPTS"' in $DESTINATION/tmp"
 cd $DESTINATION/tmp 
-$MAKE $MAKEOPTS basics OPTS="$OPTS $BUILD_SHARED" QUIET="$QUIET"
+$MAKE $MAKEOPTS basics OPTS="$OPTS" QUIET="$QUIET"
 MAKEEXIT=$?
 [ $MAKEEXIT -ne 0 ] && printError
 
@@ -944,13 +959,13 @@ then
 fi
 
 Echo "Performing '$MAKE $MAKEOPTS $PROGRAM OPTS="$OPTS" QUIET="$QUIET"' in $DESTINATION/tmp"
-$MAKE $MAKEOPTS $PROGRAM OPTS="$OPTS $BUILD_SHARED" QUIET="$QUIET"
+$MAKE $MAKEOPTS $PROGRAM OPTS="$OPTS" QUIET="$QUIET"
 MAKEEXIT=$?
 if [ $MAKEEXIT -eq 0 ]
 then
   if [ $BUILD_OMP = 1 ];
   then
-    $MAKE MFLAGS="$MAKEOPTS" openmp_llvm OPTS="$OPTS $BUILD_SHARED" QUIET="$QUIET"
+    $MAKE MFLAGS="$MAKEOPTS" openmp_llvm OPTS="$OPTS" QUIET="$QUIET"
   fi
   Echo "-------------------------------------------------"
   Echo "$PROGRAM built successfully."

--- a/buildold
+++ b/buildold
@@ -721,7 +721,17 @@ then
   if [ -z "$FORCE" ]
   then
     Echo "To attempt a partial rebuild, run 'make' in \"$DESTINATION/tmp\"."
-    Echo "To remove the existing data and run configure again, run this script again with --force."
+    Echo "To remove the existing data and reconfigure, run this script again with --force."
+    exit 1
+  else
+    Echo "Removing existing data and starting over. (--force)"
+  fi
+elif [ -e "$DESTINATION" ]
+then
+  Echo "\"$DESTINATION\" already exists but is in an inconsistent state."
+  if [ -z "$FORCE" ]
+  then
+    Echo "To remove the existing data and reconfigure, run this script again with --force."
     exit 1
   else
     Echo "Removing existing data and starting over. (--force)"

--- a/buildold
+++ b/buildold
@@ -720,7 +720,7 @@ then
   Echo "The configure step has already taken place for the specified build."
   if [ -z "$FORCE" ]
   then
-    Echo "To attempt a partial rebuild, run make in \"$DESTINATION/tmp\"."
+    Echo "To attempt a partial rebuild, run 'make' in \"$DESTINATION/tmp\"."
     Echo "To remove the existing data and run configure again, run this script again with --force."
     exit 1
   else


### PR DESCRIPTION
Fixes a bug where partial rebuilds in tmp/ lacked -build-shared.
Fixes a bug where re-invoking ./buildold with AMPI-only failed.