### PR TITLE
AMPI: expose msg pool size parameters to users

### DIFF
--- a/src/libs/ck-libs/ampi/ampi.C
+++ b/src/libs/ck-libs/ampi/ampi.C
@@ -962,10 +962,10 @@ static void ampiNodeInit() noexcept
   if (CkMyNode() == 0 && localThresholdSet) {
 #if AMPI_PE_LOCAL_IMPL
 #if AMPI_NODE_LOCAL_IMPL
-    CkPrintf("AMPI> PE-local messaging threshold is %d Bytes and Node-local messaging threshold is %d Bytes.\n",
+    CkPrintf("AMPI> PE-local messaging threshold is %d bytes and Node-local messaging threshold is %d bytes.\n",
              AMPI_PE_LOCAL_THRESHOLD, AMPI_NODE_LOCAL_THRESHOLD);
 #else
-    CkPrintf("AMPI> PE-local messaging threshold is %d Bytes.\n",
+    CkPrintf("AMPI> PE-local messaging threshold is %d bytes.\n",
              AMPI_PE_LOCAL_THRESHOLD);
     if (AMPI_NODE_LOCAL_THRESHOLD != AMPI_NODE_LOCAL_THRESHOLD_DEFAULT) {
       CkPrintf("Warning: AMPI Node-local messaging threshold ignored on non-SMP build.\n");
@@ -979,7 +979,7 @@ static void ampiNodeInit() noexcept
     AMPI_RDMA_THRESHOLD = atoi(value);
     if (CkMyNode() == 0) {
 #if AMPI_RDMA_IMPL
-      CkPrintf("AMPI> RDMA threshold is %d Bytes.\n", AMPI_RDMA_THRESHOLD);
+      CkPrintf("AMPI> RDMA threshold is %d bytes.\n", AMPI_RDMA_THRESHOLD);
 #else
       CkPrintf("Warning: AMPI RDMA threshold ignored since AMPI RDMA is disabled.\n");
 #endif
@@ -988,7 +988,7 @@ static void ampiNodeInit() noexcept
   if ((value = getenv("AMPI_SSEND_THRESHOLD"))) {
     AMPI_SSEND_THRESHOLD = atoi(value);
     if (CkMyNode() == 0) {
-      CkPrintf("AMPI> Synchronous messaging threshold is %d Bytes.\n", AMPI_SSEND_THRESHOLD);
+      CkPrintf("AMPI> Synchronous messaging threshold is %d bytes.\n", AMPI_SSEND_THRESHOLD);
     }
   }
   if ((value = getenv("AMPI_MSG_POOL_SIZE"))) {
@@ -1000,7 +1000,7 @@ static void ampiNodeInit() noexcept
   if ((value = getenv("AMPI_POOLED_MSG_SIZE"))) {
     AMPI_POOLED_MSG_SIZE = atoi(value);
     if (CkMyNode() == 0) {
-      CkPrintf("AMPI> Pooled message size is %d Bytes.\n", AMPI_POOLED_MSG_SIZE);
+      CkPrintf("AMPI> Pooled message size is %d bytes.\n", AMPI_POOLED_MSG_SIZE);
     }
   }
 

--- a/src/libs/ck-libs/ampi/ampi.C
+++ b/src/libs/ck-libs/ampi/ampi.C
@@ -779,6 +779,8 @@ int AMPI_PE_LOCAL_THRESHOLD = AMPI_PE_LOCAL_THRESHOLD_DEFAULT;
 int AMPI_NODE_LOCAL_THRESHOLD = AMPI_NODE_LOCAL_THRESHOLD_DEFAULT;
 int AMPI_RDMA_THRESHOLD = AMPI_RDMA_THRESHOLD_DEFAULT;
 int AMPI_SSEND_THRESHOLD = AMPI_SSEND_THRESHOLD_DEFAULT;
+int AMPI_MSG_POOL_SIZE = AMPI_MSG_POOL_SIZE_DEFAULT;
+int AMPI_POOLED_MSG_SIZE = AMPI_POOLED_MSG_SIZE_DEFAULT;
 
 bool ampi_nodeinit_has_been_called=false;
 CtvDeclare(ampiParent*, ampiPtr);
@@ -987,6 +989,18 @@ static void ampiNodeInit() noexcept
     AMPI_SSEND_THRESHOLD = atoi(value);
     if (CkMyNode() == 0) {
       CkPrintf("AMPI> Synchronous messaging threshold is %d Bytes.\n", AMPI_SSEND_THRESHOLD);
+    }
+  }
+  if ((value = getenv("AMPI_MSG_POOL_SIZE"))) {
+    AMPI_MSG_POOL_SIZE = atoi(value);
+    if (CkMyNode() == 0) {
+      CkPrintf("AMPI> Message pool size size is %d Bytes.\n", AMPI_MSG_POOL_SIZE);
+    }
+  }
+  if ((value = getenv("AMPI_POOLED_MSG_SIZE"))) {
+    AMPI_POOLED_MSG_SIZE = atoi(value);
+    if (CkMyNode() == 0) {
+      CkPrintf("AMPI> Pooled message size is %d Bytes.\n", AMPI_POOLED_MSG_SIZE);
     }
   }
 

--- a/src/libs/ck-libs/ampi/ampi.C
+++ b/src/libs/ck-libs/ampi/ampi.C
@@ -994,7 +994,7 @@ static void ampiNodeInit() noexcept
   if ((value = getenv("AMPI_MSG_POOL_SIZE"))) {
     AMPI_MSG_POOL_SIZE = atoi(value);
     if (CkMyNode() == 0) {
-      CkPrintf("AMPI> Message pool size size is %d Bytes.\n", AMPI_MSG_POOL_SIZE);
+      CkPrintf("AMPI> Message pool size is %d Bytes.\n", AMPI_MSG_POOL_SIZE);
     }
   }
   if ((value = getenv("AMPI_POOLED_MSG_SIZE"))) {

--- a/src/libs/ck-libs/ampi/ampi.C
+++ b/src/libs/ck-libs/ampi/ampi.C
@@ -994,7 +994,7 @@ static void ampiNodeInit() noexcept
   if ((value = getenv("AMPI_MSG_POOL_SIZE"))) {
     AMPI_MSG_POOL_SIZE = atoi(value);
     if (CkMyNode() == 0) {
-      CkPrintf("AMPI> Message pool size is %d Bytes.\n", AMPI_MSG_POOL_SIZE);
+      CkPrintf("AMPI> Message pool size is %d messages.\n", AMPI_MSG_POOL_SIZE);
     }
   }
   if ((value = getenv("AMPI_POOLED_MSG_SIZE"))) {

--- a/src/libs/ck-libs/ampi/ampiimpl.h
+++ b/src/libs/ck-libs/ampi/ampiimpl.h
@@ -1833,8 +1833,13 @@ class AmpiMsg final : public CMessage_AmpiMsg {
   friend AmpiMsgPool;
 };
 
-#define AMPI_MSG_POOL_SIZE    32 // Max # of AmpiMsg's allowed in the pool
-#define AMPI_POOLED_MSG_SIZE 128 // Max # of Bytes in pooled msgs' payload
+#ifndef AMPI_MSG_POOL_SIZE_DEFAULT
+#define AMPI_MSG_POOL_SIZE_DEFAULT    32 // Max # of AmpiMsg's allowed in the pool
+#endif
+
+#ifndef AMPI_POOLED_MSG_SIZE_DEFAULT
+#define AMPI_POOLED_MSG_SIZE_DEFAULT 128 // Max # of Bytes in pooled msgs' payload
+#endif
 
 class AmpiMsgPool {
  private:


### PR DESCRIPTION
Users can set these at AMPI build time by appending
-DAMPI_MSG_POOL_SIZE_DEFAULT=X -DAMPI_POOLED_MSG_SIZE_DEFAULT=Y
and/or at run time by setting the environment variables AMPI_MSG_POOL_SIZE=X and
AMPI_POOLED_MSG_SIZE=Y, where X is the max number of msgs kept in the pool
and Y is the max number of bytes in a pooled message.