### PR TITLE
ZC Bcast API: Fix bug seen in smp mode with 2 level bcast

### DIFF
--- a/src/arch/util/machine-broadcast.C
+++ b/src/arch/util/machine-broadcast.C
@@ -115,6 +115,7 @@ void CmiForwardProcBcastMsg(int size, char *msg) {
 #if CMK_SMP
 // API to forward message to peer PEs
 void CmiForwardMsgToPeers(int size, char *msg) {
+  CMI_DEST_RANK(msg) = CmiMyRank(); // Reset DEST RANK before forwarding to peers
   SendToPeers(size, msg);
 }
 #endif


### PR DESCRIPTION
The bug is seen as a crash on the child node when it tries to forward the
message to its peer PEs after receiving a bcast message forwarded by an
an intermediate root node. The bug was caused by an incorrect CMI_DEST_RANK
and the fix was to reset this on the child node before forwarding it to peers.