### PR TITLE
AMPI: Avoid self-inflicted deprecation warnings when building

### DIFF
--- a/src/libs/ck-libs/ampi/CMakeLists.txt
+++ b/src/libs/ck-libs/ampi/CMakeLists.txt
@@ -10,13 +10,14 @@ add_library(ampi-compat compat_ampi.c
        compat_ampicpp.C)
 
 add_library(moduleampi ${ampi-cxx-sources} ${ampi-h-sources})
+target_compile_options(moduleampi PRIVATE -DAMPI_NO_UNIMPLEMENTED_WARNINGS)
 add_dependencies(moduleampi moduletcharm ck)
 
 
 # fsglobals/pipglobals
 
 add_library(ampi_funcptr_shim ampi_funcptr_shim.C)
-target_compile_options(ampi_funcptr_shim PRIVATE -language ampi -DAMPI_USE_FUNCPTR -fPIE -shared -fvisibility=hidden)
+target_compile_options(ampi_funcptr_shim PRIVATE -language ampi -DAMPI_USE_FUNCPTR -DAMPI_NO_UNIMPLEMENTED_WARNINGS -fPIE -shared -fvisibility=hidden)
 add_dependencies(ampi_funcptr_shim moduleampi)
 add_custom_command(TARGET ampi_funcptr_shim
     POST_BUILD
@@ -34,7 +35,7 @@ add_custom_command(TARGET ampi_funcptr_shim_main
 )
 
 add_library(ampi_funcptr_loader ampi_funcptr_loader.C)
-target_compile_options(ampi_funcptr_loader PRIVATE -language ampi)
+target_compile_options(ampi_funcptr_loader PRIVATE -language ampi -DAMPI_NO_UNIMPLEMENTED_WARNINGS)
 add_dependencies(ampi_funcptr_loader moduleampi)
 add_custom_command(TARGET ampi_funcptr_loader
     POST_BUILD
@@ -96,6 +97,7 @@ endif()
 
 if(${CMK_CAN_LINK_FORTRAN})
     add_library(moduleampif ${ampi-f90-sources} ${ampi-cxx-sources} ${ampi-h-sources})
+    target_compile_options(moduleampif PRIVATE -DAMPI_NO_UNIMPLEMENTED_WARNINGS)
     add_dependencies(moduleampif moduletcharm ck)
 
     add_library(ampif OBJECT ampif.C)

--- a/src/libs/ck-libs/ampi/Makefile
+++ b/src/libs/ck-libs/ampi/Makefile
@@ -174,6 +174,7 @@ compat_ampi.o: compat_ampi.c
 ampi_mpix.o: ampi_mpix.C $(HEADDEP) headers
 
 ampi_noimpl.o: ampi_noimpl.C $(HEADDEP) headers
+	$(CHARMC) -c $< -DAMPI_NO_UNIMPLEMENTED_WARNINGS
 
 compat_ampicpp.o: compat_ampicpp.C
 	$(CHARMC) -c compat_ampicpp.C
@@ -199,7 +200,7 @@ ampi.decl.h ampi.def.h: ampi.ci
 ddt.o: ddt.C ddt.h $(HEADDEP) headers
 
 $(FUNCPTR_SHIM_OBJ): ampi_funcptr_shim.C $(HEADDEP) headers | $(ROMIO)
-	$(CHARMC) -language ampi -DAMPI_USE_FUNCPTR -fPIE -shared -fvisibility=hidden -c $< -o $@
+	$(CHARMC) -language ampi -DAMPI_USE_FUNCPTR -DAMPI_NO_UNIMPLEMENTED_WARNINGS -fPIE -shared -fvisibility=hidden -c $< -o $@
 
 $(FUNCPTR_SHIM_MAIN_OBJ): ampi_funcptr_shim_main.C | $(ROMIO)
 	$(CHARMC) -language ampi -fPIE -c $< -o $@
@@ -211,7 +212,7 @@ $(FUNCPTR_SHIM_FORTRAN_OBJ): ampif.C $(HEADDEP) headers | $(ROMIO)
 	$(CHARMC) -language ampi -DAMPI_USE_FUNCPTR -fPIE -shared -fvisibility=hidden -c $< -o $@
 
 $(FUNCPTR_LOADER_OBJ): ampi_funcptr_loader.C $(HEADDEP) headers | $(ROMIO)
-	$(CHARMC) -language ampi -c $< -o $@
+	$(CHARMC) -language ampi -DAMPI_NO_UNIMPLEMENTED_WARNINGS -c $< -o $@
 
 $(FUNCPTR_LOADER_STUB_OBJ): ampi_funcptr_loader_stub.C $(HEADDEP) headers | $(ROMIO)
 	$(CHARMC) -language ampi -c $< -o $@


### PR DESCRIPTION
Fixes warning spam seen with ICC.