### PR TITLE
LB: Remove typedef for structs in lbdb.h

### DIFF
--- a/src/ck-ldb/lbdb.h
+++ b/src/ck-ldb/lbdb.h
@@ -36,44 +36,44 @@ extern int _lb_version;
   /*  as OBJ_ID_SZ */
 
 #if CMK_LBDB_ON
-typedef struct {
+struct LDHandle {
   void *handle;            // pointer to LBDB
-} LDHandle;
+};
 #else
 typedef int LDHandle;
 #endif
 
-typedef struct _LDOMid {
+struct LDOMid {
   CkGroupID id;
-  bool operator==(const struct _LDOMid& omId) const {
+  bool operator==(const LDOMid& omId) const {
     return id == omId.id?true:false;
   }
-  bool operator<(const struct _LDOMid& omId) const {
+  bool operator<(const LDOMid& omId) const {
     return id < omId.id?true:false;
   }
-  bool operator!=(const struct _LDOMid& omId) const {
+  bool operator!=(const LDOMid& omId) const {
     return id == omId.id?false:true;
   }
   inline void pup(PUP::er &p);
-} LDOMid;
+};
 
-typedef struct {
+struct LDOMHandle {
 //  void *user_ptr;
   LDOMid id;
   int handle;		// index to LBOM
   inline void pup(PUP::er &p);
-} LDOMHandle;
+};
 
 /* LDObjKey uniquely identify one object */
-typedef struct _LDObjKey {
+struct LDObjKey {
   /// Id of the location manager for this object
   LDOMid omId;
   CmiUInt8 objId;
 public:
-  bool operator==(const _LDObjKey& obj) const {
+  bool operator==(const LDObjKey& obj) const {
     return (bool)(omId == obj.omId && objId == obj.objId);
   }
-  bool operator<(const _LDObjKey& obj) const {
+  bool operator<(const LDObjKey& obj) const {
     if (omId < obj.omId) return true;
     else if (omId == obj.omId) return objId < obj.objId;
     else return false;
@@ -83,19 +83,19 @@ public:
   inline const LDOMid &omID() const { return omId; }
   inline const CmiUInt8 &objID() const { return objId; }
   inline void pup(PUP::er &p);
-} LDObjKey;
+};
 
 typedef int LDObjIndex;
 typedef int LDOMIndex;
 
-typedef struct {
+struct LDObjHandle {
   LDOMHandle omhandle;
   CmiUInt8 id;
   LDObjIndex  handle;
   inline const LDOMid &omID() const { return omhandle.id; }
   inline const CmiUInt8 &objID() const { return id; }
   inline void pup(PUP::er &p);
-} LDObjHandle;
+};
 
 /* defines user data layout  */
 class LBUserDataLayout {
@@ -145,7 +145,7 @@ private:
   inline void init() { data = new char[CkpvAccess(lbobjdatalayout).size()]; }
 };
 
-typedef struct {
+struct LDObjData {
   LDObjHandle handle;
   LBRealType wallTime;
 #if CMK_LB_CPUTIMER
@@ -170,22 +170,22 @@ typedef struct {
 #if CMK_LB_USER_DATA
   void* getUserData(int idx)  { return userData.getData(idx); }
 #endif
-} LDObjData;
+};
 
 /* used by load balancer */
-typedef struct {
+struct LDObjStats {
   int index;
   LDObjData data;
   int from_proc;
   int to_proc;
   inline void pup(PUP::er &p);
-} LDObjStats;
+};
 
 #define LD_PROC_MSG      1
 #define LD_OBJ_MSG       2
 #define LD_OBJLIST_MSG   3
 
-typedef struct _LDCommDesc {
+struct LDCommDesc {
   char type;
   union {
     int destProc;		/* 1:   processor level message */
@@ -228,19 +228,19 @@ typedef struct _LDCommDesc {
   	  dest.destObjs.objs[i].objID() =objid[i];
 	}
   }
-  inline bool operator==(const _LDCommDesc &obj) const;
-  inline _LDCommDesc &operator=(const _LDCommDesc &c);
+  inline bool operator==(const LDCommDesc &obj) const;
+  inline LDCommDesc &operator=(const LDCommDesc &c);
   inline void pup(PUP::er &p);
-} LDCommDesc;
+};
 
-typedef struct _LDCommData {
+struct LDCommData {
   int src_proc;			// sender can either be a proc or an obj
   LDObjKey  sender;		// 
   LDCommDesc   receiver;
   int  sendHash, recvHash;
   int messages;
   int bytes;
-  inline _LDCommData &operator=(const _LDCommData &o) {
+  inline LDCommData &operator=(const LDCommData &o) {
     if (&o == this) return *this;
     src_proc = o.src_proc;
     sender = o.sender; receiver = o.receiver;
@@ -253,7 +253,7 @@ typedef struct _LDCommData {
   inline int recv_type() const { return receiver.get_type(); }
   inline void pup(PUP::er &p);
   inline void clearHash() { sendHash = recvHash = -1; }
-} LDCommData;
+};
 
 /*
  * Callbacks from database to object managers
@@ -264,13 +264,13 @@ typedef void (*LDQueryEstLoadFn)(LDOMHandle h);
 typedef void (*LDMetaLBResumeWaitingCharesFn) (LDObjHandle handle, int lb_ideal_period);
 typedef void (*LDMetaLBCallLBOnCharesFn) (LDObjHandle handle);
 
-typedef struct {
+struct LDCallbacks {
   LDMigrateFn migrate;
   LDStatsFn setStats;
   LDQueryEstLoadFn queryEstLoad;
   LDMetaLBResumeWaitingCharesFn metaLBResumeWaitingChares;
   LDMetaLBCallLBOnCharesFn metaLBCallLBOnChares;
-} LDCallbacks;
+};
 
 /*
  * Local Barrier calls


### PR DESCRIPTION
Pursuant to P1766R1 <http://wg21.link/p1766r1>, remove typedef name
for linkage on non-C compatible structs.

Clang 11 warns about this, this patch fixes those warnings.