### PR TITLE
CkCache.h: Fix compile error if COSMO_STATS is defined.

### DIFF
--- a/src/libs/ck-libs/cache/CkCache.h
+++ b/src/libs/ck-libs/cache/CkCache.h
@@ -612,7 +612,7 @@ inline void CkCacheManager<CkCacheKey>::recvData(CkCacheKey key, void *data, CkC
     CkCacheStatistics cs(dataArrived, dataTotalArrived,
         dataMisses, dataLocal, dataError, totalDataRequested,
         maxData, CkMyPe());
-    contribute(sizeof(CkCacheStatistics), &cs, CkCacheStatistics::sum, cb);
+    this->contribute(sizeof(CkCacheStatistics), &cs, CkCacheStatistics::sum, cb);
 #else
     CkAbort("Invalid call, only valid if COSMO_STATS is defined");
 #endif


### PR DESCRIPTION
When changa is compiled with COSMO_STATS defined, the compile fails with
```
/home/trq/nchil/src/charm/include/CkCache.h: In member function ‘void CkCacheManager<CkCacheKey>::collectStatistics(CkCallback)’:
/home/trq/nchil/src/charm/include/CkCache.h:615:5: error: there are no arguments to ‘contribute’ that depend on a template parameter, so a declaration of ‘contribute’ must be available [-fpermissive]
  615 |     contribute(sizeof(CkCacheStatistics), &cs, CkCacheStatistics::sum, cb);
      |     ^~~~~~~~~~
/home/trq/nchil/src/charm/include/CkCache.h:615:5: note: (if you use ‘-fpermissive’, G++ will accept your code, but allowing the use of an undeclared name is deprecated)

```
This fixes the error.