### PR TITLE
Remove Unused Function `msg_prepareSend_noinline`

### DIFF
--- a/src/ck-core/ckarray.C
+++ b/src/ck-core/ckarray.C
@@ -1073,24 +1073,6 @@ inline void msg_prepareSend(CkArrayMessage *msg, int ep,CkArrayID aid)
 #endif
 }
 
-
-/// Just a non-inlined version of msg_prepareSend()
-void msg_prepareSend_noinline(CkArrayMessage *msg, int ep,CkArrayID aid)
-{
-	envelope *env=UsrToEnv((void *)msg);
-	env->setArrayMgr(aid);
-	env->getsetArraySrcPe()=CkMyPe();
-#if CMK_SMP_TRACE_COMMTHREAD
-        env->setSrcPe(CkMyPe());
-#endif
-	env->setEpIdx(ep);
-	env->getsetArrayHops()=0;
-#ifdef USE_CRITICAL_PATH_HEADER_ARRAY
-	criticalPath_send(env);
-	automaticallySetMessagePriority(env);
-#endif
-}
-
 void CProxyElement_ArrayBase::ckSend(CkArrayMessage *msg, int ep, int opts) const
 {
 #if CMK_ERROR_CHECKING


### PR DESCRIPTION
The function `msg_prepareSend_noinline` is completely unused and serves only as non-inline, outdated/incorrect version of an internal function for whom having a non-inline version has no benefits. Namely, it does not have the updates/later additions of `env->setMsgtype(ForArrayEltMsg);` and `env->setRecipientID(ck::ObjID(0));` found in `msg_prepareSend`, which will cause error-checking failures if it is used instead of its inline counterpart.

I am of the opinion that it should be removed, updated, or made externally available. Perhaps, at one point, it was declared in `ckarray.h` so it was externally available -- but most users (e.g. libraries) that need to prepare a message destined for an array need more customization than this function offers, anyway.