### PR TITLE
Collide: Add functionality to print the number of voxels created

### DIFF
--- a/examples/collide/collidecharm/Makefile
+++ b/examples/collide/collidecharm/Makefile
@@ -26,3 +26,4 @@ hello_cb.o: hello.C
 test: all
 	$(call run, ./hello_fn +p4 10 )
 	$(call run, ./hello_cb +p4 10 )
+	$(call run, ./hello_cb +p4 10 +printVoxCount)

--- a/src/libs/ck-libs/collide/collidecharm.ci
+++ b/src/libs/ck-libs/collide/collidecharm.ci
@@ -9,24 +9,32 @@ module collidecharm {
     entry void reductionDone(CkReductionMsg *m);
   };
 
+  chare [migratable] statsCollector {
+    entry statsCollector();
+    entry [reductiontarget] void voxelCountDone(int result);
+  };
+
   group syncReductionMgr {
     entry syncReductionMgr();
     entry void childProd(int stepCount);
     entry void childDone(int stepCount);
   };
+
   group collideMgr : syncReductionMgr {
     entry collideMgr(CollideGrid3d gridMap,
         CProxy_collideClient client,
-        CkArrayID cells);
+        CkArrayID cells,
+        collideStats statObj);
     entry void voxelMessageRecvd(void);
   };
 
   array [3D] collideVoxel {
-    entry collideVoxel(void);
+    entry collideVoxel();
     entry [createhere] void add(objListMsg *);
     //    entry [createhome] void add(objListMsg *);
     entry void startCollision(int step,
         CollideGrid3d gridMap,
-        CProxy_collideClient client);
+        CProxy_collideClient client,
+        collideStats statObj);
   };
 };

--- a/src/libs/ck-libs/collide/collidecharm.h
+++ b/src/libs/ck-libs/collide/collidecharm.h
@@ -7,6 +7,7 @@
 
 #include "charm++.h"
 #include "collide_util.h"
+struct collideStats; // forward declaration for collideStats
 #include "collidecharm.decl.h"
 
 /********************** collideClient *****************


### PR DESCRIPTION
The number of voxels created can be printed by using the
'+printVoxCount' runtime flag.