### PR TITLE
LB: Fix MetisLB crash when there are no edges

### DIFF
--- a/src/ck-ldb/CentralLB.C
+++ b/src/ck-ldb/CentralLB.C
@@ -447,7 +447,7 @@ void CentralLB::depositData(CLBStatsMsg *m)
   statsData->from_proc.insert(statsData->from_proc.end(), n_objs, pe);
   statsData->to_proc.insert(statsData->to_proc.end(), n_objs, pe);
 
-  CmiAssert(statsData->commData.size() + n_objs <= statsData->commData.capacity());
+  CmiAssert(statsData->commData.size() + n_comm <= statsData->commData.capacity());
   statsData->commData.insert(statsData->commData.end(), m->commData.begin(), m->commData.end());
 
   statsData->n_migrateobjs +=

--- a/src/ck-ldb/MetisLB.C
+++ b/src/ck-ldb/MetisLB.C
@@ -134,6 +134,13 @@ void MetisLB::work(LDStats* stats)
   // mapping of objs to partitions
   std::vector<idx_t> pemap(numVertices);
 
+  // METIS always looks at the zeroth element of these, even when there are no edges, so
+  // create dummy elements when there are no edges
+  if (adjncy.data() == nullptr)
+    adjncy = {0};
+  if (adjwgt.data() == nullptr)
+    adjwgt = {0};
+
   // numVertices: num vertices in the graph; ncon: num balancing constrains
   // xadj, adjncy: of size n+1 and adjncy of 2m, adjncy[xadj[i]] through and
   // including adjncy[xadj[i+1]-1];


### PR DESCRIPTION
The METIS manual says that `adjncy` should be of size `2m` where `m = |E|` and that `adjwgt` can be `NULL` when edges are unweighted (they implicitly are when there are no edges, of course). However, internally when it checks the graph, it accesses element zero of both of these arrays, so they can't actually be `NULL` in practice, so create dummy arrays when there are no elements.