### PR TITLE
Support runtime parameters for IB verbs machine layer

### DIFF
--- a/src/arch/verbs/machine-ibverbs.C
+++ b/src/arch/verbs/machine-ibverbs.C
@@ -718,12 +718,11 @@ static void CmiMachineInit(char** argv)
   rdmaThreshold = 22000;
   firstBinSize = 128;
   CmiAssert(rdmaThreshold > firstBinSize);
-#if 0
-  blockAllocRatio = 16;
-  blockThreshold = 8;
-#endif
-  blockAllocRatio = 128;
-  blockThreshold = 9;
+
+  if (CmiGetArgIntDesc(argv, "+IBVBlockAllocRatio", &blockAllocRatio,"") == 0)
+    blockAllocRatio = 128;
+  if (CmiGetArgIntDesc(argv, "+IBVBlockThreshold", &blockThreshold,"") == 0)
+    blockThreshold = 9;
 
 #if !THREAD_MULTI_POOL
   initInfiCmiChunkPools();


### PR DESCRIPTION
Allow `blockAllocRatio` and `blockThreshold` parameters to be specified at runtime.
ChaNGa can use these to change the values and bypass `ibv_reg_mr` errors on machines such as Bridges-2.