### PR TITLE
Remove AtSync's dependence on existence of LB

### DIFF
--- a/src/ck-core/cklocation.C
+++ b/src/ck-core/cklocation.C
@@ -2087,7 +2087,7 @@ CkLocMgr::CkLocMgr(CkMigrateMessage* m)
 
 CkLocMgr::~CkLocMgr() {
 #if CMK_LBDB_ON
-  syncBarrier->RemoveReceiver(lbBarrierReceiver);
+  syncBarrier->RemoveBeginReceiver(lbBarrierBeginReceiver);
   syncBarrier->RemoveEndReceiver(lbBarrierEndReceiver);
   lbmgr->UnregisterOM(myLBHandle);
 #endif
@@ -3281,7 +3281,7 @@ void CkLocMgr::initLB(CkGroupID lbmgrID_, CkGroupID metalbID_)
 
 	// Set up callbacks for this LocMgr to call Registering/DoneRegistering during
 	// each AtSync.
-	lbBarrierReceiver = syncBarrier->AddReceiver([=]() {
+	lbBarrierBeginReceiver = syncBarrier->AddBeginReceiver([=]() {
 	  DEBL((AA "CkLocMgr AtSync Receiver called\n" AB));
 	  lbmgr->RegisteringObjects(myLBHandle);
 	});

--- a/src/ck-core/cklocation.h
+++ b/src/ck-core/cklocation.h
@@ -560,7 +560,7 @@ private:
 	LBManager *lbmgr;
   MetaBalancer *the_metalb;
 	LDOMHandle myLBHandle;
-        LDBarrierReceiver lbBarrierReceiver;
+        LDBarrierReceiver lbBarrierBeginReceiver;
         LDBarrierReceiver lbBarrierEndReceiver;
 #endif
 private:

--- a/src/ck-core/cksyncbarrier.h
+++ b/src/ck-core/cksyncbarrier.h
@@ -118,7 +118,8 @@ public:
 
   // A begin receiver is a callback function that is called after all of the clients on
   // this PE reach this barrier and before calling the actual receivers, useful for
-  // setting up for the execution of those receivers
+  // setting up for the execution of those receivers. Will only be called when a receiver
+  // exists.
   LDBarrierReceiver AddBeginReceiver(std::function<void()> fn);
   template <typename T>
   inline LDBarrierReceiver AddBeginReceiver(T* obj, void (T::*method)(void))
@@ -128,7 +129,7 @@ public:
 
   // An end receiver is a callback function that is called when the receivers on this PE
   // have finished executing, right before the clients are resumed, useful for cleaning up
-  // or resetting state
+  // or resetting state. Will only be called when a receiver exists.
   LDBarrierReceiver AddEndReceiver(std::function<void()> fn);
   template <typename T>
   inline LDBarrierReceiver AddEndReceiver(T* obj, void (T::*method)(void))
@@ -151,6 +152,8 @@ public:
   void TurnOff() { on = false; };
 
   void ResumeClients(void);
+
+  bool hasReceivers() { return !receivers.empty(); };
 };
 
 #endif /* CKSYNCBARRIER_H */


### PR DESCRIPTION
Previously, AtSync would only be called when at least one load balancer existed, this removes that restriction, allowing AtSync to be cleanly used for non-LB purposes.

A new class of receiver, a BeginReceiver, is added as part of this PR. BeginReceiver and EndReceiver are used for setup and cleanup tasks for regular Receivers, which is where things like LB or other useful work is done. Currently, BeginReceiver and EndReceiver are used in `CkLocMgr` to trigger `RegisteringObjects` and `DoneRegisteringObjects`.
