### PR TITLE
Update .clang-format: Indent preprocessor directives

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -26,6 +26,7 @@ ConstructorInitializerIndentWidth: 4
 DerivePointerAlignment: false
 ExperimentalAutoDetectBinPacking: false
 IndentCaseLabels: true
+IndentPPDirectives: AfterHash
 IndentWrappedFunctionNames: false
 IndentFunctionDeclarationAfterType: false
 MaxEmptyLinesToKeep: 1


### PR DESCRIPTION
Improves readability of nested preprocessor directives. `clang-format` has enough awareness to not apply this to things like include guards.

Changes this:
```
#if FOO
#if BAR
#include <foo>
#endif
#endif
```
to this:
```
#if FOO
#  if BAR
#    include <foo>
#  endif
#endif
```