### PR TITLE
LB #3131: Show pluggable TreeLB strategies in help message

### DIFF
--- a/src/ck-ldb/LBManager.C
+++ b/src/ck-ldb/LBManager.C
@@ -122,7 +122,7 @@ static void createLoadBalancer(const char* lbname, const char* legacybalancer = 
   {  // invalid lb name
     CmiPrintf("Abort: Unknown load balancer: '%s'!\n", lbname);
     lbRegistry.displayLBs();  // display help page
-    CkAbort("Abort");
+    CkExit(1);
   }
   // invoke function to create load balancer
   int seqno = LBManagerObj()->getLoadbalancerTicket();

--- a/src/ck-ldb/LBManager.C
+++ b/src/ck-ldb/LBManager.C
@@ -122,7 +122,10 @@ static void createLoadBalancer(const char* lbname, const char* legacybalancer = 
   {  // invalid lb name
     CmiPrintf("Abort: Unknown load balancer: '%s'!\n", lbname);
     lbRegistry.displayLBs();  // display help page
-    CkExit(1);
+    if(lbname == "help")
+      CkExit(0);
+    else
+      CkExit(1);
   }
   // invoke function to create load balancer
   int seqno = LBManagerObj()->getLoadbalancerTicket();

--- a/src/ck-ldb/LBManager.C
+++ b/src/ck-ldb/LBManager.C
@@ -39,14 +39,14 @@ class LBDBRegistry
   // table for all available LBs linked in
   struct LBDBEntry
   {
-    const char* name;
+    std::string name;
     LBCreateFn cfn;
     LBAllocFn afn;
-    const char* help;
+    std::string help;
     int shown;  // if 0, donot show in help page
-    LBDBEntry() : name(0), cfn(0), afn(0), help(0), shown(1) {}
+    LBDBEntry() : name(""), cfn(0), afn(0), help(""), shown(1) {}
     LBDBEntry(int) {}
-    LBDBEntry(const char* n, LBCreateFn cf, LBAllocFn af, const char* h, int show = 1)
+    LBDBEntry(std::string n, LBCreateFn cf, LBAllocFn af, std::string h, int show = 1)
         : name(n), cfn(cf), afn(af), help(h), shown(show){};
   };
   CkVec<LBDBEntry> lbtables;       // a list of available LBs linked
@@ -63,11 +63,11 @@ class LBDBRegistry
     for (int i = 0; i < lbtables.length(); i++)
     {
       LBDBEntry& entry = lbtables[i];
-      if (entry.shown) CmiPrintf("* %s:	%s\n", entry.name, entry.help);
+      if (entry.shown) CmiPrintf("* %s:\t%s\n", entry.name.c_str(), entry.help.c_str());
     }
     CmiPrintf("\n");
   }
-  void addEntry(const char* name, LBCreateFn fn, LBAllocFn afn, const char* help,
+  void addEntry(std::string name, LBCreateFn fn, LBAllocFn afn, std::string help,
                 int shown)
   {
     lbtables.push_back(LBDBEntry(name, fn, afn, help, shown));
@@ -82,21 +82,21 @@ class LBDBRegistry
 
     runtime_lbs.push_back(name);
   }
-  LBCreateFn search(const char* name)
+  LBCreateFn search(std::string name)
   {
-    char* ptr = strpbrk((char*)name, ":,");
-    int slen = ptr != NULL ? ptr - name : strlen(name);
+    const auto index = name.find_first_of(":,");
     for (int i = 0; i < lbtables.length(); i++)
-      if (0 == strncmp(name, lbtables[i].name, slen)) return lbtables[i].cfn;
-    return NULL;
+      if (0 == lbtables[i].name.compare(0, index, name))
+        return lbtables[i].cfn;
+    return nullptr;
   }
-  LBAllocFn getLBAllocFn(const char* name)
+  LBAllocFn getLBAllocFn(std::string name)
   {
-    char* ptr = strpbrk((char*)name, ":,");
-    int slen = ptr - name;
+    const auto index = name.find_first_of(":,");
     for (int i = 0; i < lbtables.length(); i++)
-      if (0 == strncmp(name, lbtables[i].name, slen)) return lbtables[i].afn;
-    return NULL;
+      if (0 == lbtables[i].name.compare(0, index, name))
+        return lbtables[i].afn;
+    return nullptr;
   }
 };
 
@@ -106,7 +106,7 @@ static std::vector<std::string> lbNames;
 void LBDefaultCreate(const char* lbname) { lbRegistry.addCompiletimeBalancer(lbname); }
 
 // default is to show the helper
-void LBRegisterBalancer(const char* name, LBCreateFn fn, LBAllocFn afn, const char* help,
+void LBRegisterBalancer(std::string name, LBCreateFn fn, LBAllocFn afn, std::string help,
                         int shown)
 {
   lbRegistry.addEntry(name, fn, afn, help, shown);

--- a/src/ck-ldb/LBManager.C
+++ b/src/ck-ldb/LBManager.C
@@ -43,7 +43,7 @@ class LBDBRegistry
     LBCreateFn cfn;
     LBAllocFn afn;
     std::string help;
-    int shown;  // if 0, donot show in help page
+    bool shown;  // if false, do not show in help page
     LBDBEntry() : name(""), cfn(0), afn(0), help(""), shown(1) {}
     LBDBEntry(int) {}
     LBDBEntry(std::string n, LBCreateFn cf, LBAllocFn af, std::string h, int show = 1)

--- a/src/ck-ldb/LBManager.C
+++ b/src/ck-ldb/LBManager.C
@@ -115,12 +115,12 @@ void LBRegisterBalancer(std::string name, LBCreateFn fn, LBAllocFn afn, std::str
 LBAllocFn getLBAllocFn(const char* lbname) { return lbRegistry.getLBAllocFn(lbname); }
 
 // create a load balancer group using the strategy name
-static void createLoadBalancer(const char* lbname, const char* legacybalancer = nullptr)
+static void createLoadBalancer(const std::string& lbname, const char* legacybalancer = nullptr)
 {
   LBCreateFn fn = lbRegistry.search(lbname);
   if (!fn)
   {  // invalid lb name
-    CmiPrintf("Abort: Unknown load balancer: '%s'!\n", lbname);
+    CmiPrintf("Abort: Unknown load balancer: '%s'!\n", lbname.c_str());
     lbRegistry.displayLBs();  // display help page
     if(lbname == "help")
       CkExit(0);

--- a/src/ck-ldb/LBManager.C
+++ b/src/ck-ldb/LBManager.C
@@ -44,9 +44,9 @@ class LBDBRegistry
     LBAllocFn afn;
     std::string help;
     bool shown;  // if false, do not show in help page
-    LBDBEntry() : name(""), cfn(0), afn(0), help(""), shown(1) {}
+    LBDBEntry() : name(""), cfn(0), afn(0), help(""), shown(true) {}
     LBDBEntry(int) {}
-    LBDBEntry(std::string n, LBCreateFn cf, LBAllocFn af, std::string h, int show = 1)
+    LBDBEntry(std::string n, LBCreateFn cf, LBAllocFn af, std::string h, bool show = true)
         : name(n), cfn(cf), afn(af), help(h), shown(show){};
   };
   CkVec<LBDBEntry> lbtables;       // a list of available LBs linked
@@ -68,7 +68,7 @@ class LBDBRegistry
     CmiPrintf("\n");
   }
   void addEntry(std::string name, LBCreateFn fn, LBAllocFn afn, std::string help,
-                int shown)
+                bool shown)
   {
     lbtables.push_back(LBDBEntry(name, fn, afn, help, shown));
   }
@@ -107,7 +107,7 @@ void LBDefaultCreate(const char* lbname) { lbRegistry.addCompiletimeBalancer(lbn
 
 // default is to show the helper
 void LBRegisterBalancer(std::string name, LBCreateFn fn, LBAllocFn afn, std::string help,
-                        int shown)
+                        bool shown)
 {
   lbRegistry.addEntry(name, fn, afn, help, shown);
 }

--- a/src/ck-ldb/LBManager.h
+++ b/src/ck-ldb/LBManager.h
@@ -121,7 +121,7 @@ typedef void (*LBCreateFn)(const CkLBOptions&);
 typedef BaseLB* (*LBAllocFn)();
 void LBDefaultCreate(LBCreateFn f);
 
-void LBRegisterBalancer(const char*, LBCreateFn, LBAllocFn, const char*, int shown = 1);
+void LBRegisterBalancer(std::string, LBCreateFn, LBAllocFn, std::string, int shown = 1);
 
 void _LBMgrInit();
 

--- a/src/ck-ldb/LBManager.h
+++ b/src/ck-ldb/LBManager.h
@@ -121,7 +121,7 @@ typedef void (*LBCreateFn)(const CkLBOptions&);
 typedef BaseLB* (*LBAllocFn)();
 void LBDefaultCreate(LBCreateFn f);
 
-void LBRegisterBalancer(std::string, LBCreateFn, LBAllocFn, std::string, int shown = 1);
+void LBRegisterBalancer(std::string, LBCreateFn, LBAllocFn, std::string, bool shown = true);
 
 void _LBMgrInit();
 

--- a/src/ck-ldb/TreeLB.C
+++ b/src/ck-ldb/TreeLB.C
@@ -6,7 +6,8 @@
 
 extern int quietModeRequested;
 
-CreateLBFunc_Def(TreeLB, "TreeLB")
+CreateLBFunc_Def(TreeLB, "Pluggable hierarchical LB with available strategies:" +
+                             TreeStrategy::getLBNamesString());
 
 void TreeLB::Migrated(int waitBarrier)
 {

--- a/src/ck-ldb/TreeLevel.h
+++ b/src/ck-ldb/TreeLevel.h
@@ -258,7 +258,7 @@ class StrategyWrapper : public IStrategyWrapper
   {
     strategy_name = _strategy_name;
     isTreeRoot = _isTreeRoot;
-    strategy = TreeStrategyFactory::makeStrategy<O, P, Solution>(strategy_name, config);
+    strategy = TreeStrategy::Factory::makeStrategy<O, P, Solution>(strategy_name, config);
   }
 
   virtual ~StrategyWrapper() { delete strategy; }

--- a/src/ck-ldb/TreeStrategyFactory.h
+++ b/src/ck-ldb/TreeStrategyFactory.h
@@ -7,21 +7,26 @@
 
 namespace TreeStrategy
 {
-#define LB_STRATEGIES_FOR_TESTING 1
-
-constexpr auto LBNames = {"Greedy",
-                          "GreedyRefine",
-                          "RefineA",
-                          "RefineB",
-                          "Random",
-#if LB_STRATEGIES_FOR_TESTING
-                          "Dummy",
-                          "Rotate",
-#endif
-};
+// Strategies must be added here to be usable.
+// The name must match exactly the name of the class and will be the string that is used
+// to specify it in the config file.
+// The second parameter is whether or not the constructor takes a json& config argument
+// (which some strategies to accept additional parameters from the config file)
+#define FOREACH_STRATEGY(STRATEGY) \
+  STRATEGY(Greedy, false)          \
+  STRATEGY(GreedyRefine, true)     \
+  STRATEGY(RefineA, false)         \
+  STRATEGY(RefineB, false)         \
+  STRATEGY(Random, false)          \
+  STRATEGY(Dummy, false)           \
+  STRATEGY(Rotate, false)
 
 std::string getLBNamesString()
 {
+  // Eat the second parameter, it's needed for registration below
+#define STRINGIFYLB(_name, _) (#_name),
+  static const auto LBNames = {FOREACH_STRATEGY(STRINGIFYLB)};
+
   std::ostringstream output;
   for (const auto& name : LBNames)
   {
@@ -40,15 +45,14 @@ public:
   template <class O, class P, class S>
   static Strategy<O, P, S>* makeStrategy(const std::string& name, json& config)
   {
-    if (name == "Greedy") return new Greedy<O, P, S>();
-    if (name == "GreedyRefine") return new GreedyRefine<O, P, S>(config);
-    if (name == "RefineA") return new RefineA<O, P, S>();
-    if (name == "RefineB") return new RefineB<O, P, S>();
-    if (name == "Random") return new Random<O, P, S>();
-#if LB_STRATEGIES_FOR_TESTING
-    if (name == "Dummy") return new Dummy<O, P, S>();
-    if (name == "Rotate") return new Rotate<O, P, S>();
-#endif
+    // Only pass config if the strategy needs it
+#define LBNEEDS_CONFIG(_config) LBNEEDS_CONFIG_##_config
+#define LBNEEDS_CONFIG_true config
+#define LBNEEDS_CONFIG_false
+
+#define REGISTERLB(_name, _config) if (name == (#_name)) return new _name<O, P, S>(LBNEEDS_CONFIG(_config));
+    FOREACH_STRATEGY(REGISTERLB);
+
     std::string error_msg("Unrecognized strategy ");
     error_msg += name;
     CkAbort("%s\n", error_msg.c_str());

--- a/src/ck-ldb/TreeStrategyFactory.h
+++ b/src/ck-ldb/TreeStrategyFactory.h
@@ -5,20 +5,41 @@
 #include "greedy.h"
 #include "refine.h"
 
+namespace TreeStrategy
+{
 #define LB_STRATEGIES_FOR_TESTING 1
 
-class TreeStrategyFactory
+constexpr auto LBNames = {"Greedy",
+                          "GreedyRefine",
+                          "RefineA",
+                          "RefineB",
+                          "Random",
+#if LB_STRATEGIES_FOR_TESTING
+                          "Dummy",
+                          "Rotate",
+#endif
+};
+
+std::string getLBNamesString()
 {
- public:
+  std::ostringstream output;
+  for (const auto& name : LBNames)
+  {
+    output << "\n\t" << name;
+  }
+  return output.str();
+}
+
+class Factory
+{
+public:
   // NOTE: This is the only place currently where the templates for each strategy
   // are instantiated. This means that code for any strategies that are disabled here
   // during preprocessing will not be part of the executable (because the templates
   // won't be instantiated)
   template <class O, class P, class S>
-  static TreeStrategy::Strategy<O, P, S>* makeStrategy(const std::string& name,
-                                                       json& config)
+  static Strategy<O, P, S>* makeStrategy(const std::string& name, json& config)
   {
-    using namespace TreeStrategy;
     if (name == "Greedy") return new Greedy<O, P, S>();
     if (name == "GreedyRefine") return new GreedyRefine<O, P, S>(config);
     if (name == "RefineA") return new RefineA<O, P, S>();
@@ -33,5 +54,5 @@ class TreeStrategyFactory
     CkAbort("%s\n", error_msg.c_str());
   }
 };
-
+}  // namespace TreeStrategy
 #endif /* TREESTRATEGYFACTORY_H */


### PR DESCRIPTION
I'm not 100% sold on using using macros for registration and name printing as done here, but I think it's the only real way to map class names to strings "automatically." I think ideally the strategy classes would register themselves using a `map` in the factory and some static initialization, but that gets a little bit complicated with the templating here.