### PR TITLE
Fix Potential Invalid Free Due to Dynamic Cast

### DIFF
--- a/src/util/pup.h
+++ b/src/util/pup.h
@@ -753,9 +753,10 @@ public:
 protected:
 	able() {}
 	able(CkMigrateMessage *) {}
-	virtual ~able();//Virtual destructor may be needed by some child
 
 public:
+	virtual ~able();//Virtual destructor may be needed by some child
+
 //Constructor function registration:
 	typedef able* (*constructor_function)(void);
 	static PUP_ID register_constructor(const char *className,

--- a/src/util/pup_stl.h
+++ b/src/util/pup_stl.h
@@ -516,7 +516,12 @@ using Requires = typename requires_impl<
   inline void pup(PUP::er &p, std::shared_ptr<T> &t) {
     PUP::able* _ = (p.isUnpacking()) ? nullptr : t.get();
     p(&_);
-    if (p.isUnpacking()) { t.reset(dynamic_cast<T*>(_)); }
+    if (p.isUnpacking()) {
+      // the shared ptr must be created with the original PUP::able ptr
+      // otherwise the dynamic cast can lead to invalid free's
+      // (it changes the pointer's address)
+      t = std::dynamic_pointer_cast<T>(std::shared_ptr<PUP::able>(_));
+    }
   }
 
   template <typename T>


### PR DESCRIPTION
This fixes potential invalid frees that can arise when a dynamic cast "changes" the address of the pointer. This _rarely_ occurs, but complex inheritance relationships can lead to these classes of failures (particularly when `PUP::able` is not the last class that a class publicly inherits). To make this possible, the virtual destructor of `PUP::able` needed to be made `public` from `protected`, but this is consistent with `PUP::er` and, since the destructor is a no-op, does not break encapsulation.