### PR TITLE
fixup! CI: Classify external code as "library" for lgtm (#3217)

### DIFF
--- a/.lgtm.yml
+++ b/.lgtm.yml
@@ -1,6 +1,6 @@
 # Classify external code as "library" to prevent lgtm from reporting their errors
 path_classifiers:
   library:
-    - src/libs/ck-libs/metis/libmetis/
+    - src/libs/ck-libs/metis/
     - src/util/json*
 


### PR DESCRIPTION
The previous commit excluded `src/libs/ck-libs/metis/GKlib` and other METIS root level files/folders.