### PR TITLE
Tracing: Add hostname to Projections logs

### DIFF
--- a/src/ck-perf/trace-common.C
+++ b/src/ck-perf/trace-common.C
@@ -21,10 +21,30 @@
 
 // To get username
 #if defined(_WIN32) || defined(_WIN64)
+#define WIN32_LEAN_AND_MEAN
 #include <windows.h>
 #include <Lmcons.h>
 #else
 #include <pwd.h>
+#endif
+
+// To get hostname
+#if defined(_WIN32) || defined(_WIN64)
+#  include <Winsock2.h>
+#else
+#  include <unistd.h>
+#  include <limits.h> // For HOST_NAME_MAX
+#endif
+
+#ifndef HOST_NAME_MAX
+// Apple seems to not adhere to POSIX and defines this non-standard variable
+// instead of HOST_NAME_MAX
+#  ifdef MAXHOSTNAMELEN
+#    define HOST_NAME_MAX MAXHOSTNAMELEN
+// Windows docs say 256 bytes (so 255 + 1 added at use) will always be sufficient
+#  else
+#    define HOST_NAME_MAX 255
+#  endif
 #endif
 
 CpvExtern(int, _traceCoreOn);   // projector
@@ -260,6 +280,11 @@ void traceWriteSTS(FILE *stsfp,int nUserEvents) {
   if (pw != nullptr)
     fprintf(stsfp, "USERNAME \"%s\"\n", pw->pw_name);
 #endif
+
+  // Add 1 for null terminator
+  char hostname[HOST_NAME_MAX + 1];
+  if(gethostname(hostname, HOST_NAME_MAX + 1) == 0)
+    fprintf(stsfp, "HOSTNAME \"%s\"\n", hostname);
 
   fprintf(stsfp, "COMMANDLINE \"");
   int index = 0;


### PR DESCRIPTION
In making this patch, I also discovered that we currently have a `gethostname` check in `configure.ac`. I don't think this is really needed (plus, the result `CMK_GET_HOSTNAME` is already not universally used) since both POSIX and Windows guarantee this function exists. Am I missing some reason why we need this check or can it be removed?