### PR TITLE
Migrate AtSync barrier refcount

### DIFF
--- a/src/ck-core/ckmigratable.h
+++ b/src/ck-core/ckmigratable.h
@@ -103,7 +103,7 @@ private:
   void ResumeFromSyncHelper();
 public:
   void ReadyMigrate(bool ready);
-  void ckFinishConstruction(int refcount = -1);
+  void ckFinishConstruction(int epoch = -1);
   void setMigratable(int migratable);
   void setPupSize(size_t obj_pup_size);
 #else
@@ -111,7 +111,7 @@ public:
   void setMigratable(int migratable)  { }
   void setPupSize(size_t obj_pup_size) { }
 public:
-  void ckFinishConstruction(int refcount) { }
+  void ckFinishConstruction(int epoch) { }
 #endif
 
 #if CMK_OUT_OF_CORE

--- a/src/ck-core/ckmigratable.h
+++ b/src/ck-core/ckmigratable.h
@@ -103,7 +103,7 @@ private:
   void ResumeFromSyncHelper();
 public:
   void ReadyMigrate(bool ready);
-  void ckFinishConstruction(void);
+  void ckFinishConstruction(int refcount = -1);
   void setMigratable(int migratable);
   void setPupSize(size_t obj_pup_size);
 #else
@@ -111,7 +111,7 @@ public:
   void setMigratable(int migratable)  { }
   void setPupSize(size_t obj_pup_size) { }
 public:
-  void ckFinishConstruction(void) { }
+  void ckFinishConstruction(int refcount) { }
 #endif
 
 #if CMK_OUT_OF_CORE

--- a/src/ck-core/cksyncbarrier.ci
+++ b/src/ck-core/cksyncbarrier.ci
@@ -9,6 +9,7 @@ module CkSyncBarrier {
     entry void CkSyncBarrier(void);
     entry void ResumeClients();
     entry void recvLbStart(int lb_step, int sourcenode, int pe);
+    entry void CheckBarrier(bool flood_atsync);
   };
 
 };

--- a/src/ck-core/cksyncbarrier.h
+++ b/src/ck-core/cksyncbarrier.h
@@ -13,6 +13,28 @@ public:
   CkSyncBarrierInit(CkMigrateMessage* m) : Chare(m) {}
 };
 
+class LBClient
+{
+public:
+  Chare* chare;
+  std::function<void()> fn;
+  int refcount;
+
+  LBClient(Chare* chare, std::function<void()> fn, int refcount)
+      : chare(chare), fn(fn), refcount(refcount)
+  {
+  }
+};
+
+class LBReceiver
+{
+public:
+  std::function<void()> fn;
+  int on;
+
+  LBReceiver(std::function<void()> fn, int on = 1) : fn(fn), on(on) {}
+};
+
 CkpvExtern(bool, cksyncbarrierInited);
 
 class CkSyncBarrier : public CBase_CkSyncBarrier
@@ -54,7 +76,6 @@ private:
   void propagate_atsync();
   void reset();
   void CallReceivers(void);
-  void CheckBarrier(bool flood_atsync = false);
 
 public:
   CkSyncBarrier() { init(); };
@@ -69,11 +90,24 @@ public:
                                            : nullptr;
   }
 
+  void CheckBarrier(bool flood_atsync = false);
   void recvLbStart(int lb_step, int sourcenode, int pe);
 
-  LDBarrierClient AddClient(Chare* chare, std::function<void()> fn);
+  LDBarrierClient AddClient(Chare* chare, std::function<void()> fn, int refcount = -1);
+  template <typename T>
+  inline LDBarrierClient AddClient(T* obj, void (T::*method)(void), int refcount = -1)
+  {
+    return AddClient((Chare*)obj, std::bind(method, obj), refcount);
+  }
+
   void RemoveClient(LDBarrierClient h);
   LDBarrierReceiver AddReceiver(std::function<void()> fn);
+  template <typename T>
+  inline LDBarrierReceiver AddReceiver(T* obj, void (T::*method)(void))
+  {
+    return AddReceiver(std::bind(method, obj));
+  }
+
   void RemoveReceiver(LDBarrierReceiver h);
   void TurnOnReceiver(LDBarrierReceiver h);
   void TurnOffReceiver(LDBarrierReceiver h);

--- a/src/ck-core/cksyncbarrier.h
+++ b/src/ck-core/cksyncbarrier.h
@@ -18,10 +18,10 @@ class LBClient
 public:
   Chare* chare;
   std::function<void()> fn;
-  int refcount;
+  int epoch;
 
-  LBClient(Chare* chare, std::function<void()> fn, int refcount)
-      : chare(chare), fn(fn), refcount(refcount)
+  LBClient(Chare* chare, std::function<void()> fn, int epoch)
+      : chare(chare), fn(fn), epoch(epoch)
   {
   }
 };
@@ -45,7 +45,7 @@ private:
 
   std::vector<bool> rank_needs_flood;
 
-  int cur_refcount;
+  int cur_epoch;
   int at_count;
   bool on;
   bool rank0pe;
@@ -59,7 +59,7 @@ private:
   void init()
   {
     CkpvAccess(cksyncbarrierInited) = true;
-    cur_refcount = 1;
+    cur_epoch = 1;
     iter_no = -1;
     propagated_atsync_step = 0;
     at_count = 0;
@@ -93,11 +93,11 @@ public:
   void CheckBarrier(bool flood_atsync = false);
   void recvLbStart(int lb_step, int sourcenode, int pe);
 
-  LDBarrierClient AddClient(Chare* chare, std::function<void()> fn, int refcount = -1);
+  LDBarrierClient AddClient(Chare* chare, std::function<void()> fn, int epoch = -1);
   template <typename T>
-  inline LDBarrierClient AddClient(T* obj, void (T::*method)(void), int refcount = -1)
+  inline LDBarrierClient AddClient(T* obj, void (T::*method)(void), int epoch = -1)
   {
-    return AddClient((Chare*)obj, std::bind(method, obj), refcount);
+    return AddClient((Chare*)obj, std::bind(method, obj), epoch);
   }
 
   void RemoveClient(LDBarrierClient h);


### PR DESCRIPTION
Fixes race condition where CkMigratable calls AtSync before migrating, causing a hang on destination PE.