### PR TITLE
Do not skip commbench on Golub

### DIFF
--- a/benchmarks/converse/commbench/Makefile
+++ b/benchmarks/converse/commbench/Makefile
@@ -9,21 +9,11 @@ all: commbench
 commbench: $(OBJS)
 	$(CHARMC) -o commbench $(OBJS) -language converse++
 
-LOCALHOSTNAME:=$(shell hostname 2>/dev/null)
-
 test: commbench
-ifneq (,$(findstring golub,$(LOCALHOSTNAME)))
-	@echo "Skipping commbench on Golub because of performance bug #3257"
-else
 	$(call run, ./commbench +p4 )
-endif
 
 testp: commbench
-ifneq (,$(findstring golub,$(LOCALHOSTNAME)))
-	@echo "Skipping commbench on Golub because of performance bug #3257"
-else
 	$(call run, ./commbench +p$(P))
-endif
 
 memoryAccess.o: memoryAccess.c
 	$(CHARMC) memoryAccess.c


### PR DESCRIPTION
The previously seen slowdown in commbench was a result of incorrect
PE-binding caused because of not specifying the number of processes
in the slurm job script. Since it was not a bug within charm, this
commit reverts the skipping of benchmarks/converse/commbench since
it runs without any slowdown when the -n <processes> SBATCH directive
is passed in the slurm script. 

