### PR TITLE
Add refnum with CkCallback example that hangs

### DIFF
--- a/examples/charm++/refnum/Makefile
+++ b/examples/charm++/refnum/Makefile
@@ -1,0 +1,17 @@
+CHARMC = ../../../bin/charmc $(OPTS)
+
+all: test
+
+test: test.o
+	$(CHARMC) -language charm++ -o $@ $^
+
+test.def.h: test.ci
+	$(CHARMC) $<
+
+test.decl.h: test.ci
+
+test.o: test.C test.decl.h test.def.h
+	$(CHARMC) -c $<
+
+clean:
+	rm -f test *.decl.h *.def.h *.o charmrun

--- a/examples/charm++/refnum/test.C
+++ b/examples/charm++/refnum/test.C
@@ -1,0 +1,36 @@
+#include "test.decl.h"
+
+/* readonly */ CProxy_Main main_proxy;
+/* readonly */ CProxy_Array1 array1_proxy;
+
+class Main : public CBase_Main {
+public:
+  Main(CkArgMsg* args) {
+    array1_proxy = CProxy_Array1::ckNew(4);
+    array1_proxy.foo();
+  }
+
+  void done() {
+    CkExit();
+  }
+};
+
+class Array1 : public CBase_Array1 {
+  Array1_SDAG_CODE
+
+public:
+  int iter;
+  CkCallback cb;
+
+  Array1() {
+    iter = 0;
+    cb = CkCallback(CkIndex_Array1::recv(), thisProxy[thisIndex]);
+  }
+
+  void send() {
+    cb.setRefnum(iter);
+    cb.send();
+  }
+};
+
+#include "test.def.h"

--- a/examples/charm++/refnum/test.ci
+++ b/examples/charm++/refnum/test.ci
@@ -1,0 +1,29 @@
+mainmodule test {
+  readonly CProxy_Main main_proxy;
+  readonly CProxy_Array1 array1_proxy;
+
+  mainchare Main {
+    entry Main(CkArgMsg* args);
+    entry [reductiontarget] void done();
+  };
+
+  array [1d] Array1 {
+    entry Array1();
+    entry void foo() {
+      for (; iter < 100; iter++) {
+        serial {
+          send();
+        }
+
+        when recv[iter]() serial {
+          CkPrintf("[%d] recv for iter %d\n", thisIndex, iter);
+        }
+      }
+
+      serial {
+        contribute(CkCallback(CkReductionTarget(Main, done), main_proxy));
+      }
+    }
+    entry void recv();
+  };
+};


### PR DESCRIPTION
Test command: `jsrun -n2 -a1 -c1 -g1 ./test +ppn 1 +pemap L0,4`

Hangs with both `pamilrts-linux-ppc64le-smp` and `netlrts-linux-ppc64le-smp` on OLCF Summit.