### PR TITLE
LocMgr: Add epoch to location updates to prevent hangs

### DIFF
--- a/src/ck-core/ckarray.C
+++ b/src/ck-core/ckarray.C
@@ -901,7 +901,7 @@ void CkArray::prepareCtorMsg(CkMessage *m, int *listenerData)
 
 int CkArray::findInitialHostPe(const CkArrayIndex &idx, int proposedPe)
 {
-  int hostPe = locMgr->whichPE(idx);
+  int hostPe = locMgr->whichPe(idx);
 
   if (hostPe == -1 && proposedPe == -1)
     return procNum(idx);

--- a/src/ck-core/ckarray.h
+++ b/src/ck-core/ckarray.h
@@ -591,7 +591,10 @@ public:
   /// Return the last known processor for this array index.
   /// Valid for any possible array index.
   inline int lastKnown(const CkArrayIndex &idx) const
-	  {return locMgr->lastKnown(idx);}
+	{
+    int pe = locMgr->whichPe(idx);
+    return pe == -1 ? homePe(idx) : pe;
+  }
   /// Deliver message to this element (directly if local)
   /// doFree if is local
   inline void deliver(CkMessage *m, const CkArrayIndex &idx, CkDeliver_t type,int opts=0)

--- a/src/ck-core/ckarray.h
+++ b/src/ck-core/ckarray.h
@@ -591,7 +591,7 @@ public:
   /// Return the last known processor for this array index.
   /// Valid for any possible array index.
   inline int lastKnown(const CkArrayIndex &idx) const
-	{
+  {
     int pe = locMgr->whichPe(idx);
     return pe == -1 ? homePe(idx) : pe;
   }

--- a/src/ck-core/cklocation.C
+++ b/src/ck-core/cklocation.C
@@ -2460,6 +2460,7 @@ void CkLocCache::insert(CmiUInt8 id, int epoch)
   e.id = id;
   e.pe = CkMyPe();
   e.epoch = epoch;
+  notifyListeners(e.id, e.pe);
 }
 
 /*************************** LocMgr: CREATION *****************************/

--- a/src/ck-core/cklocation.C
+++ b/src/ck-core/cklocation.C
@@ -3531,7 +3531,7 @@ void CkLocMgr::immigrate(CkArrayElementMigrateMessage* msg)
 
   // Create a record for this element
   CkLocRec* rec =
-      createLocal(idx, true, msg->ignoreArrival, false, msg->epoch /* home told on departure */);
+      createLocal(idx, true, msg->ignoreArrival, false, /* home told on departure */, msg->epoch);
 
   envelope* env = UsrToEnv(msg);
   CmiAssert(CpvAccess(newZCPupGets).empty());  // Ensure that vector is empty

--- a/src/ck-core/cklocation.C
+++ b/src/ck-core/cklocation.C
@@ -2423,6 +2423,9 @@ void CkLocCache::requestLocation(CmiUInt8 id, const int peToTell)
   if (peToTell == CkMyPe()) return;
 
   LocationMap::const_iterator itr = locMap.find(id);
+  // TODO: If the location is not found, we probably need to buffer this request. Should
+  // only effect very weird corner cases at the moment, and is a problem that already
+  // existed, but should be addressed in the upcoming delivery/buffering cleanup.
   if (itr != locMap.end())
   {
     thisProxy[peToTell].updateLocation(itr->second);

--- a/src/ck-core/cklocation.C
+++ b/src/ck-core/cklocation.C
@@ -2363,6 +2363,7 @@ void CkLocMgr::flushLocalRecs(void)
 void CkLocMgr::flushAllRecs(void) { flushLocalRecs(); }
 
 /*************************** LocCache **************************/
+const CkLocEntry CkLocEntry::nullEntry = CkLocEntry();
 void CkLocCache::pup(PUP::er& p)
 {
 #if __FAULT__
@@ -3531,7 +3532,7 @@ void CkLocMgr::immigrate(CkArrayElementMigrateMessage* msg)
 
   // Create a record for this element
   CkLocRec* rec =
-      createLocal(idx, true, msg->ignoreArrival, false, /* home told on departure */, msg->epoch);
+      createLocal(idx, true, msg->ignoreArrival, false /* home told on departure */, msg->epoch);
 
   envelope* env = UsrToEnv(msg);
   CmiAssert(CpvAccess(newZCPupGets).empty());  // Ensure that vector is empty

--- a/src/ck-core/cklocation.C
+++ b/src/ck-core/cklocation.C
@@ -2398,6 +2398,7 @@ void CkLocCache::pup(PUP::er& p)
     {
       CkLocEntry e;
       p | e;
+      e.epoch = 0;
       updateLocation(e);
       if (homePe(e.id) != CkMyPe())
       {

--- a/src/ck-core/cklocation.C
+++ b/src/ck-core/cklocation.C
@@ -2443,7 +2443,7 @@ void CkLocCache::updateLocation(const CkLocEntry& newEntry)
   }
 }
 
-void CkLocCache::moveTo(CmiUInt8 id, int pe)
+void CkLocCache::recordEmigration(CmiUInt8 id, int pe)
 {
   LocationMap::iterator itr = locMap.find(id);
 
@@ -3481,7 +3481,7 @@ void CkLocMgr::emigrate(CkLocRec* rec, int toPe)
   }
   duringMigration = false;
 
-  cache->moveTo(id, toPe);
+  cache->recordEmigration(id, toPe);
   informHome(idx, toPe);
 
 #if !CMK_LBDB_ON && CMK_GLOBAL_LOCATION_UPDATE

--- a/src/ck-core/cklocation.ci
+++ b/src/ck-core/cklocation.ci
@@ -8,15 +8,14 @@ module CkLocation {
   group [migratable] CkLocCache {
     entry CkLocCache();
     entry [expedited] void requestLocation(CmiUInt8 id, int peToTell);
-    entry [expedited] void updateLocation(CmiUInt8 id, int nowOnPe);
+    entry [expedited] void updateLocation(CkLocEntry newEntry);
   };
 
   group [migratable] CkLocMgr {
     entry CkLocMgr(CkArrayOptions opts);
     entry [expedited] void immigrate(CkArrayElementMigrateMessage *msg);
     entry [expedited] void requestLocation(CkArrayIndex idx, int peToTell);
-    entry [expedited] void updateLocation(
-        CkArrayIndex idx, CmiUInt8 id, int nowOnPe);
+    entry [expedited] void updateLocation(CkArrayIndex idx, CkLocEntry e);
     entry [expedited] void requestDemandCreation(
         const CkArrayIndex& idx, int forPe, int onPe, int cType, CkArrayID mgr);
     entry void reclaimRemote(CkArrayIndex idx,int deletedOnPe);

--- a/src/ck-core/cklocation.ci
+++ b/src/ck-core/cklocation.ci
@@ -8,17 +8,17 @@ module CkLocation {
   group [migratable] CkLocCache {
     entry CkLocCache();
     entry [expedited] void requestLocation(CmiUInt8 id, int peToTell);
-    entry [expedited] void updateLocation(CkLocEntry newEntry);
+    entry [expedited] void updateLocation(const CkLocEntry& newEntry);
   };
 
   group [migratable] CkLocMgr {
     entry CkLocMgr(CkArrayOptions opts);
     entry [expedited] void immigrate(CkArrayElementMigrateMessage *msg);
-    entry [expedited] void requestLocation(CkArrayIndex idx, int peToTell);
-    entry [expedited] void updateLocation(CkArrayIndex idx, CkLocEntry e);
+    entry [expedited] void requestLocation(const CkArrayIndex& idx, int peToTell);
+    entry [expedited] void updateLocation(const CkArrayIndex& idx, const CkLocEntry& e);
     entry [expedited] void requestDemandCreation(
         const CkArrayIndex& idx, int forPe, int onPe, int cType, CkArrayID mgr);
-    entry void reclaimRemote(CkArrayIndex idx,int deletedOnPe);
+    entry void reclaimRemote(const CkArrayIndex& idx,int deletedOnPe);
   };
   
   // Array Map object support:

--- a/src/ck-core/cklocation.h
+++ b/src/ck-core/cklocation.h
@@ -72,6 +72,14 @@ typedef enum : uint8_t
 PUPbytes(CkDeliver_t)
 
     class CkArrayOptions;
+
+struct CkLocEntry {
+  CmiUInt8 id = 0;
+  int pe = -1;
+  int epoch = -1;
+};
+PUPbytes(CkLocEntry);
+
 #include "CkLocation.decl.h"
 
 /************************** Array Messages ****************************/
@@ -83,12 +91,13 @@ class CkArrayElementMigrateMessage : public CMessage_CkArrayElementMigrateMessag
 {
 public:
   CkArrayElementMigrateMessage(CkArrayIndex idx_, CmiUInt8 id_, bool ignoreArrival_,
-                               int length_, int nManagers_)
+                               int length_, int nManagers_, int epoch_)
       : idx(idx_),
         id(id_),
         ignoreArrival(ignoreArrival_),
         length(length_),
-        nManagers(nManagers_)
+        nManagers(nManagers_),
+        epoch(epoch_)
   {
   }
 
@@ -97,6 +106,7 @@ public:
   bool ignoreArrival;  // if to inform LB of arrival
   int length;          // Size in bytes of the packed data
   int nManagers;       // Number of associated array managers
+  int epoch;
   char* packData;
 };
 
@@ -301,25 +311,33 @@ enum CkElementCreation_t : uint8_t
 class CkLocCache : public CBase_CkLocCache
 {
 private:
+  // TODO: Temporary fix to allow for direct access to location entries
+  friend CkLocMgr;
+  // This is the entry in the location table, which stores the PE and epoch number of the
+  // latest location update.
+  // TODO: If we can template CkLocCache on this type, we could store more useful
+  // information for specific entities being managed. ie: for arrays it could store
+  // indices as well. Could also store homePe if useful? Then one lookup would get you
+  // everything you need, rather than looking up in a bunch of tables.
+  // TODO: Is in the right type for pe and epoch?
+
   // Map of ID to PE
-  using IdPeMap = std::unordered_map<CmiUInt8, int>;
-  IdPeMap id2pe;
+  using LocationMap = std::unordered_map<CmiUInt8, CkLocEntry>;
+  LocationMap locMap;
 
   using Listener = std::function<void(CmiUInt8, int)>;
   std::list<Listener> listeners;
-
 public:
   CkLocCache() = default;
   CkLocCache(CkMigrateMessage* m) : CBase_CkLocCache(m) {}
   ~CkLocCache() = default;
   void pup(PUP::er& p);
 
-  void inform(CmiUInt8 id, int nowOnPe);
   int homePe(const CmiUInt8 id) const { return id >> CMK_OBJID_ELEMENT_BITS; }
   void requestLocation(CmiUInt8 id);
   void requestLocation(CmiUInt8 id, int peToTell);
-  void updateLocation(CmiUInt8 id, int nowOnPe);
-  void erase(CmiUInt8 id) { id2pe.erase(id); }
+  void updateLocation(const CkLocEntry& e);
+  void erase(CmiUInt8 id) { locMap.erase(id); }
 
   void addListener(Listener l) { listeners.push_back(l); }
   void notifyListeners(CmiUInt8 id, int pe)
@@ -332,8 +350,8 @@ public:
 
   int whichPE(const CmiUInt8 id) const
   {
-    IdPeMap::const_iterator itr = id2pe.find(id);
-    return itr != id2pe.end() ? itr->second : -1;
+    LocationMap::const_iterator itr = locMap.find(id);
+    return itr != locMap.end() ? itr->second.pe : -1;
   }
 
   int lastKnown(CmiUInt8 id) const
@@ -391,7 +409,7 @@ private:
 
   // Create a new local record at this array index.
   CkLocRec* createLocal(const CkArrayIndex& idx, bool forMigration, bool ignoreArrival,
-                        bool notifyHome);
+                        bool notifyHome, int epoch = 0);
 
   LocationRequestBuffer bufferedLocationRequests;
 
@@ -685,7 +703,7 @@ public:
   void immigrate(CkArrayElementMigrateMessage* msg);
   void requestLocation(const CkArrayIndex& idx);
   bool requestLocation(const CkArrayIndex& idx, int peToTell);
-  void updateLocation(const CkArrayIndex& idx, CmiUInt8 id, int nowOnPe);
+  void updateLocation(const CkArrayIndex& idx, const CkLocEntry& e);
   void reclaimRemote(const CkArrayIndex& idx, int deletedOnPe);
   void dummyAtSync(void);
 

--- a/src/ck-core/cklocation.h
+++ b/src/ck-core/cklocation.h
@@ -672,7 +672,6 @@ public:
 
   // Advisories:
   /// This index now lives on the given processor-- update local records
-  void inform(const CkArrayIndex& idx, CmiUInt8 id, int nowOnPe);
   void informHome(const CkArrayIndex& idx, int nowOnPe);
 
   /// This message took several hops to reach us-- fix it

--- a/src/ck-core/cklocation.h
+++ b/src/ck-core/cklocation.h
@@ -73,6 +73,13 @@ PUPbytes(CkDeliver_t)
 
     class CkArrayOptions;
 
+// This is the entry in the location table, which stores the PE and epoch number of the
+// latest location update.
+// TODO: If we can template CkLocCache on this type, we could store more useful
+// information for specific entities being managed. ie: for arrays it could store
+// indices as well. Then one lookup would get you everything you need, rather than looking
+// up in a bunch of tables.
+// TODO: Is int the right type for pe and epoch?
 struct CkLocEntry {
   CmiUInt8 id = 0;
   int pe = -1;
@@ -311,14 +318,6 @@ enum CkElementCreation_t : uint8_t
 class CkLocCache : public CBase_CkLocCache
 {
 private:
-  // This is the entry in the location table, which stores the PE and epoch number of the
-  // latest location update.
-  // TODO: If we can template CkLocCache on this type, we could store more useful
-  // information for specific entities being managed. ie: for arrays it could store
-  // indices as well. Could also store homePe if useful? Then one lookup would get you
-  // everything you need, rather than looking up in a bunch of tables.
-  // TODO: Is int the right type for pe and epoch?
-
   // Map of ID to PE
   using LocationMap = std::unordered_map<CmiUInt8, CkLocEntry>;
   LocationMap locMap;
@@ -326,7 +325,7 @@ private:
   using Listener = std::function<void(CmiUInt8, int)>;
   std::list<Listener> listeners;
 
-  const CkLocEntry nullEntry = CkLocEntry();
+  constexpr CkLocEntry nullEntry = CkLocEntry();
 public:
   CkLocCache() = default;
   CkLocCache(CkMigrateMessage* m) : CBase_CkLocCache(m) {}
@@ -350,7 +349,7 @@ public:
   }
   int getPe(const CmiUInt8 id) const { return getLocationEntry(id).pe; }
   int getEpoch(const CmiUInt8 id) const { return getLocationEntry(id).epoch; }
-  int homePe(const CmiUInt8 id) const { return id >> CMK_OBJID_ELEMENT_BITS; }
+  int homePe(const CmiUInt8 id) const { return ck::ObjID(id).getHomeID(); }
 
   // Insertion and removal
   void insert(CmiUInt8 id, int epoch = 0);

--- a/src/ck-core/cklocation.h
+++ b/src/ck-core/cklocation.h
@@ -339,6 +339,9 @@ public:
   void requestLocation(CmiUInt8 id, int peToTell);
   void updateLocation(const CkLocEntry& e);
 
+  // Update the location table when an element migrates away
+  void recordEmigration(CmiUInt8 id, int pe);
+
   // Query the local location table
   const CkLocEntry& getLocationEntry(CmiUInt8 id) const
   {
@@ -349,8 +352,7 @@ public:
   int getEpoch(const CmiUInt8 id) const { return getLocationEntry(id).epoch; }
   int homePe(const CmiUInt8 id) const { return id >> CMK_OBJID_ELEMENT_BITS; }
 
-  // Modify the location table
-  void moveTo(CmiUInt8 id, int pe);
+  // Insertion and removal
   void insert(CmiUInt8 id, int epoch = 0);
   void erase(CmiUInt8 id) { locMap.erase(id); }
 

--- a/src/ck-core/cklocation.h
+++ b/src/ck-core/cklocation.h
@@ -84,6 +84,8 @@ struct CkLocEntry {
   CmiUInt8 id = 0;
   int pe = -1;
   int epoch = -1;
+
+  const static CkLocEntry nullEntry;
 };
 PUPbytes(CkLocEntry);
 
@@ -325,7 +327,6 @@ private:
   using Listener = std::function<void(CmiUInt8, int)>;
   std::list<Listener> listeners;
 
-  constexpr CkLocEntry nullEntry = CkLocEntry();
 public:
   CkLocCache() = default;
   CkLocCache(CkMigrateMessage* m) : CBase_CkLocCache(m) {}
@@ -345,7 +346,7 @@ public:
   const CkLocEntry& getLocationEntry(CmiUInt8 id) const
   {
     LocationMap::const_iterator itr = locMap.find(id);
-    return itr != locMap.end() ? itr->second : nullEntry;
+    return itr != locMap.end() ? itr->second : CkLocEntry::nullEntry;
   }
   int getPe(const CmiUInt8 id) const { return getLocationEntry(id).pe; }
   int getEpoch(const CmiUInt8 id) const { return getLocationEntry(id).epoch; }

--- a/src/ck-core/cklocation.h
+++ b/src/ck-core/cklocation.h
@@ -317,7 +317,7 @@ private:
   // information for specific entities being managed. ie: for arrays it could store
   // indices as well. Could also store homePe if useful? Then one lookup would get you
   // everything you need, rather than looking up in a bunch of tables.
-  // TODO: Is in the right type for pe and epoch?
+  // TODO: Is int the right type for pe and epoch?
 
   // Map of ID to PE
   using LocationMap = std::unordered_map<CmiUInt8, CkLocEntry>;

--- a/src/ck-core/ckmemcheckpoint.C
+++ b/src/ck-core/ckmemcheckpoint.C
@@ -1061,7 +1061,8 @@ void CkMemCheckPT::gotData()
 
 void CkMemCheckPT::updateLocations(int n, CkGroupID *g, CkArrayIndex *idx, CmiUInt8 *id, int nowOnPe)
 {
-
+  // TODO: This function is not called, and no longer works with the new location
+  // management API.
   for (int i=0; i<n; i++) {
     CkLocMgr *mgr = CProxy_CkLocMgr(g[i]).ckLocalBranch();
     //mgr->updateLocation(idx[i], id[i], nowOnPe);

--- a/src/ck-core/ckmemcheckpoint.C
+++ b/src/ck-core/ckmemcheckpoint.C
@@ -1064,7 +1064,7 @@ void CkMemCheckPT::updateLocations(int n, CkGroupID *g, CkArrayIndex *idx, CmiUI
 
   for (int i=0; i<n; i++) {
     CkLocMgr *mgr = CProxy_CkLocMgr(g[i]).ckLocalBranch();
-    mgr->updateLocation(idx[i], id[i], nowOnPe);
+    //mgr->updateLocation(idx[i], id[i], nowOnPe);
   }
 	thisProxy[nowOnPe].gotReply();
 }

--- a/src/libs/ck-libs/NDMeshStreamer/NDMeshStreamer.h
+++ b/src/libs/ck-libs/NDMeshStreamer/NDMeshStreamer.h
@@ -1295,6 +1295,7 @@ public:
 
   void resendMisdeliveredItems(CkArrayIndex arrayId, int destinationPe) {
 
+    // TODO: This is an optimization that no longer works with the new CkLocMgr API
     //clientLocMgr_->updateLocation(arrayId, clientLocMgr_->lookupID(arrayId),destinationPe);
 
     std::vector<dtype > &bufferedItems
@@ -1315,6 +1316,7 @@ public:
     int prevOwner = clientArrayMgr_->lastKnown((CkArrayIndex)arrayId);
 
     if (prevOwner != destinationPe) {
+      // TODO: This is an optimization that no longer works with the new CkLocMgr API
       //clientLocMgr_->updateLocation(arrayId,clientLocMgr_->lookupID(arrayId), destinationPe);
 
       // it is possible to also fix destinations of items buffered for arrayId,

--- a/src/libs/ck-libs/NDMeshStreamer/NDMeshStreamer.h
+++ b/src/libs/ck-libs/NDMeshStreamer/NDMeshStreamer.h
@@ -1295,7 +1295,7 @@ public:
 
   void resendMisdeliveredItems(CkArrayIndex arrayId, int destinationPe) {
 
-    clientLocMgr_->updateLocation(arrayId, clientLocMgr_->lookupID(arrayId),destinationPe);
+    //clientLocMgr_->updateLocation(arrayId, clientLocMgr_->lookupID(arrayId),destinationPe);
 
     std::vector<dtype > &bufferedItems
       = misdeliveredItems[arrayId];
@@ -1315,7 +1315,7 @@ public:
     int prevOwner = clientArrayMgr_->lastKnown((CkArrayIndex)arrayId);
 
     if (prevOwner != destinationPe) {
-      clientLocMgr_->updateLocation(arrayId,clientLocMgr_->lookupID(arrayId), destinationPe);
+      //clientLocMgr_->updateLocation(arrayId,clientLocMgr_->lookupID(arrayId), destinationPe);
 
       // it is possible to also fix destinations of items buffered for arrayId,
       // but the search could be expensive; instead, with the current code


### PR DESCRIPTION
Without ordering location update messages, we can get incorrect entries in the location
tables when old updates arrive after new ones. In some cases this can cause stale cycles
that can trap messages indefinitely.