### PR TITLE
Add const correctness to ck::future

### DIFF
--- a/src/ck-core/ckfutures.h
+++ b/src/ck-core/ckfutures.h
@@ -88,7 +88,7 @@ namespace ck {
     }
 
     bool const is_ready() const { return CkProbeFuture(handle_); }
-    void release() const { CkReleaseFuture(handle_); }
+    void release() { CkReleaseFuture(handle_); }
     void pup(PUP::er &p) { p | handle_; }
   };
 }


### PR DESCRIPTION
This patch allows to work with `ck::future` const objects. Furthermore, it restricts value type `T` to be non-const and non-volatile.