### PR TITLE
Fix rare bug seen in ZC EM Post API examples

### DIFF
--- a/examples/charm++/zerocopy/entry_method_post_api/prereg/simpleZeroCopy/simpleZeroCopy.C
+++ b/examples/charm++/zerocopy/entry_method_post_api/prereg/simpleZeroCopy/simpleZeroCopy.C
@@ -8,6 +8,7 @@
 #define TOTAL_ITER    40
 
 int numElements;
+CProxy_Main mProxy;
 
 //Main chare
 class Main : public CBase_Main{
@@ -17,7 +18,10 @@ class Main : public CBase_Main{
         ckout<<"Usage: zerocopy <numelements>"<<endl;
         CkExit(1);
       }
+
       numElements = atoi(m->argv[1]);
+      mProxy = thisProxy;
+
       delete m;
       if(numElements%2 != 0){
         ckout<<"Argument <numelements> should be even"<<endl;
@@ -27,7 +31,7 @@ class Main : public CBase_Main{
       CProxy_RRMap rrMap = CProxy_RRMap::ckNew();
       CkArrayOptions opts(numElements);
       opts.setMap(rrMap);
-      CProxy_zerocopyObject zerocopyObj = CProxy_zerocopyObject::ckNew(thisProxy, opts);
+      CProxy_zerocopyObject zerocopyObj = CProxy_zerocopyObject::ckNew(opts);
     }
 
     void done(){
@@ -80,7 +84,6 @@ class zerocopyObject : public CBase_zerocopyObject{
   bool firstMigrationPending;
   CkCallback cb, sdagCb, cbCopy, compReductionCb, lbReductionCb;
   int idx_zerocopySent, idx_sdagZeroCopySent;;
-  CProxy_Main mainProxy;
 
   public:
     zerocopyObject_SDAG_CODE
@@ -109,7 +112,7 @@ class zerocopyObject : public CBase_zerocopyObject{
       idx_sdagZeroCopySent = CkIndex_zerocopyObject::sdagZeroCopySent(NULL);
       cb = CkCallback(idx_zerocopySent, thisProxy[thisIndex]);
       sdagCb = CkCallback(idx_sdagZeroCopySent, thisProxy[thisIndex]);
-      compReductionCb = CkCallback(CkReductionTarget(Main, done), mainProxy);
+      compReductionCb = CkCallback(CkReductionTarget(Main, done), mProxy);
       lbReductionCb = CkCallback(CkReductionTarget(zerocopyObject, BarrierDone), thisProxy);
 
       testZeroCopy();
@@ -125,7 +128,6 @@ class zerocopyObject : public CBase_zerocopyObject{
       p|mixedZeroCopySentCounter;
       p|sdagZeroCopySentCounter;
       p|sdagZeroCopyRecvCounter;
-      p|mainProxy;
       p|sdagCb;
       p|compReductionCb;
       p|lbReductionCb;

--- a/examples/charm++/zerocopy/entry_method_post_api/prereg/simpleZeroCopy/simpleZeroCopy.C
+++ b/examples/charm++/zerocopy/entry_method_post_api/prereg/simpleZeroCopy/simpleZeroCopy.C
@@ -27,8 +27,7 @@ class Main : public CBase_Main{
       CProxy_RRMap rrMap = CProxy_RRMap::ckNew();
       CkArrayOptions opts(numElements);
       opts.setMap(rrMap);
-      CProxy_zerocopyObject zerocopyObj = CProxy_zerocopyObject::ckNew(opts);
-      zerocopyObj.testZeroCopy(thisProxy);
+      CProxy_zerocopyObject zerocopyObj = CProxy_zerocopyObject::ckNew(thisProxy, opts);
     }
 
     void done(){
@@ -112,6 +111,8 @@ class zerocopyObject : public CBase_zerocopyObject{
       sdagCb = CkCallback(idx_sdagZeroCopySent, thisProxy[thisIndex]);
       compReductionCb = CkCallback(CkReductionTarget(Main, done), mainProxy);
       lbReductionCb = CkCallback(CkReductionTarget(zerocopyObject, BarrierDone), thisProxy);
+
+      testZeroCopy();
     }
 
     void pup(PUP::er &p){
@@ -192,14 +193,13 @@ class zerocopyObject : public CBase_zerocopyObject{
         nextStep();
     }
 
-    void testZeroCopy(CProxy_Main mProxy){
+    void testZeroCopy(){
       iSize1 = 210;
       iSize2 = 11;
       dSize1 = 4700;
       dSize2 = 79;
       cSize1 = 32;
 
-      mainProxy = mProxy;
       if(thisIndex < numElements/2){
         assignValues(iArr1, iSize1);
         assignValues(iArr2, iSize2);

--- a/examples/charm++/zerocopy/entry_method_post_api/prereg/simpleZeroCopy/simpleZeroCopy.ci
+++ b/examples/charm++/zerocopy/entry_method_post_api/prereg/simpleZeroCopy/simpleZeroCopy.ci
@@ -1,6 +1,7 @@
 mainmodule simpleZeroCopy {
 
   readonly int numElements;
+  readonly CProxy_Main mProxy;
 
   mainchare Main {
     entry Main(CkArgMsg *m);
@@ -8,7 +9,7 @@ mainmodule simpleZeroCopy {
   };
 
   array [1D] zerocopyObject{
-    entry zerocopyObject(CProxy_Main mProxy);
+    entry zerocopyObject();
     entry void ResumeFromSync();
     entry void zerocopySent(CkDataMsg *msg);
     entry void send(int n1, int ptr1[n1], int n2, double ptr2[n2], int n3, char ptr3[n3]);

--- a/examples/charm++/zerocopy/entry_method_post_api/prereg/simpleZeroCopy/simpleZeroCopy.ci
+++ b/examples/charm++/zerocopy/entry_method_post_api/prereg/simpleZeroCopy/simpleZeroCopy.ci
@@ -8,8 +8,7 @@ mainmodule simpleZeroCopy {
   };
 
   array [1D] zerocopyObject{
-    entry zerocopyObject();
-    entry void testZeroCopy(CProxy_Main mProxy);
+    entry zerocopyObject(CProxy_Main mProxy);
     entry void ResumeFromSync();
     entry void zerocopySent(CkDataMsg *msg);
     entry void send(int n1, int ptr1[n1], int n2, double ptr2[n2], int n3, char ptr3[n3]);

--- a/examples/charm++/zerocopy/entry_method_post_api/reg/simpleZeroCopy/simpleZeroCopy.C
+++ b/examples/charm++/zerocopy/entry_method_post_api/reg/simpleZeroCopy/simpleZeroCopy.C
@@ -27,8 +27,7 @@ class Main : public CBase_Main{
       CProxy_RRMap rrMap = CProxy_RRMap::ckNew();
       CkArrayOptions opts(numElements);
       opts.setMap(rrMap);
-      CProxy_zerocopyObject zerocopyObj = CProxy_zerocopyObject::ckNew(opts);
-      zerocopyObj.testZeroCopy(thisProxy);
+      CProxy_zerocopyObject zerocopyObj = CProxy_zerocopyObject::ckNew(thisProxy, opts);
     }
 
     void done(){
@@ -111,6 +110,8 @@ class zerocopyObject : public CBase_zerocopyObject{
       sdagCb = CkCallback(idx_sdagZeroCopySent, thisProxy[thisIndex]);
       compReductionCb = CkCallback(CkReductionTarget(Main, done), mainProxy);
       lbReductionCb = CkCallback(CkReductionTarget(zerocopyObject, BarrierDone), thisProxy);
+
+      testZeroCopy();
     }
 
     void pup(PUP::er &p){
@@ -196,7 +197,7 @@ class zerocopyObject : public CBase_zerocopyObject{
         nextStep();
     }
 
-    void testZeroCopy(CProxy_Main mProxy){
+    void testZeroCopy(){
       iSize1 = 210;
       iSize2 = 11;
       dSize1 = 4700;
@@ -206,7 +207,6 @@ class zerocopyObject : public CBase_zerocopyObject{
       iOffset1 = 3;
       cOffset1 = 2;
 
-      mainProxy = mProxy;
       if(thisIndex < numElements/2){
         assignValues(iArr1, iSize1);
         assignValues(iArr2, iSize2);

--- a/examples/charm++/zerocopy/entry_method_post_api/reg/simpleZeroCopy/simpleZeroCopy.C
+++ b/examples/charm++/zerocopy/entry_method_post_api/reg/simpleZeroCopy/simpleZeroCopy.C
@@ -8,6 +8,7 @@
 #define TOTAL_ITER    40
 
 int numElements;
+CProxy_Main mProxy;
 
 //Main chare
 class Main : public CBase_Main{
@@ -17,7 +18,10 @@ class Main : public CBase_Main{
         ckout<<"Usage: zerocopy <numelements>"<<endl;
         CkExit(1);
       }
+
       numElements = atoi(m->argv[1]);
+      mProxy = thisProxy;
+
       delete m;
       if(numElements%2 != 0){
         ckout<<"Argument <numelements> should be even"<<endl;
@@ -27,7 +31,7 @@ class Main : public CBase_Main{
       CProxy_RRMap rrMap = CProxy_RRMap::ckNew();
       CkArrayOptions opts(numElements);
       opts.setMap(rrMap);
-      CProxy_zerocopyObject zerocopyObj = CProxy_zerocopyObject::ckNew(thisProxy, opts);
+      CProxy_zerocopyObject zerocopyObj = CProxy_zerocopyObject::ckNew(opts);
     }
 
     void done(){
@@ -78,7 +82,6 @@ class zerocopyObject : public CBase_zerocopyObject{
   bool firstMigrationPending;
   CkCallback cb, sdagCb, cbCopy, compReductionCb, lbReductionCb;
   int idx_zerocopySent, idx_sdagZeroCopySent;;
-  CProxy_Main mainProxy;
 
   public:
     zerocopyObject_SDAG_CODE
@@ -108,7 +111,7 @@ class zerocopyObject : public CBase_zerocopyObject{
       cb = CkCallback(idx_zerocopySent, thisProxy[thisIndex]);
       cbCopy = cb;
       sdagCb = CkCallback(idx_sdagZeroCopySent, thisProxy[thisIndex]);
-      compReductionCb = CkCallback(CkReductionTarget(Main, done), mainProxy);
+      compReductionCb = CkCallback(CkReductionTarget(Main, done), mProxy);
       lbReductionCb = CkCallback(CkReductionTarget(zerocopyObject, BarrierDone), thisProxy);
 
       testZeroCopy();
@@ -124,7 +127,6 @@ class zerocopyObject : public CBase_zerocopyObject{
       p|mixedZeroCopySentCounter;
       p|sdagZeroCopySentCounter;
       p|sdagZeroCopyRecvCounter;
-      p|mainProxy;
       p|sdagCb;
       p|compReductionCb;
       p|lbReductionCb;

--- a/examples/charm++/zerocopy/entry_method_post_api/reg/simpleZeroCopy/simpleZeroCopy.ci
+++ b/examples/charm++/zerocopy/entry_method_post_api/reg/simpleZeroCopy/simpleZeroCopy.ci
@@ -1,6 +1,7 @@
 mainmodule simpleZeroCopy {
 
   readonly int numElements;
+  readonly CProxy_Main mProxy;
 
   mainchare Main {
     entry Main(CkArgMsg *m);
@@ -8,7 +9,7 @@ mainmodule simpleZeroCopy {
   };
 
   array [1D] zerocopyObject{
-    entry zerocopyObject(CProxy_Main mProxy);
+    entry zerocopyObject();
     entry void ResumeFromSync();
     entry void zerocopySent(CkDataMsg *msg);
     entry void send(int n1, int ptr1[n1], int n2, double ptr2[n2], int n3, char ptr3[n3]);

--- a/examples/charm++/zerocopy/entry_method_post_api/reg/simpleZeroCopy/simpleZeroCopy.ci
+++ b/examples/charm++/zerocopy/entry_method_post_api/reg/simpleZeroCopy/simpleZeroCopy.ci
@@ -8,8 +8,7 @@ mainmodule simpleZeroCopy {
   };
 
   array [1D] zerocopyObject{
-    entry zerocopyObject();
-    entry void testZeroCopy(CProxy_Main mProxy);
+    entry zerocopyObject(CProxy_Main mProxy);
     entry void ResumeFromSync();
     entry void zerocopySent(CkDataMsg *msg);
     entry void send(int n1, int ptr1[n1], int n2, double ptr2[n2], int n3, char ptr3[n3]);

--- a/examples/charm++/zerocopy/entry_method_post_api/unreg/simpleZeroCopy/simpleZeroCopy.C
+++ b/examples/charm++/zerocopy/entry_method_post_api/unreg/simpleZeroCopy/simpleZeroCopy.C
@@ -27,8 +27,7 @@ class Main : public CBase_Main{
       CProxy_RRMap rrMap = CProxy_RRMap::ckNew();
       CkArrayOptions opts(numElements);
       opts.setMap(rrMap);
-      CProxy_zerocopyObject zerocopyObj = CProxy_zerocopyObject::ckNew(opts);
-      zerocopyObj.testZeroCopy(thisProxy);
+      CProxy_zerocopyObject zerocopyObj = CProxy_zerocopyObject::ckNew(thisProxy, opts);
     }
 
     void done(){
@@ -113,6 +112,8 @@ class zerocopyObject : public CBase_zerocopyObject{
       sdagCb = CkCallback(idx_sdagZeroCopySent, thisProxy[thisIndex]);
       compReductionCb = CkCallback(CkReductionTarget(Main, done), mainProxy);
       lbReductionCb = CkCallback(CkReductionTarget(zerocopyObject, BarrierDone), thisProxy);
+
+      testZeroCopy();
     }
 
     void pup(PUP::er &p){
@@ -198,7 +199,7 @@ class zerocopyObject : public CBase_zerocopyObject{
         nextStep();
     }
 
-    void testZeroCopy(CProxy_Main mProxy){
+    void testZeroCopy(){
       iSize1 = 210;
       iSize2 = 11;
       dSize1 = 4700;
@@ -208,7 +209,6 @@ class zerocopyObject : public CBase_zerocopyObject{
       iOffset1 = 3;
       cOffset1 = 2;
 
-      mainProxy = mProxy;
       if(thisIndex < numElements/2){
         assignValues(iArr1, iSize1);
         assignValues(iArr2, iSize2);

--- a/examples/charm++/zerocopy/entry_method_post_api/unreg/simpleZeroCopy/simpleZeroCopy.C
+++ b/examples/charm++/zerocopy/entry_method_post_api/unreg/simpleZeroCopy/simpleZeroCopy.C
@@ -8,6 +8,7 @@
 #define TOTAL_ITER    40
 
 int numElements;
+CProxy_Main mProxy;
 
 //Main chare
 class Main : public CBase_Main{
@@ -17,7 +18,10 @@ class Main : public CBase_Main{
         ckout<<"Usage: zerocopy <numelements>"<<endl;
         CkExit(1);
       }
+
       numElements = atoi(m->argv[1]);
+      mProxy = thisProxy;
+
       delete m;
       if(numElements%2 != 0){
         ckout<<"Argument <numelements> should be even"<<endl;
@@ -27,7 +31,7 @@ class Main : public CBase_Main{
       CProxy_RRMap rrMap = CProxy_RRMap::ckNew();
       CkArrayOptions opts(numElements);
       opts.setMap(rrMap);
-      CProxy_zerocopyObject zerocopyObj = CProxy_zerocopyObject::ckNew(thisProxy, opts);
+      CProxy_zerocopyObject zerocopyObj = CProxy_zerocopyObject::ckNew(opts);
     }
 
     void done(){
@@ -80,7 +84,6 @@ class zerocopyObject : public CBase_zerocopyObject{
   bool firstMigrationPending;
   CkCallback cb, sdagCb, cbCopy, compReductionCb, lbReductionCb;
   int idx_zerocopySent, idx_sdagZeroCopySent;;
-  CProxy_Main mainProxy;
 
   public:
     zerocopyObject_SDAG_CODE
@@ -110,7 +113,7 @@ class zerocopyObject : public CBase_zerocopyObject{
       cb = CkCallback(idx_zerocopySent, thisProxy[thisIndex]);
       cbCopy = cb;
       sdagCb = CkCallback(idx_sdagZeroCopySent, thisProxy[thisIndex]);
-      compReductionCb = CkCallback(CkReductionTarget(Main, done), mainProxy);
+      compReductionCb = CkCallback(CkReductionTarget(Main, done), mProxy);
       lbReductionCb = CkCallback(CkReductionTarget(zerocopyObject, BarrierDone), thisProxy);
 
       testZeroCopy();
@@ -126,7 +129,6 @@ class zerocopyObject : public CBase_zerocopyObject{
       p|mixedZeroCopySentCounter;
       p|sdagZeroCopySentCounter;
       p|sdagZeroCopyRecvCounter;
-      p|mainProxy;
       p|sdagCb;
       p|compReductionCb;
       p|lbReductionCb;

--- a/examples/charm++/zerocopy/entry_method_post_api/unreg/simpleZeroCopy/simpleZeroCopy.ci
+++ b/examples/charm++/zerocopy/entry_method_post_api/unreg/simpleZeroCopy/simpleZeroCopy.ci
@@ -1,6 +1,7 @@
 mainmodule simpleZeroCopy {
 
   readonly int numElements;
+  readonly CProxy_Main mProxy;
 
   mainchare Main {
     entry Main(CkArgMsg *m);
@@ -8,7 +9,7 @@ mainmodule simpleZeroCopy {
   };
 
   array [1D] zerocopyObject{
-    entry zerocopyObject(CProxy_Main mProxy);
+    entry zerocopyObject();
     entry void ResumeFromSync();
     entry void zerocopySent(CkDataMsg *msg);
     entry void send(int n1, int ptr1[n1], int n2, double ptr2[n2], int n3, char ptr3[n3]);

--- a/examples/charm++/zerocopy/entry_method_post_api/unreg/simpleZeroCopy/simpleZeroCopy.ci
+++ b/examples/charm++/zerocopy/entry_method_post_api/unreg/simpleZeroCopy/simpleZeroCopy.ci
@@ -8,8 +8,7 @@ mainmodule simpleZeroCopy {
   };
 
   array [1D] zerocopyObject{
-    entry zerocopyObject();
-    entry void testZeroCopy(CProxy_Main mProxy);
+    entry zerocopyObject(CProxy_Main mProxy);
     entry void ResumeFromSync();
     entry void zerocopySent(CkDataMsg *msg);
     entry void send(int n1, int ptr1[n1], int n2, double ptr2[n2], int n3, char ptr3[n3]);


### PR DESCRIPTION
The bug was causing a segfault because of the execution of the POST
entry method before the allocation of the receive buffers. This was
happening because the allocation was not happening in the object's
constructor. The fix involved moving the allocation of receive buffers to the
constructor of the object. This ensures that the buffers are
allocated before the POST entry method executes.