### PR TITLE
AMPI: Document that attribute pointers become invalid after migration

### DIFF
--- a/doc/ampi/04-extensions.rst
+++ b/doc/ampi/04-extensions.rst
@@ -484,17 +484,24 @@ These attributes are accessible from any rank by calling
 .. code-block:: fortran
 
    ! Fortran:
-   integer (kind=MPI_ADDRESS_KIND) :: my_wth
-   integer :: flag, ierr
-   call MPI_Comm_get_attr(MPI_COMM_WORLD, AMPI_MY_WTH, my_wth, flag, ierr)
-
+   integer (kind=MPI_ADDRESS_KIND) :: my_wth_ptr
+   integer :: my_wth, flag, ierr
+   call MPI_Comm_get_attr(MPI_COMM_WORLD, AMPI_MY_WTH, my_wth_ptr, flag, ierr)
+   my_wth = my_wth_ptr
 
 .. code-block:: c++
 
    // C/C++:
-   int * my_wth;
-   int flag;
-   MPI_Comm_get_attr(MPI_COMM_WORLD, AMPI_MY_WTH, &my_wth, &flag);
+   int * my_wth_ptr;
+   int my_wth, flag;
+   MPI_Comm_get_attr(MPI_COMM_WORLD, AMPI_MY_WTH, &my_wth_ptr, &flag);
+   my_wth = *my_wth_ptr;
+
+.. warning::
+
+   The pointers retrieved for these attributes will become invalid after
+   migration. Always copy their values into local variables if you need
+   to access the old values after a migration.
 
 AMPI also provides extra communicator types that users can pass to
 ``MPI_Comm_split_type``: ``AMPI_COMM_TYPE_HOST`` for splitting a

--- a/tests/ampi/megampi/test.C
+++ b/tests/ampi/megampi/test.C
@@ -278,13 +278,14 @@ void MPI_Tester::testMigrate(void) {
 	beginTest(2,"Migration");
 
 #ifdef AMPI
-	int * srcPe;
+	int * srcPePtr;
 	int flag;
-	MPI_Comm_get_attr(MPI_COMM_WORLD, AMPI_MY_WTH, &srcPe, &flag);
+	MPI_Comm_get_attr(MPI_COMM_WORLD, AMPI_MY_WTH, &srcPePtr, &flag);
 	if (!flag) {
 		printf("Missing AMPI_MY_WTH attribute on MPI_COMM_WORLD\n");
 		MPI_Abort(MPI_COMM_WORLD, MPI_ERR_UNKNOWN);
 	}
+	const int srcPe = *srcPePtr;
 #endif
 	
 	TEST_MPI(MPI_Barrier,(comm));
@@ -294,14 +295,15 @@ void MPI_Tester::testMigrate(void) {
 	
 	TEST_MPI(MPI_Barrier,(comm));
 
-	int * destPe;
-	MPI_Comm_get_attr(MPI_COMM_WORLD, AMPI_MY_WTH, &destPe, &flag);
+	int * destPePtr;
+	MPI_Comm_get_attr(MPI_COMM_WORLD, AMPI_MY_WTH, &destPePtr, &flag);
 	if (!flag) {
 		printf("Missing AMPI_MY_WTH attribute on MPI_COMM_WORLD\n");
 		MPI_Abort(MPI_COMM_WORLD, MPI_ERR_UNKNOWN);
 	}
-	if (*srcPe != *destPe)
-		printf("[%d] migrated from %d to %d\n", rank, *srcPe, *destPe);
+	const int destPe = *destPePtr;
+	if (srcPe != destPe)
+		printf("[%d] migrated from %d to %d\n", rank, srcPe, destPe);
 #endif
 }
 


### PR DESCRIPTION
Fixes autobuild issue seen on Windows.