### PR TITLE
Disable chkpt test in SMP mode

### DIFF
--- a/tests/charm++/Makefile
+++ b/tests/charm++/Makefile
@@ -6,7 +6,6 @@ DIRS = \
   simplearrayhello \
   provisioning \
   load_balancing \
-  chkpt \
   delegation \
   queue \
   sdag \
@@ -27,6 +26,12 @@ DIRS = \
   longIdle \
   bombard \
   varTRAM \
+
+ifneq ($(CMK_SMP),1)
+ifneq ($(CMK_MULTICORE),1)
+  DIRS += chkpt
+endif
+endif
 
 FTDIRS = \
   jacobi3d \


### PR DESCRIPTION
Avoids CI and autobuild failures caused by lack of SMP-awareness in checkpoint/restore code.

See: #3295, #2613, #1955, #1775, #1510