### PR TITLE
CI: Remove Python 2 test for charm4py

### DIFF
--- a/.github/workflows/charm4py.yml
+++ b/.github/workflows/charm4py.yml
@@ -14,7 +14,6 @@ jobs:
         ./build charm4py netlrts-linux-x86_64 tcp -g -j4 --with-production
     - name: build-charm4py
       run: |
-        pip install setuptools cython cffi greenlet numpy
         pip3 install setuptools cython cffi greenlet numpy
         git clone https://github.com/UIUC-PPL/charm4py
         export PYTHONPATH="$PWD/charm4py"
@@ -26,7 +25,6 @@ jobs:
         cd charm4py
         export CHARM4PY_BUILD_CFFI=1
         python3 setup.py build_ext --inplace
-        python2 setup.py build_ext --inplace
     - name: test-charm4py
       run: |
         export PYTHONPATH="$PWD/charm4py"


### PR DESCRIPTION
Official Python 2 support ended on January 1, 2020 (and that's after a long extension), so I think it's more than fine not to test it or support it anymore.