### PR TITLE
Skip commbench on Golub because it times out autobuild run

### DIFF
--- a/benchmarks/converse/commbench/Makefile
+++ b/benchmarks/converse/commbench/Makefile
@@ -13,7 +13,7 @@ LOCALHOSTNAME:=$(shell hostname 2>/dev/null)
 
 test: commbench
 ifneq (,$(findstring golub,$(LOCALHOSTNAME)))
-	@echo "Skipping commbench on Golub because of performance bug"
+	@echo "Skipping commbench on Golub because of performance bug #3257"
 else
 	$(call run, ./commbench +p4 )
 endif

--- a/benchmarks/converse/commbench/Makefile
+++ b/benchmarks/converse/commbench/Makefile
@@ -19,7 +19,11 @@ else
 endif
 
 testp: commbench
+ifneq (,$(findstring golub,$(LOCALHOSTNAME)))
+	@echo "Skipping commbench on Golub because of performance bug"
+else
 	$(call run, ./commbench +p$(P))
+endif
 
 memoryAccess.o: memoryAccess.c
 	$(CHARMC) memoryAccess.c

--- a/benchmarks/converse/commbench/Makefile
+++ b/benchmarks/converse/commbench/Makefile
@@ -9,8 +9,14 @@ all: commbench
 commbench: $(OBJS)
 	$(CHARMC) -o commbench $(OBJS) -language converse++
 
+HOST=$(shell hostname)
+
 test: commbench
+ifneq (,$(findstring golub,$(HOST)))
+	@echo "Skipping commbench on Golub because of performance bug"
+else
 	$(call run, ./commbench +p4 )
+endif
 
 testp: commbench
 	$(call run, ./commbench +p$(P))

--- a/benchmarks/converse/commbench/Makefile
+++ b/benchmarks/converse/commbench/Makefile
@@ -9,10 +9,10 @@ all: commbench
 commbench: $(OBJS)
 	$(CHARMC) -o commbench $(OBJS) -language converse++
 
-HOST=$(shell hostname)
+LOCALHOSTNAME:=$(shell hostname 2>/dev/null)
 
 test: commbench
-ifneq (,$(findstring golub,$(HOST)))
+ifneq (,$(findstring golub,$(LOCALHOSTNAME)))
 	@echo "Skipping commbench on Golub because of performance bug"
 else
 	$(call run, ./commbench +p4 )
@@ -62,4 +62,3 @@ clean:
 	rm -f TAGS *.o
 	rm -f commbench
 	rm -f conv-host charmrun charmrun.exe commbench.exe commbench.pdb commbench.ilk
-

--- a/benchmarks/converse/commbench/Makefile
+++ b/benchmarks/converse/commbench/Makefile
@@ -20,7 +20,7 @@ endif
 
 testp: commbench
 ifneq (,$(findstring golub,$(LOCALHOSTNAME)))
-	@echo "Skipping commbench on Golub because of performance bug"
+	@echo "Skipping commbench on Golub because of performance bug #3257"
 else
 	$(call run, ./commbench +p$(P))
 endif


### PR DESCRIPTION
I've opened a separate issue to look into the performance issue on golub. (https://github.com/UIUC-PPL/charm/issues/3257). 