### PR TITLE
LocMgr: Fix syncft builds

### DIFF
--- a/src/ck-core/cklocation.h
+++ b/src/ck-core/cklocation.h
@@ -312,7 +312,7 @@ public:
   CkLocCache() = default;
   CkLocCache(CkMigrateMessage* m) : CBase_CkLocCache(m) {}
   ~CkLocCache() = default;
-  void pup(PUP::er& p) {}
+  void pup(PUP::er& p);
 
   void inform(CmiUInt8 id, int nowOnPe);
   int homePe(const CmiUInt8 id) const { return id >> CMK_OBJID_ELEMENT_BITS; }


### PR DESCRIPTION
This moves pupping of the location table to CkLocCache, where the table is stored. It
also fixes an issue where IDs were being packing but indices were being unpacked.