### PR TITLE
Cleanup CkSyncBarrier code

### DIFF
--- a/src/ck-core/cklocation.C
+++ b/src/ck-core/cklocation.C
@@ -1511,7 +1511,7 @@ CkMigratable::~CkMigratable() {
 	if (barrierRegistered) {
 	  DEBL((AA "Removing barrier for element %s\n" AB,idx2str(thisIndexMax)));
 	  if (usesAtSync)
-	    myRec->getSyncBarrier()->RemoveClient(ldBarrierHandle);
+	    myRec->getSyncBarrier()->removeClient(ldBarrierHandle);
 	}
 
   if (_lb_args.metaLbOn()) {
@@ -1612,7 +1612,7 @@ void CkMigratable::recvLBPeriod(void *data) {
 
 void CkMigratable::metaLBCallLB() {
   if(usesAtSync)
-    myRec->getSyncBarrier()->AtBarrier(ldBarrierHandle);
+    myRec->getSyncBarrier()->atBarrier(ldBarrierHandle);
 }
 
 void CkMigratable::ckFinishConstruction(int epoch)
@@ -1625,7 +1625,7 @@ void CkMigratable::ckFinishConstruction(int epoch)
 	if (barrierRegistered) return;
 	DEBL((AA "Registering barrier client for %s\n" AB,idx2str(thisIndexMax)));
 	if (usesAtSync) {
-	  ldBarrierHandle = myRec->getSyncBarrier()->AddClient(
+	  ldBarrierHandle = myRec->getSyncBarrier()->addClient(
 	    this, [=]() { this->ResumeFromSyncHelper(); }, epoch);
 	}
 	barrierRegistered=true;
@@ -1658,7 +1658,7 @@ void CkMigratable::AtSync(int waitForMigration)
   }
 
   if (!_lb_args.metaLbOn()) {
-    myRec->getSyncBarrier()->AtBarrier(ldBarrierHandle);
+    myRec->getSyncBarrier()->atBarrier(ldBarrierHandle);
     return;
   }
 
@@ -1815,7 +1815,7 @@ CkLocRec::CkLocRec(CkLocMgr *mgr,bool fromMigration,
 #if CMK_FAULT_EVAC
 	bounced  = false;
 #endif
-        syncBarrier = CkSyncBarrier::Object();
+        syncBarrier = CkSyncBarrier::object();
 	lbmgr=mgr->getLBMgr();
 	if(_lb_args.metaLbOn())
 	  the_metalb=mgr->getMetaBalancer();
@@ -2089,8 +2089,8 @@ CkLocMgr::CkLocMgr(CkMigrateMessage* m)
 
 CkLocMgr::~CkLocMgr() {
 #if CMK_LBDB_ON
-  syncBarrier->RemoveBeginReceiver(lbBarrierBeginReceiver);
-  syncBarrier->RemoveEndReceiver(lbBarrierEndReceiver);
+  syncBarrier->removeBeginReceiver(lbBarrierBeginReceiver);
+  syncBarrier->removeEndReceiver(lbBarrierEndReceiver);
   lbmgr->UnregisterOM(myLBHandle);
 #endif
   map->unregisterArray(mapHandle);
@@ -3262,7 +3262,7 @@ void CkLocMgr::initLB(CkGroupID lbmgrID_, CkGroupID metalbID_)
 	  if (the_metalb == 0)
 		  CkAbort("MetaBalancer not yet created?\n");
 	}
-	syncBarrier = CkSyncBarrier::Object();
+	syncBarrier = CkSyncBarrier::object();
 	if (syncBarrier == nullptr)
 	  CkAbort("CkSyncBarrier not yet created?\n");
 	// Register myself as an object manager
@@ -3283,11 +3283,11 @@ void CkLocMgr::initLB(CkGroupID lbmgrID_, CkGroupID metalbID_)
 
 	// Set up callbacks for this LocMgr to call Registering/DoneRegistering during
 	// each AtSync.
-	lbBarrierBeginReceiver = syncBarrier->AddBeginReceiver([=]() {
+	lbBarrierBeginReceiver = syncBarrier->addBeginReceiver([=]() {
 	  DEBL((AA "CkLocMgr AtSync Receiver called\n" AB));
 	  lbmgr->RegisteringObjects(myLBHandle);
 	});
-	lbBarrierEndReceiver = syncBarrier->AddEndReceiver([=]() {
+	lbBarrierEndReceiver = syncBarrier->addEndReceiver([=]() {
 	  lbmgr->DoneRegisteringObjects(myLBHandle);
 	});
 }

--- a/src/ck-core/cksyncbarrier.C
+++ b/src/ck-core/cksyncbarrier.C
@@ -169,7 +169,7 @@ void CkSyncBarrier::kick(int kickEpoch, const int sourceNode, const int sourcePe
 
   // Ignore the kick if it's for an epoch we've already completed or we're currently
   // triggered
-  if (kickEpoch < curEpoch || startedAtSync)
+  if (kickEpoch <= curEpoch || startedAtSync)
     return;
 
   const int myPe = CkMyPe();
@@ -196,7 +196,7 @@ void CkSyncBarrier::checkBarrier()
 
   // If there are no clients and the current kick is out of date or we're currently in the
   // barrier, then return without triggering the barrier
-  if ((clientCount == 0 && curKickEpoch < curEpoch) || startedAtSync)
+  if ((clientCount == 0 && curKickEpoch <= curEpoch) || startedAtSync)
     return;
 
   if (atCount >= clientCount)
@@ -217,11 +217,11 @@ void CkSyncBarrier::checkBarrier()
     if (atBarrier)
     {
       startedAtSync = true;
+      curEpoch++;
       // Propagate kick message to trigger barrier on PEs that don't have any AtSync
       // elements on them
       propagateKick();
       atCount -= clientCount;
-      curEpoch++;
       callReceiverList(beginReceivers);
       callReceiverList(receivers);
     }

--- a/src/ck-core/cksyncbarrier.C
+++ b/src/ck-core/cksyncbarrier.C
@@ -1,13 +1,15 @@
+#include <utility>
+
 #include "cksyncbarrier.h"
 
 CkGroupID _syncBarrier;
 
-CkpvDeclare(bool, cksyncbarrierInited);
+CkpvDeclare(bool, CkSyncBarrierInited);
 
-void _cksyncbarrierInit()
+void _CkSyncBarrierInit()
 {
-  CkpvInitialize(bool, cksyncbarrierInited);
-  CkpvAccess(cksyncbarrierInited) = false;
+  CkpvInitialize(bool, CkSyncBarrierInited);
+  CkpvAccess(CkSyncBarrierInited) = false;
 }
 
 // mainchare
@@ -21,209 +23,214 @@ void CkSyncBarrier::reset()
 {
   startedAtSync = false;
 
-  if (rank0pe)
+  if (isRank0pe)
   {
-    std::fill(rank_needs_kick.begin(), rank_needs_kick.end(), true);
-    received_from_left = false;
-    received_from_right = false;
+    std::fill(rankNeedsKick.begin(), rankNeedsKick.end(), true);
+    receivedFromLeft = false;
+    receivedFromRight = false;
   }
   else
-    received_from_rank0 = false;
+    receivedFromRank0 = false;
 }
 
-// Since AtSync() is global across all registered objects, the epoch should be consistent
-// across PEs. The incoming client might have called AtSync() before it gets migrated in, so
-// track it and check the barrier if necessary.
-LDBarrierClient CkSyncBarrier::AddClient(Chare* chare, std::function<void()> fn,
+// Since AtSync() is global across all registered objects, the epoch is valid across PEs.
+// The incoming client might have called AtSync() before it gets migrated in, so track it
+// and check the barrier if necessary.
+LDBarrierClient CkSyncBarrier::addClient(Chare* chare, std::function<void()> fn,
                                          int epoch)
 {
   if (epoch == -1)
-    epoch = cur_epoch;
-  else if (epoch > cur_epoch)
+    epoch = curEpoch;
+  else if (epoch > curEpoch)
   {
     // If the incoming client is ahead of us, then record those syncs
-    at_count += epoch - cur_epoch;
+    atCount += epoch - curEpoch;
   }
 
-  LBClient* new_client = new LBClient(chare, fn, epoch);
-  const auto client = LDBarrierClient(clients.insert(clients.end(), new_client));
+  const auto client = LDBarrierClient(
+      clients.insert(clients.end(), new LBClient(chare, std::move(fn), epoch)));
   // Check the barrier if it can trigger. Do this asynchronously so that the caller
   // functions for object construction finish first.
-  if (on && !startedAtSync && at_count >= clients.size())
-    thisProxy[thisIndex].CheckBarrier();
+  if (on && !startedAtSync && atCount >= clients.size())
+    thisProxy[thisIndex].checkBarrier();
   return client;
 }
 
-void CkSyncBarrier::RemoveClient(LDBarrierClient c)
+void CkSyncBarrier::removeClient(LDBarrierClient c)
 {
   const auto epoch = (*c)->epoch;
-  if (epoch > cur_epoch)
-    at_count -= epoch - cur_epoch;
+  if (epoch > curEpoch)
+    atCount -= epoch - curEpoch;
   delete *(c);
   clients.erase(c);
-  if (on && !startedAtSync && at_count >= clients.size())
-      thisProxy[thisIndex].CheckBarrier();
+  if (on && !startedAtSync && atCount >= clients.size())
+    thisProxy[thisIndex].checkBarrier();
 }
 
-LDBarrierReceiver CkSyncBarrier::AddReceiverHelper(std::function<void()> fn,
+LDBarrierReceiver CkSyncBarrier::addReceiverHelper(std::function<void()> fn,
                                                    std::list<LBReceiver*>& receiverList)
 {
-  LBReceiver* new_receiver = new LBReceiver(fn);
-  return LDBarrierReceiver(receiverList.insert(receiverList.end(), new_receiver));
+  LBReceiver* newReceiver = new LBReceiver(std::move(fn));
+  return LDBarrierReceiver(receiverList.insert(receiverList.end(), newReceiver));
 }
 
-LDBarrierReceiver CkSyncBarrier::AddReceiver(std::function<void()> fn)
+LDBarrierReceiver CkSyncBarrier::addReceiver(std::function<void()> fn)
 {
-  return AddReceiverHelper(std::move(fn), receivers);
+  return addReceiverHelper(std::move(fn), receivers);
 }
 
-LDBarrierReceiver CkSyncBarrier::AddBeginReceiver(std::function<void()> fn)
+LDBarrierReceiver CkSyncBarrier::addBeginReceiver(std::function<void()> fn)
 {
-  return AddReceiverHelper(std::move(fn), beginReceivers);
+  return addReceiverHelper(std::move(fn), beginReceivers);
 }
 
-LDBarrierReceiver CkSyncBarrier::AddEndReceiver(std::function<void()> fn)
+LDBarrierReceiver CkSyncBarrier::addEndReceiver(std::function<void()> fn)
 {
-  return AddReceiverHelper(std::move(fn), endReceivers);
+  return addReceiverHelper(std::move(fn), endReceivers);
 }
 
-void CkSyncBarrier::RemoveReceiverHelper(
-    LDBarrierReceiver r, std::list<LBReceiver*>& receiverList)
+void CkSyncBarrier::removeReceiverHelper(LDBarrierReceiver r,
+                                         std::list<LBReceiver*>& receiverList)
 {
   delete *(r);
   receiverList.erase(r);
 }
 
-void CkSyncBarrier::RemoveReceiver(LDBarrierReceiver c)
+void CkSyncBarrier::removeReceiver(LDBarrierReceiver r)
 {
-  RemoveReceiverHelper(c, receivers);
+  removeReceiverHelper(r, receivers);
 }
 
-void CkSyncBarrier::RemoveBeginReceiver(LDBarrierReceiver c)
+void CkSyncBarrier::removeBeginReceiver(LDBarrierReceiver r)
 {
-  RemoveReceiverHelper(c, beginReceivers);
+  removeReceiverHelper(r, beginReceivers);
 }
 
-void CkSyncBarrier::RemoveEndReceiver(LDBarrierReceiver c)
+void CkSyncBarrier::removeEndReceiver(LDBarrierReceiver r)
 {
-  RemoveReceiverHelper(c, endReceivers);
+  removeReceiverHelper(r, endReceivers);
 }
 
-void CkSyncBarrier::TurnOnReceiver(LDBarrierReceiver c) { (*c)->on = 1; }
+void CkSyncBarrier::turnOnReceiver(LDBarrierReceiver r) { (*r)->on = true; }
 
-void CkSyncBarrier::TurnOffReceiver(LDBarrierReceiver c) { (*c)->on = 0; }
+void CkSyncBarrier::turnOffReceiver(LDBarrierReceiver r) { (*r)->on = false; }
 
-void CkSyncBarrier::AtBarrier(LDBarrierClient h)
+void CkSyncBarrier::atBarrier(LDBarrierClient c)
 {
-  (*h)->epoch++;
-  at_count++;
+  (*c)->epoch++;
+  atCount++;
 
-  CheckBarrier();
+  checkBarrier();
 }
 
-void CkSyncBarrier::DecreaseBarrier(int c) { at_count -= c; }
-
-void CkSyncBarrier::propagate_atsync()
+// Whenever a PE triggers the barrier, send a kick through the system to tell PEs without
+// any AtSync elements on them to also trigger the barrier.
+// Without this, PEs devoid of AtSync elements would never trigger their receivers, which
+// would cause a hang if the receiver uses group reductions (as load balancing does, for
+// example).
+void CkSyncBarrier::propagateKick()
 {
-  if (propagated_atsync_step < cur_epoch)
-  {
-    const int mype = CkMyPe();
-    const int mynode = CkNodeOf(mype);
-    if (!rank0pe)
+  const int myPe = CkMyPe();
+  const int myNode = CkNodeOf(myPe);
+  if (!isRank0pe)
+  {  // Propagate kick to rank 0 if we haven't received from it
+    if (!receivedFromRank0)
     {
-      if (!received_from_rank0)
+      const int rank0Pe = CkNodeFirst(myNode);
+      thisProxy[rank0Pe].kick(curEpoch, myNode, myPe);
+    }
+  }
+  else
+  {  // Rank 0 PE
+    // Propagate kick to the rest of the ranks on this node
+    for (int i = 1; i < rankNeedsKick.size(); ++i)
+    {
+      if (rankNeedsKick[i])
       {
-        // If this PE is non-rank0 and non-empty PE, then trigger AtSync barrier on rank0
-        int node_rank0_pe = CkNodeFirst(mynode);
-        thisProxy[node_rank0_pe].recvLbStart(cur_epoch, mynode, mype);
+        thisProxy[myPe + i].kick(curEpoch, myNode, myPe);
       }
     }
-    else
-    {  // Rank0 PE
-      // Kick non-zero ranks on this node
-      for (int i = 1; i < rank_needs_kick.size(); ++i)
-      {
-        if (rank_needs_kick[i])
-        {
-          thisProxy[mype + i].recvLbStart(cur_epoch, mynode, mype);
-        }
-      }
-      if (!received_from_left && mynode > 0)
-      {  // Kick left node
-        int pe = CkNodeFirst(mynode - 1);
-        thisProxy[pe].recvLbStart(cur_epoch, mynode, mype);
-      }
-      if (!received_from_right && mynode < CkNumNodes() - 1)
-      {  // Kick right node
-        int pe = CkNodeFirst(mynode + 1);
-        thisProxy[pe].recvLbStart(cur_epoch, mynode, mype);
-      }
+    if (!receivedFromLeft && myNode > 0)
+    {  // Kick left node
+      const int pe = CkNodeFirst(myNode - 1);
+      thisProxy[pe].kick(curEpoch, myNode, myPe);
     }
-    propagated_atsync_step = cur_epoch;
+    if (!receivedFromRight && myNode < CkNumNodes() - 1)
+    {  // Kick right node
+      const int pe = CkNodeFirst(myNode + 1);
+      thisProxy[pe].kick(curEpoch, myNode, myPe);
+    }
   }
 }
 
-void CkSyncBarrier::recvLbStart(int lb_step, int sourcenode, int pe)
+void CkSyncBarrier::kick(int kickEpoch, const int sourceNode, const int sourcePe)
 {
-  if (lb_step > currentKick)
-    currentKick = lb_step;
-  if (lb_step < cur_epoch || startedAtSync)
+  curKickEpoch = std::max(kickEpoch, curKickEpoch);
+
+  // Ignore the kick if it's for an epoch we've already completed or we're currently
+  // triggered
+  if (kickEpoch < curEpoch || startedAtSync)
     return;
 
-  const int mype = CkMyPe();
-  const int mynode = CkNodeOf(mype);
-  if (sourcenode < mynode)
-    received_from_left = true;
-  else if (sourcenode > mynode)
-    received_from_right = true;
-  else if (rank0pe) // convert incoming pe number to local rank
-    rank_needs_kick[pe - mype] = false;
+  const int myPe = CkMyPe();
+  const int myNode = CkNodeOf(myPe);
+  if (sourceNode < myNode)
+    receivedFromLeft = true;
+  else if (sourceNode > myNode)
+    receivedFromRight = true;
+  else if (isRank0pe)  // myNode = sourceNode, so convert incoming pe number to local rank
+    rankNeedsKick[sourcePe - myPe] = false;
   else
-    received_from_rank0 = true;
+    receivedFromRank0 = true;
 
   if (clients.empty())
-    CheckBarrier();  // Empty PE invokes barrier on self on receiving a kick
+    checkBarrier();  // Empty PE invokes barrier on self on receiving a kick
 }
 
-void CkSyncBarrier::CheckBarrier()
+void CkSyncBarrier::checkBarrier()
 {
-  if (!on) return;
+  if (!on)
+    return;
 
-  const auto client_count = clients.size();
+  const auto clientCount = clients.size();
 
   // If there are no clients and the current kick is out of date or we're currently in the
   // barrier, then return without triggering the barrier
-  if ((client_count == 0 && currentKick < cur_epoch) || startedAtSync)
+  if ((clientCount == 0 && curKickEpoch < curEpoch) || startedAtSync)
     return;
 
-  if (at_count >= client_count)
+  if (atCount >= clientCount)
   {
-    bool at_barrier = true;
+    bool atBarrier = true;
 
-    for (auto& c : clients)
+    // Ensure that all AtSync elements on this PE have completed the current epoch before
+    // triggering the barrier
+    for (const auto& c : clients)
     {
-      if (c->epoch <= cur_epoch)
+      if (c->epoch <= curEpoch)
       {
-        at_barrier = false;
+        atBarrier = false;
         break;
       }
     }
 
-    if (at_barrier)
+    if (atBarrier)
     {
       startedAtSync = true;
-      propagate_atsync();
-      at_count -= client_count;
-      cur_epoch++;
-      CallReceiverList(beginReceivers);
-      CallReceiverList(receivers);
+      // Propagate kick message to trigger barrier on PEs that don't have any AtSync
+      // elements on them
+      propagateKick();
+      atCount -= clientCount;
+      curEpoch++;
+      callReceiverList(beginReceivers);
+      callReceiverList(receivers);
     }
   }
 }
 
-void CkSyncBarrier::CallReceiverList(const std::list<LBReceiver*>& receiverList)
+void CkSyncBarrier::callReceiverList(const std::list<LBReceiver*>& receiverList)
 {
-  for (auto& r : receiverList)
+  for (const auto& r : receiverList)
   {
     if (r->on)
     {
@@ -232,20 +239,17 @@ void CkSyncBarrier::CallReceiverList(const std::list<LBReceiver*>& receiverList)
   }
 }
 
-void CkSyncBarrier::ResumeClients(void)
+void CkSyncBarrier::resumeClients()
 {
   // The end receiver or client functions may trigger the barrier again, so make sure
   // reset() is called before them to put the barrier in a valid state to be triggered
   reset();
 
-  CallReceiverList(endReceivers);
+  callReceiverList(endReceivers);
 
-  for (auto& c : clients) c->fn();
+  for (const auto& c : clients) c->fn();
 }
 
-void CkSyncBarrier::pup(PUP::er& p)
-{
-  IrrGroup::pup(p);
-}
+void CkSyncBarrier::pup(PUP::er& p) { IrrGroup::pup(p); }
 
 #include "CkSyncBarrier.def.h"

--- a/src/ck-core/cksyncbarrier.ci
+++ b/src/ck-core/cksyncbarrier.ci
@@ -6,10 +6,12 @@ module CkSyncBarrier {
   };
 
   group [migratable] CkSyncBarrier {
-    entry void CkSyncBarrier(void);
-    entry void ResumeClients();
-    entry void recvLbStart(int lb_step, int sourcenode, int pe);
-    entry void CheckBarrier();
+    entry void CkSyncBarrier();
+    entry void resumeClients();
+
+    // Only for internal use
+    entry void kick(int kickStep, int sourceNode, int sourcePe);
+    entry void checkBarrier();
   };
 
 };

--- a/src/ck-core/cksyncbarrier.h
+++ b/src/ck-core/cksyncbarrier.h
@@ -1,6 +1,8 @@
 #ifndef CKSYNCBARRIER_H
 #define CKSYNCBARRIER_H
 
+#include <utility>
+
 #include "CkSyncBarrier.decl.h"
 #include "lbdb.h"
 
@@ -9,7 +11,7 @@ extern CkGroupID _syncBarrier;
 class CkSyncBarrierInit : public Chare
 {
 public:
-  CkSyncBarrierInit(CkArgMsg*);
+  CkSyncBarrierInit(CkArgMsg* m);
   CkSyncBarrierInit(CkMigrateMessage* m) : Chare(m) {}
 };
 
@@ -21,7 +23,7 @@ public:
   int epoch;
 
   LBClient(Chare* chare, std::function<void()> fn, int epoch)
-      : chare(chare), fn(fn), epoch(epoch)
+      : chare(chare), fn(std::move(fn)), epoch(epoch)
   {
   }
 };
@@ -30,12 +32,12 @@ class LBReceiver
 {
 public:
   std::function<void()> fn;
-  int on;
+  bool on;
 
-  LBReceiver(std::function<void()> fn, int on = 1) : fn(fn), on(on) {}
+  LBReceiver(std::function<void()> fn, bool on = true) : fn(std::move(fn)), on(on) {}
 };
 
-CkpvExtern(bool, cksyncbarrierInited);
+CkpvExtern(bool, CkSyncBarrierInited);
 
 class CkSyncBarrier : public CBase_CkSyncBarrier
 {
@@ -45,113 +47,111 @@ private:
   std::list<LBReceiver*> beginReceivers;
   std::list<LBReceiver*> endReceivers;
 
-  std::vector<bool> rank_needs_kick;
+  std::vector<bool> rankNeedsKick;
 
-  int cur_epoch;
-  int at_count;
-  bool on;
-  bool rank0pe;
-  int propagated_atsync_step;
-  int currentKick;
-  bool received_from_left;
-  bool received_from_right;
-  bool received_from_rank0;
-  bool startedAtSync;
+  int atCount = 0;
+  int curEpoch = 1;
+  int curKickEpoch = 0;
+  bool on = false;
+  bool isRank0pe = CkMyRank() == 0;
+  bool receivedFromLeft = false;
+  bool receivedFromRight = false;
+  bool receivedFromRank0 = false;
+  bool startedAtSync = false;
 
   void init()
   {
-    CkpvAccess(cksyncbarrierInited) = true;
-    cur_epoch = 1;
-    currentKick = 0;
-    propagated_atsync_step = 0;
-    at_count = 0;
-    on = false;
-    rank0pe = CkMyRank() == 0;
-    if (rank0pe)
+    CkpvAccess(CkSyncBarrierInited) = true;
+    if (isRank0pe)
     {
-      rank_needs_kick.resize(CkNodeSize(CkMyNode()));
+      rankNeedsKick.resize(CkNodeSize(CkMyNode()), true);
     }
-    reset();
   }
 
-  void propagate_atsync();
+  void propagateKick();
   void reset();
-  static void CallReceiverList(const std::list<LBReceiver*>& receiverList);
+  static void callReceiverList(const std::list<LBReceiver*>& receiverList);
 
-  static LDBarrierReceiver AddReceiverHelper(std::function<void()> fn,
-                                      std::list<LBReceiver*>& receiverList);
-  void RemoveReceiverHelper(LDBarrierReceiver r, std::list<LBReceiver*>& receiverList);
+  static LDBarrierReceiver addReceiverHelper(std::function<void()> fn,
+                                             std::list<LBReceiver*>& receiverList);
+  static void removeReceiverHelper(LDBarrierReceiver r,
+                                   std::list<LBReceiver*>& receiverList);
 
 public:
   CkSyncBarrier() { init(); };
   CkSyncBarrier(CkMigrateMessage* m) : CBase_CkSyncBarrier(m) { init(); }
-  ~CkSyncBarrier(){};
+  ~CkSyncBarrier() override = default;
 
-  void pup(PUP::er& p);
+  CkSyncBarrier(const CkSyncBarrier&) = delete;
+  CkSyncBarrier& operator=(const CkSyncBarrier&) = delete;
+  CkSyncBarrier(CkSyncBarrier&&) = delete;
+  CkSyncBarrier& operator=(CkSyncBarrier&&) = delete;
 
-  inline static CkSyncBarrier* Object()
+  void pup(PUP::er& p) override;
+
+  inline static CkSyncBarrier* object()
   {
-    return CkpvAccess(cksyncbarrierInited) ? (CkSyncBarrier*)CkLocalBranch(_syncBarrier)
-                                           : nullptr;
+    return CkpvAccess(CkSyncBarrierInited)
+               ? static_cast<CkSyncBarrier*>(CkLocalBranch(_syncBarrier))
+               : nullptr;
   }
 
-  void CheckBarrier();
-  void recvLbStart(int lb_step, int sourcenode, int pe);
+  void checkBarrier();
+  void kick(int kickEpoch, int sourceNode, int sourcePe);
 
-  LDBarrierClient AddClient(Chare* chare, std::function<void()> fn, int epoch = -1);
+  LDBarrierClient addClient(Chare* chare, std::function<void()> fn, int epoch = -1);
   template <typename T>
-  inline LDBarrierClient AddClient(T* obj, void (T::*method)(void), int epoch = -1)
+  inline LDBarrierClient addClient(T* obj, void (T::*method)(), int epoch = -1)
   {
-    return AddClient((Chare*)obj, std::bind(method, obj), epoch);
+    return addClient((Chare*)obj, std::bind(method, obj), epoch);
   }
 
-  void RemoveClient(LDBarrierClient h);
+  void removeClient(LDBarrierClient c);
 
   // A receiver is a callback function that is called when all of the clients on this PE
   // reach this barrier
-  LDBarrierReceiver AddReceiver(std::function<void()> fn);
+  LDBarrierReceiver addReceiver(std::function<void()> fn);
   template <typename T>
-  inline LDBarrierReceiver AddReceiver(T* obj, void (T::*method)(void))
+  inline LDBarrierReceiver addReceiver(T* obj, void (T::*method)())
   {
-    return AddReceiver(std::bind(method, obj));
+    return addReceiver(std::bind(method, obj));
   }
 
   // A begin receiver is a callback function that is called after all of the clients on
   // this PE reach this barrier and before calling the actual receivers, useful for
   // setting up for the execution of those receivers. Will only be called when a receiver
   // exists.
-  LDBarrierReceiver AddBeginReceiver(std::function<void()> fn);
+  LDBarrierReceiver addBeginReceiver(std::function<void()> fn);
   template <typename T>
-  inline LDBarrierReceiver AddBeginReceiver(T* obj, void (T::*method)(void))
+  inline LDBarrierReceiver addBeginReceiver(T* obj, void (T::*method)(void))
   {
-    return AddBeginReceiver(std::bind(method, obj));
+    return addBeginReceiver(std::bind(method, obj));
   }
 
   // An end receiver is a callback function that is called when the receivers on this PE
   // have finished executing, right before the clients are resumed, useful for cleaning up
   // or resetting state. Will only be called when a receiver exists.
-  LDBarrierReceiver AddEndReceiver(std::function<void()> fn);
+  LDBarrierReceiver addEndReceiver(std::function<void()> fn);
   template <typename T>
-  inline LDBarrierReceiver AddEndReceiver(T* obj, void (T::*method)(void))
+  inline LDBarrierReceiver addEndReceiver(T* obj, void (T::*method)())
   {
-    return AddEndReceiver(std::bind(method, obj));
+    return addEndReceiver(std::bind(method, obj));
   }
 
-  void RemoveReceiver(LDBarrierReceiver h);
-  void RemoveBeginReceiver(LDBarrierReceiver h);
-  void RemoveEndReceiver(LDBarrierReceiver h);
-  void TurnOnReceiver(LDBarrierReceiver h);
-  void TurnOffReceiver(LDBarrierReceiver h);
-  void AtBarrier(LDBarrierClient _n_c);
-  void DecreaseBarrier(int c);
-  void TurnOn()
+  void removeReceiver(LDBarrierReceiver r);
+  void removeBeginReceiver(LDBarrierReceiver r);
+  void removeEndReceiver(LDBarrierReceiver r);
+  static void turnOnReceiver(LDBarrierReceiver r);
+  static void turnOffReceiver(LDBarrierReceiver r);
+  void atBarrier(LDBarrierClient c);
+  void turnOn()
   {
     on = true;
-    CheckBarrier();
+    checkBarrier();
   };
-  void TurnOff() { on = false; };
+  void turnOff() { on = false; };
 
-  void ResumeClients(void);
+  void resumeClients();
 
   bool hasReceivers() { return !receivers.empty(); };
 };

--- a/src/ck-core/cksyncbarrier.h
+++ b/src/ck-core/cksyncbarrier.h
@@ -50,7 +50,7 @@ private:
   std::vector<bool> rankNeedsKick;
 
   int atCount = 0;
-  int curEpoch = 1;
+  int curEpoch = 0;
   int curKickEpoch = 0;
   bool on = false;
   bool isRank0pe = CkMyRank() == 0;

--- a/src/ck-core/init.C
+++ b/src/ck-core/init.C
@@ -1152,7 +1152,7 @@ extern void _registerControlPoints(void);
 extern void _registerTraceControlPoints();
 extern void _registerExternalModules(char **argv);
 extern void _ckModuleInit(void);
-extern void _cksyncbarrierInit();
+extern void _CkSyncBarrierInit();
 extern void _loadbalancerInit();
 extern void _metabalancerInit();
 #if CMK_SMP && CMK_TASKQUEUE
@@ -1414,7 +1414,7 @@ void _initCharm(int unused_argc, char **argv)
 	CldRegisterEstimator((CldEstimator)_charmLoadEstimator);
 
 	_futuresModuleInit(); // part of futures implementation is a converse module
-        _cksyncbarrierInit();
+        _CkSyncBarrierInit();
 	_loadbalancerInit();
         _metabalancerInit();
 

--- a/src/ck-ldb/LBDatabase.C
+++ b/src/ck-ldb/LBDatabase.C
@@ -8,7 +8,7 @@ LBDatabase::LBDatabase() {
   obj_running = false;
   objsEmptyHead = -1;
   commTable = new LBCommTable;
-  syncBarrier = CkSyncBarrier::Object();
+  syncBarrier = CkSyncBarrier::object();
 }
 
 LDOMHandle LBDatabase::RegisterOM(LDOMid userID, void* userPtr, LDCallbacks cb) {
@@ -35,14 +35,14 @@ void LBDatabase::RegisteringObjects(LDOMHandle omh) {
   // for an unregistered anonymous OM to join and control the barrier
   if (omh.id.id.idx == 0) {
     if (omsRegistering == 0)
-      syncBarrier->TurnOff();
+      syncBarrier->turnOff();
     omsRegistering++;
   }
   else {
     LBOM* om = oms[omh.handle];
     if (!om->RegisteringObjs()) {
       if (omsRegistering == 0)
-        syncBarrier->TurnOff();
+        syncBarrier->turnOff();
       omsRegistering++;
       om->SetRegisteringObjs(true);
     }
@@ -55,7 +55,7 @@ void LBDatabase::DoneRegisteringObjects(LDOMHandle omh)
   if (omh.id.id.idx == 0) {
     omsRegistering--;
     if (omsRegistering == 0)
-      syncBarrier->TurnOn();
+      syncBarrier->turnOn();
   }
   else {
     LBOM* om = oms[omh.handle];
@@ -63,11 +63,11 @@ void LBDatabase::DoneRegisteringObjects(LDOMHandle omh)
       omsRegistering--;
       om->SetRegisteringObjs(false);
       if (omsRegistering == 0)
-        // This call to TurnOn must come after the decrement of omsRegistering and the
-        // call to SetRegisteringObjs(false) because TurnOn() can start off a chain that
+        // This call to turnOn must come after the decrement of omsRegistering and the
+        // call to SetRegisteringObjs(false) because turnOn() can start off a chain that
         // calls RegisteringObjects(omh), so this ensures that the variables are in the correct
         // state if flow reaches there.
-        syncBarrier->TurnOn();
+        syncBarrier->turnOn();
     }
   }
 }

--- a/src/ck-ldb/LBManager.C
+++ b/src/ck-ldb/LBManager.C
@@ -527,7 +527,7 @@ void LBManager::init(void)
   }
   else
   {
-    CkSyncBarrier::Object()->AddReceiver([this](void) { this->InvokeLB(); });
+    CkSyncBarrier::object()->addReceiver([this](void) { this->InvokeLB(); });
   }
 }
 
@@ -854,7 +854,7 @@ void LBManager::ResumeClients()
   }
   else
   {
-    CkSyncBarrier::Object()->ResumeClients();
+    CkSyncBarrier::object()->resumeClients();
   }
 #endif
 }
@@ -912,46 +912,41 @@ void LBManager::UpdateDataAfterLB(double mLoad, double mCpuLoad, double avgLoad)
 
 LDBarrierClient LBManager::AddLocalBarrierClient(Chare* obj, std::function<void()> fn)
 {
-  return CkSyncBarrier::Object()->AddClient(obj, fn);
+  return CkSyncBarrier::object()->addClient(obj, fn);
 }
 
 void LBManager::RemoveLocalBarrierClient(LDBarrierClient h)
 {
-  CkSyncBarrier::Object()->RemoveClient(h);
+  CkSyncBarrier::object()->removeClient(h);
 }
 
 LDBarrierReceiver LBManager::AddLocalBarrierReceiver(std::function<void()> fn)
 {
-  return CkSyncBarrier::Object()->AddReceiver(fn);
+  return CkSyncBarrier::object()->addReceiver(fn);
 }
 
 void LBManager::RemoveLocalBarrierReceiver(LDBarrierReceiver h)
 {
-  CkSyncBarrier::Object()->RemoveReceiver(h);
+  CkSyncBarrier::object()->removeReceiver(h);
 }
 
 void LBManager::AtLocalBarrier(LDBarrierClient _n_c)
 {
-  if (useBarrier) CkSyncBarrier::Object()->AtBarrier(_n_c);
-}
-
-void LBManager::DecreaseLocalBarrier(int c)
-{
-  if (useBarrier) CkSyncBarrier::Object()->DecreaseBarrier(c);
+  if (useBarrier) CkSyncBarrier::object()->atBarrier(_n_c);
 }
 
 void LBManager::TurnOnBarrierReceiver(LDBarrierReceiver h)
 {
-  CkSyncBarrier::Object()->TurnOnReceiver(h);
+  CkSyncBarrier::object()->turnOnReceiver(h);
 }
 
 void LBManager::TurnOffBarrierReceiver(LDBarrierReceiver h)
 {
-  CkSyncBarrier::Object()->TurnOffReceiver(h);
+  CkSyncBarrier::object()->turnOffReceiver(h);
 }
 
-void LBManager::LocalBarrierOn(void) { CkSyncBarrier::Object()->TurnOn(); };
-void LBManager::LocalBarrierOff(void) { CkSyncBarrier::Object()->TurnOff(); };
+void LBManager::LocalBarrierOn(void) { CkSyncBarrier::object()->turnOn(); };
+void LBManager::LocalBarrierOff(void) { CkSyncBarrier::object()->turnOff(); };
 
 #if CMK_LBDB_ON
 static void work(int iter_block, volatile int* result)

--- a/src/ck-ldb/LBManager.h
+++ b/src/ck-ldb/LBManager.h
@@ -462,7 +462,6 @@ class LBManager : public CBase_LBManager
   }
   void RemoveLocalBarrierReceiver(LDBarrierReceiver h);
   void AtLocalBarrier(LDBarrierClient _n_c);
-  void DecreaseLocalBarrier(int c);
   void TurnOnBarrierReceiver(LDBarrierReceiver h);
   void TurnOffBarrierReceiver(LDBarrierReceiver h);
 


### PR DESCRIPTION
Fixes stylistic issues, particularly with variable and method names. Additionally, changes the semantics of the kick epoch, previously it would trigger the barrier when it was greater than or equal to the current epoch, now it must be strictly greater than the current epoch to trigger the barrier (which mirrors the behavior of regular AtSync elements).