### PR TITLE
ZC MultiplePostedBuffers Example: Fix incorrect callback creation

### DIFF
--- a/.github/workflows/ucx.yml
+++ b/.github/workflows/ucx.yml
@@ -17,7 +17,9 @@ jobs:
     #- name: Tmate session for debugging
     #  uses: mxschmitt/action-tmate@v2
     - name: install-prerequisites
-      run: sudo apt-get install libevent-dev libhwloc-dev
+      run: |
+        sudo apt-get update
+        sudo apt-get install libevent-dev libhwloc-dev xterm
     - name: build-ucx
       run: |
         git clone --recursive --depth 1 --shallow-submodules --branch v1.9.0 https://github.com/openucx/ucx.git

--- a/examples/charm++/zerocopy/entry_method_post_api/reg/multiplePostedBuffers/multiplePostedBuffers.C
+++ b/examples/charm++/zerocopy/entry_method_post_api/reg/multiplePostedBuffers/multiplePostedBuffers.C
@@ -85,7 +85,6 @@ class zerocopyObject : public CBase_zerocopyObject{
       idx_sdagZeroCopySent = CkIndex_zerocopyObject::sdagZeroCopySent(NULL);
       sdagCb = CkCallback(idx_sdagZeroCopySent, thisProxy[thisIndex]);
       lbReductionCb = CkCallback(CkReductionTarget(zerocopyObject, BarrierDone), thisProxy);
-      compReductionCb = CkCallback(CkReductionTarget(Main, done), mainProxy);
     }
 
     void pup(PUP::er &p){
@@ -145,7 +144,7 @@ class zerocopyObject : public CBase_zerocopyObject{
 
     void testZeroCopy(CProxy_Main mProxy){
       mainProxy = mProxy;
-
+      compReductionCb = CkCallback(CkReductionTarget(Main, done), mainProxy);
       thisProxy[thisIndex].sdagRun();
     }
 


### PR DESCRIPTION
This patch fixes the crash seen in this example on UCX CI builds.
Previously, the compReductionCb was constructed in the constructor
of zerocopyObject when the mainProxy data member was uninitialized.
With this patch, the compReductionCb construction call has been moved
to the testZeroCopy method, where the mainProxy is passed as a
parameter.