### PR TITLE
unix2nt_cc: Implement -fno-stack-protector and update comments

### DIFF
--- a/cmake/detect-features-cxx.cmake
+++ b/cmake/detect-features-cxx.cmake
@@ -20,17 +20,20 @@ check_cxx_compiler_flag("-mno-tls-direct-seg-refs" CMK_COMPILER_KNOWS_TLSDIRECTS
 
 check_cxx_compiler_flag("-fvisibility=hidden" CMK_COMPILER_KNOWS_FVISIBILITY)
 
+# Needed to avoid migratable threads failing the stack check
 check_cxx_compiler_flag("-fno-stack-protector" CMK_COMPILER_KNOWS_FNOSTACKPROTECTOR)
 if(${CMK_COMPILER_KNOWS_FNOSTACKPROTECTOR})
   set(OPTS_CC "${OPTS_CC} -fno-stack-protector")
   set(OPTS_CXX "${OPTS_CXX} -fno-stack-protector")
 endif()
 
+# Workaround for bug #1045 appearing in GCC >6.x
 check_cxx_compiler_flag("-fno-lifetime-dse" CMK_COMPILER_KNOWS_LIFETIMEDSE)
 if(${CMK_COMPILER_KNOWS_LIFETIMEDSE})
   set(OPTS_CXX "${OPTS_CXX} -fno-lifetime-dse")
 endif()
 
+# Allow seeing own symbols dynamically, needed for programmatic backtraces
 check_cxx_compiler_flag("-rdynamic" CMK_COMPILER_KNOWS_RDYNAMIC)
 check_cxx_compiler_flag("-Wl,--export-dynamic" CMK_LINKER_KNOWS_EXPORT_DYNAMIC)
 if(${CMK_COMPILER_KNOWS_RDYNAMIC})

--- a/cmake/detect-features-cxx.cmake
+++ b/cmake/detect-features-cxx.cmake
@@ -21,6 +21,7 @@ check_cxx_compiler_flag("-mno-tls-direct-seg-refs" CMK_COMPILER_KNOWS_TLSDIRECTS
 check_cxx_compiler_flag("-fvisibility=hidden" CMK_COMPILER_KNOWS_FVISIBILITY)
 
 # Needed to avoid migratable threads failing the stack check
+# See https://github.com/UIUC-PPL/charm/pull/3174 for details.
 check_cxx_compiler_flag("-fno-stack-protector" CMK_COMPILER_KNOWS_FNOSTACKPROTECTOR)
 if(${CMK_COMPILER_KNOWS_FNOSTACKPROTECTOR})
   set(OPTS_CC "${OPTS_CC} -fno-stack-protector")

--- a/src/arch/win/unix2nt_cc
+++ b/src/arch/win/unix2nt_cc
@@ -363,9 +363,8 @@ do
 		LINK+=" $base.o"
 		DOCOMPILE='1'
 		;;
-	'-fno-stack-protector')
+	-fno-stack-protector)
 		CL_OPTS+=" -GS-"
-		shift
 		;;
 	'-fno-lifetime-dse'|'-rdynamic'|'-Wl,--export-dynamic'|'-fvisibility=hidden'|'-Wl,-undefined,dynamic_lookup')
 		# Error out so configure knows not to pass us these arguments, avoiding the below warning.

--- a/src/arch/win/unix2nt_cc
+++ b/src/arch/win/unix2nt_cc
@@ -44,7 +44,7 @@ fi
 CL_CMD='CL.EXE'
 # Define NOMINMAX to avoid definition of unexpected min(a,b) and max(a,b)
 # macros,per http://support.microsoft.com/kb/143208
-CL_COMMON='-nologo -W1 -EHsc -D_WINDOWS -DNOMINMAX -GS-'
+CL_COMMON='-nologo -W1 -EHsc -D_WINDOWS -DNOMINMAX'
 # CL_COMMON+=" -I`cygpath -d \"$SDK_DIR/Include\"`"
 # CL_COMMON+=" -I`cygpath -d \"$VCC_DIR/Include\"`"
 CL_MT='-MT'
@@ -362,6 +362,10 @@ do
 #		OUTPUT="-Fo$base.o"
 		LINK+=" $base.o"
 		DOCOMPILE='1'
+		;;
+	'-fno-stack-protector')
+		CL_OPTS+=" -GS-"
+		shift
 		;;
 	'-fno-lifetime-dse'|'-rdynamic'|'-Wl,--export-dynamic'|'-fvisibility=hidden'|'-Wl,-undefined,dynamic_lookup')
 		# Error out so configure knows not to pass us these arguments, avoiding the below warning.

--- a/src/scripts/configure.ac
+++ b/src/scripts/configure.ac
@@ -724,6 +724,7 @@ AC_MSG_RESULT("$CMK_NATIVE_CXX")
 AC_MSG_CHECKING("Sequential C++ compiler as")
 AC_MSG_RESULT("$CMK_SEQ_CXX")
 
+# Needed to avoid migratable threads failing the stack check
 test_link "whether compiler accepts -fno-stack-protector" "ok" "no" "-fno-stack-protector"
 if test $strictpass -eq 1
 then

--- a/src/scripts/configure.ac
+++ b/src/scripts/configure.ac
@@ -725,6 +725,7 @@ AC_MSG_CHECKING("Sequential C++ compiler as")
 AC_MSG_RESULT("$CMK_SEQ_CXX")
 
 # Needed to avoid migratable threads failing the stack check
+# See https://github.com/UIUC-PPL/charm/pull/3174 for details.
 test_link "whether compiler accepts -fno-stack-protector" "ok" "no" "-fno-stack-protector"
 if test $strictpass -eq 1
 then

--- a/src/scripts/configure.ac
+++ b/src/scripts/configure.ac
@@ -724,14 +724,11 @@ AC_MSG_RESULT("$CMK_NATIVE_CXX")
 AC_MSG_CHECKING("Sequential C++ compiler as")
 AC_MSG_RESULT("$CMK_SEQ_CXX")
 
-if echo "$CMK_CC" | grep -E "gcc|clang|icc" > /dev/null 2> /dev/null
+test_link "whether compiler accepts -fno-stack-protector" "ok" "no" "-fno-stack-protector"
+if test $strictpass -eq 1
 then
-  test_link "whether compiler accept -fno-stack-protector" "ok" "no" "-fno-stack-protector"
-  if test $strictpass -eq 1
-  then
-	add_flag OPTS_CC='"$OPTS_CC -fno-stack-protector"' "stack-protection disabling"
-	add_flag OPTS_CXX='"$OPTS_CXX -fno-stack-protector"' "stack-protection disabling"
-  fi
+  add_flag OPTS_CC='"$OPTS_CC -fno-stack-protector"' "stack-protection disabling"
+  add_flag OPTS_CXX='"$OPTS_CXX -fno-stack-protector"' "stack-protection disabling"
 fi
 
 #### check if C++ compiler will accept C++11 features without warning ####


### PR DESCRIPTION
Needed to avoid migratable threads failing the stack check.