### PR TITLE
Revert "buildcmake: Use -cpmod to copy Fortran .mod files (#3159)"

### DIFF
--- a/cmake/converse.cmake
+++ b/cmake/converse.cmake
@@ -152,7 +152,11 @@ set(conv-util-cxx-sources
 
 if(CMK_CAN_LINK_FORTRAN)
     add_library(conv-utilf pup_f.f90)
-    target_compile_options(conv-utilf PRIVATE -cpmod)
+    add_custom_command(TARGET conv-utilf
+        POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_BINARY_DIR}/pupmod.mod ${CMAKE_BINARY_DIR}/include/
+        VERBATIM
+    )
 endif()
 
 add_custom_command(OUTPUT pup_f.f90 COMMAND ${CMAKE_SOURCE_DIR}/src/util/pup_f.f90.sh > /dev/null)

--- a/src/ck-core/CMakeLists.txt
+++ b/src/ck-core/CMakeLists.txt
@@ -132,10 +132,14 @@ target_include_directories(ck PRIVATE . ../ck-ldb ../ck-perf ../ck-cp ../util/to
 target_include_directories(ckmain PRIVATE . ../ck-ldb ../ck-perf ../ck-cp ../util/topomanager)
 
 # Fortran interface
-if(${CMK_CAN_LINK_FORTRAN})
+if(CMK_CAN_LINK_FORTRAN)
     add_library(ckf charmf.C charmmod.f90 charmf.h)
-    target_compile_options(ckf PRIVATE -cpmod)
     add_dependencies(ckf ck)
+    add_custom_command(TARGET ckf
+        POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_BINARY_DIR}/charm.mod ${CMAKE_BINARY_DIR}/include/
+        VERBATIM
+    )
     add_library(ckmainf mainf.f90)
 
     add_library(f90charm ../langs/f90charm/f90main.C ${CMAKE_BINARY_DIR}/include/f90main.decl.h)

--- a/src/ck-perf/CMakeLists.txt
+++ b/src/ck-perf/CMakeLists.txt
@@ -42,5 +42,9 @@ add_dependencies(trace-converse ck)
 
 if(CMK_CAN_LINK_FORTRAN)
     add_library(tracef_f tracef_f.f90)
-    target_compile_options(tracef_f PRIVATE -cpmod)
+    add_custom_command(TARGET tracef_f
+        POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_BINARY_DIR}/tracemod.mod ${CMAKE_BINARY_DIR}/include/
+        VERBATIM
+    )
 endif()

--- a/src/libs/ck-libs/ampi/CMakeLists.txt
+++ b/src/libs/ck-libs/ampi/CMakeLists.txt
@@ -475,7 +475,7 @@ if(CMK_CAN_LINK_FORTRAN)
     add_library(ampifimpl OBJECT ampifimpl.f90)
     target_compile_options(ampifimpl PRIVATE -I${CMAKE_BINARY_DIR}/include/ampi/)
     add_library(ampimod OBJECT ampimod.f90)
-    target_compile_options(ampimod PRIVATE -cpmod -I${CMAKE_BINARY_DIR}/include/ampi/)
+    target_compile_options(ampimod PRIVATE -I${CMAKE_BINARY_DIR}/include/ampi/)
     add_dependencies(ampif ck)
     add_dependencies(ampifimpl ck)
     add_dependencies(ampimod ck)
@@ -485,6 +485,7 @@ if(CMK_CAN_LINK_FORTRAN)
         COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_BINARY_DIR}/CMakeFiles/ampif.dir/ampif.C.o ${CMAKE_BINARY_DIR}/lib/ampif.o
         COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_BINARY_DIR}/CMakeFiles/ampifimpl.dir/ampifimpl.f90.o ${CMAKE_BINARY_DIR}/lib/ampifimpl.o
         COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_BINARY_DIR}/CMakeFiles/ampimod.dir/ampimod.f90.o ${CMAKE_BINARY_DIR}/lib/ampimod.o
+        COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_BINARY_DIR}/mpi.mod ${CMAKE_BINARY_DIR}/include/
         VERBATIM
     )
 endif()


### PR DESCRIPTION
This reverts commit 3cd2c7b17bb4be260d9606ad65b6c9de2a6c3429, which did not actually work, and CI did not catch it.