### PR TITLE
AMPI: Improve MPI-level trace printing

### DIFF
--- a/src/libs/ck-libs/ampi/ampi.C
+++ b/src/libs/ck-libs/ampi/ampi.C
@@ -5746,7 +5746,7 @@ AMPI_API_IMPL(int, MPI_Op_create, MPI_User_function *function, int commute, MPI_
 
 AMPI_API_IMPL(int, MPI_Op_free, MPI_Op *op)
 {
-  AMPI_API("AMPI_Op_free", op);
+  AMPI_API("AMPI_Op_free", op, *op);
   getAmpiParent()->freeOp(*op);
   *op = MPI_OP_NULL;
   return MPI_SUCCESS;
@@ -6572,7 +6572,7 @@ AMPI_API_IMPL(int, MPI_Testsome, int incount, MPI_Request *array_of_requests, in
 
 AMPI_API_IMPL(int, MPI_Request_free, MPI_Request *request)
 {
-  AMPI_API("AMPI_Request_free", request);
+  AMPI_API("AMPI_Request_free", request, *request);
   if(*request==MPI_REQUEST_NULL) return MPI_SUCCESS;
   checkRequest(*request);
   ampiParent* pptr = getAmpiParent();
@@ -6913,7 +6913,7 @@ AMPI_API_IMPL(int, MPI_Type_commit, MPI_Datatype *datatype)
 
 AMPI_API_IMPL(int, MPI_Type_free, MPI_Datatype *datatype)
 {
-  AMPI_API("AMPI_Type_free", datatype);
+  AMPI_API("AMPI_Type_free", datatype, *datatype);
 
   int ret;
 
@@ -7192,7 +7192,7 @@ AMPI_API_IMPL(int, MPI_Type_create_keyval, MPI_Type_copy_attr_function *copy_fn,
 
 AMPI_API_IMPL(int, MPI_Type_free_keyval, int *keyval)
 {
-  AMPI_API("AMPI_Type_free_keyval", keyval);
+  AMPI_API("AMPI_Type_free_keyval", keyval, *keyval);
   return MPI_Comm_free_keyval(keyval);
 }
 
@@ -9722,7 +9722,7 @@ AMPI_API_IMPL(int, MPI_Comm_split_type, MPI_Comm src, int split_type, int key,
 
 AMPI_API_IMPL(int, MPI_Comm_free, MPI_Comm *comm)
 {
-  AMPI_API("AMPI_Comm_free", comm);
+  AMPI_API("AMPI_Comm_free", comm, *comm);
   int ret = MPI_SUCCESS;
   if (*comm != MPI_COMM_NULL) {
     if (*comm != MPI_COMM_WORLD && *comm != MPI_COMM_SELF) {
@@ -10383,7 +10383,7 @@ AMPI_API_IMPL(int, MPI_Group_range_excl, MPI_Group group, int n, int ranges[][3]
 
 AMPI_API_IMPL(int, MPI_Group_free, MPI_Group *group)
 {
-  AMPI_API("AMPI_Group_free", group);
+  AMPI_API("AMPI_Group_free", group, *group);
   return MPI_SUCCESS;
 }
 
@@ -10529,7 +10529,7 @@ AMPI_API_IMPL(int, MPI_Comm_create_keyval, MPI_Comm_copy_attr_function *copy_fn,
 
 AMPI_API_IMPL(int, MPI_Comm_free_keyval, int *keyval)
 {
-  AMPI_API("AMPI_Comm_free_keyval", keyval);
+  AMPI_API("AMPI_Comm_free_keyval", keyval, *keyval);
   int ret = getAmpiParent()->freeKeyval(*keyval);
   *keyval = MPI_KEYVAL_INVALID;
   return ampiErrhandler("AMPI_Comm_free_keyval", ret);
@@ -10568,7 +10568,7 @@ AMPI_API_IMPL(int, MPI_Keyval_create, MPI_Copy_function *copy_fn, MPI_Delete_fun
 
 AMPI_API_IMPL(int, MPI_Keyval_free, int *keyval)
 {
-  AMPI_API("AMPI_Keyval_free", keyval);
+  AMPI_API("AMPI_Keyval_free", keyval, *keyval);
   return MPI_Comm_free_keyval(keyval);
 }
 

--- a/src/libs/ck-libs/ampi/ampiOneSided.C
+++ b/src/libs/ck-libs/ampi/ampiOneSided.C
@@ -766,8 +766,13 @@ AMPI_API_IMPL(int, MPI_Win_allocate, MPI_Aint size, int disp_unit, MPI_Info info
 // MPI_Win object deleted LOCALLY on all processes when the call returns
 AMPI_API_IMPL(int, MPI_Win_free, MPI_Win *win)
 {
-  AMPI_API("AMPI_Win_free", win);
-  if(win==NULL) { return ampiErrhandler("AMPI_Win_free", MPI_ERR_WIN); }
+  if (win == nullptr)
+  {
+    AMPI_API("AMPI_Win_free", win);
+    return ampiErrhandler("AMPI_Win_free", MPI_ERR_WIN);
+  }
+
+  AMPI_API("AMPI_Win_free", win, *win);
 
   ampiParent *parent = getAmpiParent();
   WinStruct *winStruct = parent->getWinStruct(*win);
@@ -1450,7 +1455,7 @@ AMPI_API_IMPL(int, MPI_Win_create_keyval, MPI_Win_copy_attr_function *copy_fn,
 
 AMPI_API_IMPL(int, MPI_Win_free_keyval, int *keyval)
 {
-  AMPI_API("AMPI_Win_free_keyval", keyval);
+  AMPI_API("AMPI_Win_free_keyval", keyval, *keyval);
   return MPI_Comm_free_keyval(keyval);
 }
 

--- a/src/libs/ck-libs/ampi/ampiimpl.h
+++ b/src/libs/ck-libs/ampi/ampiimpl.h
@@ -7,6 +7,7 @@
 #include <bitset>
 #include <complex>
 #include <iostream>
+#include <sstream>
 
 #include "ampi.h"
 #include "ddt.h"
@@ -53,15 +54,17 @@ extern int quietModeRequested;
 // Prints a single argument name and its value (unless the argument name is
 // '""', which indicates a nonexistent argument)
 #define PRINT_ARG(arg, last) \
-  if ("\"\""!=#arg) std::cout << #arg << "=" << arg << (last ? "" : ", ");
+  if ("\"\"" != #arg) stream << #arg << "=" << arg << (last ? "" : ", ");
 
 // Prints PE:VP, function name, and argument name/value for each function argument
 #define AMPI_DEBUG_ARGS(function_name, ...) \
   if(!quietModeRequested) { \
-  std::cout << "[" << CkMyPe() << ":" << \
-  (isAmpiThread() ? getAmpiParent()->thisIndex : -1) << "] "<< function_name <<"("; \
+  std::stringstream stream; \
+  stream << "[" << CkMyPe() << ":" << \
+  (isAmpiThread() ? getAmpiParent()->thisIndex : -1) << "] " << function_name << "("; \
   FOR_EACH(PRINT_ARG, __VA_ARGS__); \
-  std::cout << ")" << std::endl; }
+  stream << ")\n"; \
+  std::cout << stream.str() << std::flush; }
 
 #else // !AMPI_DO_DEBUG
 


### PR DESCRIPTION
- Batch prints on a whole-line basis so that SMP mode runs are legible
- Add dereferencing of pointer parameters