### PR TITLE
Enable PUP'ing of C++ Shared Pointers

### DIFF
--- a/examples/charm++/PUP/STLPUP/SimplePUP.C
+++ b/examples/charm++/PUP/STLPUP/SimplePUP.C
@@ -35,5 +35,11 @@ main::main(CkArgMsg *m)
 
     std::vector<bool> dataToCompare3{ false, false, true};
     execute_example<bool>(dataToCompare3);
+
+    thisProxy.accept(std::make_shared<Ping>(42));
 }
 
+void main::accept(std::shared_ptr<Ping> ping)
+{
+    (*ping)();
+}

--- a/examples/charm++/PUP/STLPUP/SimplePUP.ci
+++ b/examples/charm++/PUP/STLPUP/SimplePUP.ci
@@ -12,9 +12,11 @@
 mainmodule SimplePUP {
   include "HeapObjectSTL.h";
   include "vector";
+  PUPable Ping;
 
   mainchare main {
     entry main(CkArgMsg *m);
+    entry void accept(std::shared_ptr<Ping> ping);
   };
 
   template <class U> array [1D] SimpleArray{

--- a/examples/charm++/PUP/STLPUP/SimplePUP.h
+++ b/examples/charm++/PUP/STLPUP/SimplePUP.h
@@ -9,9 +9,30 @@
 //
 ///////////////////////////////////////
 
+class Ping;
+
 #include "SimplePUP.decl.h"
 #include <vector>
 #include <cassert>
+
+class Ping: public PUP::able {
+  PUPable_decl(Ping);
+
+  Ping(int value) : value_(value) {}
+  Ping(CkMigrateMessage *m) : PUP::able(m) { }
+  virtual ~Ping() { }
+
+  virtual void pup(PUP::er &p) override {
+    PUP::able::pup(p);
+    p | value_;
+  }
+
+  void operator()() const {
+    CkPrintf("Ping %d!\n", value_);
+  }
+
+  int value_;
+};
 
 class main : public CBase_main {
 
@@ -20,6 +41,8 @@ public:
   main(CkMigrateMessage *m) {}
 
   main(CkArgMsg *m);
+
+  void accept(std::shared_ptr<Ping> ping);
 
 };
 


### PR DESCRIPTION
This patch enables PUP'ing of C++ shared pointers, where previously we could only PUP unique pointers. This limitation seems rather arbitrary to me, given we're on C++11 and should have support for both.