### PR TITLE
icc: Fix broken hwloc configure

### DIFF
--- a/src/arch/common/cc-icc.sh
+++ b/src/arch/common/cc-icc.sh
@@ -1,6 +1,9 @@
 CMK_CPP_C='icc -E '
-CMK_CC="icc -fpic "
-CMK_CXX="icpc -fpic "
+CMK_CC="icc"
+CMK_CXX="icpc"
+
+CMK_CC_FLAGS="-fpic"
+CMK_CXX_FLAGS="-fpic"
 
 CMK_LD="icc -shared-intel "
 CMK_LDXX="icpc -shared-intel "


### PR DESCRIPTION
Building on Frontera without this patch results in an hwloc configure error:

```
$ ./build charm++ ucx-linux-x86_64 smp icc --with-production --enable-tracing --basedir=$HOME/ucx/build -j16
...
configure: error: unrecognized option: `-fpic'
Try `<...>/ucx-linux-x86_64-smp-icc/hwloc-prefix/src/hwloc/configure --help' for more information
make[2]: *** [hwloc-prefix/src/hwloc-stamp/hwloc-configure] Error 1
```