### PR TITLE
Disentangle AtSync-LB-CkLocMgr dependencies

### DIFF
--- a/src/ck-core/cklocation.h
+++ b/src/ck-core/cklocation.h
@@ -560,8 +560,8 @@ private:
 	LBManager *lbmgr;
   MetaBalancer *the_metalb;
 	LDOMHandle myLBHandle;
-        LDBarrierClient lbBarrierClient;
-        LDBarrierReceiver lbBarrierReceiver;
+        LDBarrierReceiver lbBarrierBeginReceiver;
+        LDBarrierReceiver lbBarrierEndReceiver;
 #endif
 private:
 	void initLB(CkGroupID lbmgrID, CkGroupID metalbID);

--- a/src/ck-core/cksyncbarrier.C
+++ b/src/ck-core/cksyncbarrier.C
@@ -19,9 +19,11 @@ CkSyncBarrierInit::CkSyncBarrierInit(CkArgMsg* m)
 
 void CkSyncBarrier::reset()
 {
+  startedAtSync = false;
+
   if (rank0pe)
   {
-    std::fill(rank_needs_flood.begin(), rank_needs_flood.end(), true);
+    std::fill(rank_needs_kick.begin(), rank_needs_kick.end(), true);
     received_from_left = false;
     received_from_right = false;
   }
@@ -39,16 +41,17 @@ LDBarrierClient CkSyncBarrier::AddClient(Chare* chare, std::function<void()> fn,
     epoch = cur_epoch;
   else if (epoch > cur_epoch)
   {
-    // If the incoming client is ahead, then record those syncs and check the barrier if
-    // it can trigger. Do this asynchronously so that the caller functions for object
-    // construction finish first.
+    // If the incoming client is ahead of us, then record those syncs
     at_count += epoch - cur_epoch;
-    if (at_count >= clients.size())
-      thisProxy[thisIndex].CheckBarrier(false);
   }
 
   LBClient* new_client = new LBClient(chare, fn, epoch);
-  return LDBarrierClient(clients.insert(clients.end(), new_client));
+  const auto client = LDBarrierClient(clients.insert(clients.end(), new_client));
+  // Check the barrier if it can trigger. Do this asynchronously so that the caller
+  // functions for object construction finish first.
+  if (on && !startedAtSync && at_count >= clients.size())
+    thisProxy[thisIndex].CheckBarrier();
+  return client;
 }
 
 void CkSyncBarrier::RemoveClient(LDBarrierClient c)
@@ -58,33 +61,64 @@ void CkSyncBarrier::RemoveClient(LDBarrierClient c)
     at_count -= epoch - cur_epoch;
   delete *(c);
   clients.erase(c);
-  if (at_count >= clients.size())
-      thisProxy[thisIndex].CheckBarrier(false);
+  if (on && !startedAtSync && at_count >= clients.size())
+      thisProxy[thisIndex].CheckBarrier();
+}
+
+LDBarrierReceiver CkSyncBarrier::AddReceiverHelper(std::function<void()> fn,
+                                                   std::list<LBReceiver*>& receiverList)
+{
+  LBReceiver* new_receiver = new LBReceiver(fn);
+  return LDBarrierReceiver(receiverList.insert(receiverList.end(), new_receiver));
 }
 
 LDBarrierReceiver CkSyncBarrier::AddReceiver(std::function<void()> fn)
 {
-  LBReceiver* new_receiver = new LBReceiver(fn);
+  return AddReceiverHelper(std::move(fn), receivers);
+}
 
-  return LDBarrierReceiver(receivers.insert(receivers.end(), new_receiver));
+LDBarrierReceiver CkSyncBarrier::AddBeginReceiver(std::function<void()> fn)
+{
+  return AddReceiverHelper(std::move(fn), beginReceivers);
+}
+
+LDBarrierReceiver CkSyncBarrier::AddEndReceiver(std::function<void()> fn)
+{
+  return AddReceiverHelper(std::move(fn), endReceivers);
+}
+
+void CkSyncBarrier::RemoveReceiverHelper(
+    LDBarrierReceiver r, std::list<LBReceiver*>& receiverList)
+{
+  delete *(r);
+  receiverList.erase(r);
 }
 
 void CkSyncBarrier::RemoveReceiver(LDBarrierReceiver c)
 {
-  delete *(c);
-  receivers.erase(c);
+  RemoveReceiverHelper(c, receivers);
+}
+
+void CkSyncBarrier::RemoveBeginReceiver(LDBarrierReceiver c)
+{
+  RemoveReceiverHelper(c, beginReceivers);
+}
+
+void CkSyncBarrier::RemoveEndReceiver(LDBarrierReceiver c)
+{
+  RemoveReceiverHelper(c, endReceivers);
 }
 
 void CkSyncBarrier::TurnOnReceiver(LDBarrierReceiver c) { (*c)->on = 1; }
 
 void CkSyncBarrier::TurnOffReceiver(LDBarrierReceiver c) { (*c)->on = 0; }
 
-void CkSyncBarrier::AtBarrier(LDBarrierClient h, bool flood_atsync)
+void CkSyncBarrier::AtBarrier(LDBarrierClient h)
 {
   (*h)->epoch++;
   at_count++;
 
-  CheckBarrier(flood_atsync);
+  CheckBarrier();
 }
 
 void CkSyncBarrier::DecreaseBarrier(int c) { at_count -= c; }
@@ -106,21 +140,21 @@ void CkSyncBarrier::propagate_atsync()
     }
     else
     {  // Rank0 PE
-      // Flood non-zero ranks on this node
-      for (int i = 1; i < rank_needs_flood.size(); ++i)
+      // Kick non-zero ranks on this node
+      for (int i = 1; i < rank_needs_kick.size(); ++i)
       {
-        if (rank_needs_flood[i])
+        if (rank_needs_kick[i])
         {
           thisProxy[mype + i].recvLbStart(cur_epoch, mynode, mype);
         }
       }
       if (!received_from_left && mynode > 0)
-      {  // Flood left node
+      {  // Kick left node
         int pe = CkNodeFirst(mynode - 1);
         thisProxy[pe].recvLbStart(cur_epoch, mynode, mype);
       }
       if (!received_from_right && mynode < CkNumNodes() - 1)
-      {  // Flood right node
+      {  // Kick right node
         int pe = CkNodeFirst(mynode + 1);
         thisProxy[pe].recvLbStart(cur_epoch, mynode, mype);
       }
@@ -131,7 +165,11 @@ void CkSyncBarrier::propagate_atsync()
 
 void CkSyncBarrier::recvLbStart(int lb_step, int sourcenode, int pe)
 {
-  if (lb_step != cur_epoch || startedAtSync) return;
+  if (lb_step > currentKick)
+    currentKick = lb_step;
+  if (lb_step < cur_epoch || startedAtSync)
+    return;
+
   const int mype = CkMyPe();
   const int mynode = CkNodeOf(mype);
   if (sourcenode < mynode)
@@ -139,31 +177,24 @@ void CkSyncBarrier::recvLbStart(int lb_step, int sourcenode, int pe)
   else if (sourcenode > mynode)
     received_from_right = true;
   else if (rank0pe) // convert incoming pe number to local rank
-    rank_needs_flood[pe - mype] = false;
+    rank_needs_kick[pe - mype] = false;
   else
     received_from_rank0 = true;
-  if (clients.size() == 1 &&
-      clients.front()->chare->isLocMgr())  // CkLocMgr is usually a client on each PE
-    CheckBarrier(true);  // Empty PE invokes barrier on self on receiving a flood msg
+
+  if (clients.empty())
+    CheckBarrier();  // Empty PE invokes barrier on self on receiving a kick
 }
 
-void CkSyncBarrier::CheckBarrier(bool flood_atsync)
+void CkSyncBarrier::CheckBarrier()
 {
   if (!on) return;
 
   const auto client_count = clients.size();
 
-  if (client_count == 1 && !flood_atsync)
-  {
-    if (clients.front()->chare->isLocMgr()) return;
-  }
-
-  // If there are no clients, resume as soon as we're turned on
-  if (client_count == 0)
-  {
-    cur_epoch++;
-    CallReceivers();
-  }
+  // If there are no clients and the current kick is out of date or we're currently in the
+  // barrier, then return without triggering the barrier
+  if ((client_count == 0 && currentKick < cur_epoch) || startedAtSync)
+    return;
 
   if (at_count >= client_count)
   {
@@ -184,14 +215,15 @@ void CkSyncBarrier::CheckBarrier(bool flood_atsync)
       propagate_atsync();
       at_count -= client_count;
       cur_epoch++;
-      CallReceivers();
+      CallReceiverList(beginReceivers);
+      CallReceiverList(receivers);
     }
   }
 }
 
-void CkSyncBarrier::CallReceivers(void)
+void CkSyncBarrier::CallReceiverList(const std::list<LBReceiver*>& receiverList)
 {
-  for (auto& r : receivers)
+  for (auto& r : receiverList)
   {
     if (r->on)
     {
@@ -202,10 +234,13 @@ void CkSyncBarrier::CallReceivers(void)
 
 void CkSyncBarrier::ResumeClients(void)
 {
-  for (auto& c : clients) c->fn();
-
+  // The end receiver or client functions may trigger the barrier again, so make sure
+  // reset() is called before them to put the barrier in a valid state to be triggered
   reset();
-  startedAtSync = false;
+
+  CallReceiverList(endReceivers);
+
+  for (auto& c : clients) c->fn();
 }
 
 void CkSyncBarrier::pup(PUP::er& p)

--- a/src/ck-core/cksyncbarrier.ci
+++ b/src/ck-core/cksyncbarrier.ci
@@ -9,7 +9,7 @@ module CkSyncBarrier {
     entry void CkSyncBarrier(void);
     entry void ResumeClients();
     entry void recvLbStart(int lb_step, int sourcenode, int pe);
-    entry void CheckBarrier(bool flood_atsync);
+    entry void CheckBarrier();
   };
 
 };

--- a/src/ck-core/cksyncbarrier.h
+++ b/src/ck-core/cksyncbarrier.h
@@ -152,6 +152,8 @@ public:
   void TurnOff() { on = false; };
 
   void ResumeClients(void);
+
+  bool hasReceivers() { return !receivers.empty(); };
 };
 
 #endif /* CKSYNCBARRIER_H */

--- a/src/ck-core/cksyncbarrier.h
+++ b/src/ck-core/cksyncbarrier.h
@@ -42,15 +42,17 @@ class CkSyncBarrier : public CBase_CkSyncBarrier
 private:
   std::list<LBClient*> clients;
   std::list<LBReceiver*> receivers;
+  std::list<LBReceiver*> beginReceivers;
+  std::list<LBReceiver*> endReceivers;
 
-  std::vector<bool> rank_needs_flood;
+  std::vector<bool> rank_needs_kick;
 
   int cur_epoch;
   int at_count;
   bool on;
   bool rank0pe;
   int propagated_atsync_step;
-  int iter_no;
+  int currentKick;
   bool received_from_left;
   bool received_from_right;
   bool received_from_rank0;
@@ -60,22 +62,25 @@ private:
   {
     CkpvAccess(cksyncbarrierInited) = true;
     cur_epoch = 1;
-    iter_no = -1;
+    currentKick = 0;
     propagated_atsync_step = 0;
     at_count = 0;
     on = false;
-    startedAtSync = false;
     rank0pe = CkMyRank() == 0;
     if (rank0pe)
     {
-      rank_needs_flood.resize(CkNodeSize(CkMyNode()));
+      rank_needs_kick.resize(CkNodeSize(CkMyNode()));
     }
     reset();
   }
 
   void propagate_atsync();
   void reset();
-  void CallReceivers(void);
+  static void CallReceiverList(const std::list<LBReceiver*>& receiverList);
+
+  static LDBarrierReceiver AddReceiverHelper(std::function<void()> fn,
+                                      std::list<LBReceiver*>& receiverList);
+  void RemoveReceiverHelper(LDBarrierReceiver r, std::list<LBReceiver*>& receiverList);
 
 public:
   CkSyncBarrier() { init(); };
@@ -90,7 +95,7 @@ public:
                                            : nullptr;
   }
 
-  void CheckBarrier(bool flood_atsync = false);
+  void CheckBarrier();
   void recvLbStart(int lb_step, int sourcenode, int pe);
 
   LDBarrierClient AddClient(Chare* chare, std::function<void()> fn, int epoch = -1);
@@ -101,6 +106,9 @@ public:
   }
 
   void RemoveClient(LDBarrierClient h);
+
+  // A receiver is a callback function that is called when all of the clients on this PE
+  // reach this barrier
   LDBarrierReceiver AddReceiver(std::function<void()> fn);
   template <typename T>
   inline LDBarrierReceiver AddReceiver(T* obj, void (T::*method)(void))
@@ -108,10 +116,33 @@ public:
     return AddReceiver(std::bind(method, obj));
   }
 
+  // A begin receiver is a callback function that is called after all of the clients on
+  // this PE reach this barrier and before calling the actual receivers, useful for
+  // setting up for the execution of those receivers. Will only be called when a receiver
+  // exists.
+  LDBarrierReceiver AddBeginReceiver(std::function<void()> fn);
+  template <typename T>
+  inline LDBarrierReceiver AddBeginReceiver(T* obj, void (T::*method)(void))
+  {
+    return AddBeginReceiver(std::bind(method, obj));
+  }
+
+  // An end receiver is a callback function that is called when the receivers on this PE
+  // have finished executing, right before the clients are resumed, useful for cleaning up
+  // or resetting state. Will only be called when a receiver exists.
+  LDBarrierReceiver AddEndReceiver(std::function<void()> fn);
+  template <typename T>
+  inline LDBarrierReceiver AddEndReceiver(T* obj, void (T::*method)(void))
+  {
+    return AddEndReceiver(std::bind(method, obj));
+  }
+
   void RemoveReceiver(LDBarrierReceiver h);
+  void RemoveBeginReceiver(LDBarrierReceiver h);
+  void RemoveEndReceiver(LDBarrierReceiver h);
   void TurnOnReceiver(LDBarrierReceiver h);
   void TurnOffReceiver(LDBarrierReceiver h);
-  void AtBarrier(LDBarrierClient _n_c, bool flood_atsync = false);
+  void AtBarrier(LDBarrierClient _n_c);
   void DecreaseBarrier(int c);
   void TurnOn()
   {

--- a/src/ck-ldb/LBDatabase.C
+++ b/src/ck-ldb/LBDatabase.C
@@ -61,9 +61,13 @@ void LBDatabase::DoneRegisteringObjects(LDOMHandle omh)
     LBOM* om = oms[omh.handle];
     if (om->RegisteringObjs()) {
       omsRegistering--;
-      if (omsRegistering == 0)
-        syncBarrier->TurnOn();
       om->SetRegisteringObjs(false);
+      if (omsRegistering == 0)
+        // This call to TurnOn must come after the decrement of omsRegistering and the
+        // call to SetRegisteringObjs(false) because TurnOn() can start off a chain that
+        // calls RegisteringObjects(omh), so this ensures that the variables are in the correct
+        // state if flow reaches there.
+        syncBarrier->TurnOn();
     }
   }
 }


### PR DESCRIPTION
Previously, `CkLocMgr` was shoehorned into being an AtSync client and AtSync would only be called when at least one load balancer existed, this removes these restrictions, allowing AtSync to be cleanly used for non-LB purposes and creating less blurry boundaries between the various components.

New classes of receivers, BeginReceiver and EndReceiver, are added as part of this PR. BeginReceiver and EndReceiver are used for setup and cleanup tasks for regular Receivers, which is where things like LB or other useful work is done. Currently, BeginReceiver and EndReceiver are used in CkLocMgr to trigger RegisteringObjects and DoneRegisteringObjects.

Please rebase as a merge strategy.

Replaces #3247 and #3170, this is a combined version of both of those PRs.