### PR TITLE
AMPI: clean up debug print statements

### DIFF
--- a/src/libs/ck-libs/ampi/ampi.C
+++ b/src/libs/ck-libs/ampi/ampi.C
@@ -21,12 +21,8 @@
 #define AMPI_ERRHANDLER MPI_ERRORS_ARE_FATAL
 #endif
 
-/* change this define to "x" to trace all send/recv's */
-#define MSG_ORDER_DEBUG(x) //x /* empty */
-/* change this define to "x" to trace user calls */
-#define USER_CALL_DEBUG(x) // ckout<<"vp "<<TCHARM_Element()<<": "<<x<<endl;
+#define MSG_ORDER_DEBUG(x) //x
 #define STARTUP_DEBUG(x) //ckout<<"ampi[pe "<<CkMyPe()<<"] "<< x <<endl;
-#define FUNCCALL_DEBUG(x) //x /* empty */
 
 /* For MPI_Get_library_version */
 extern const char * const CmiCommitID;
@@ -1142,7 +1138,6 @@ static void removeUnimportantArrayObjsfromPeCache() noexcept {
  */
 static ampi *ampiInit(char **argv) noexcept
 {
-  FUNCCALL_DEBUG(CkPrintf("Calling from proc %d for tcharm element %d\n", CkMyPe(), TCHARM_Element());)
   if (CtvAccess(ampiInitDone)) return NULL; /* Already called ampiInit */
   STARTUP_DEBUG("ampiInit> begin")
 
@@ -1172,8 +1167,6 @@ static ampi *ampiInit(char **argv) noexcept
     STARTUP_DEBUG("ampiInit> array size "<<_nchunks);
   }
   int *barrier = (int *)TCharm::get()->semaGet(AMPI_BARRIER_SEMAID);
-
-  FUNCCALL_DEBUG(CkPrintf("After BARRIER: sema size %d from tcharm's ele %d\n", TCharm::get()->sema.size(), TCHARM_Element());)
 
   if (TCHARM_Element()==0)
   {
@@ -1501,13 +1494,12 @@ void ampiParent::resumeAfterMigration() noexcept {
 }
 
 void ampiParent::ckJustRestored() noexcept {
-  FUNCCALL_DEBUG(CkPrintf("Call just restored from ampiParent[%d] with ampiInitCallDone %d\n", thisIndex, ampiInitCallDone);)
   ArrayElement1D::ckJustRestored();
   prepareCtv();
 }
 
 ampiParent::~ampiParent() noexcept {
-  STARTUP_DEBUG("ampiParent> destructor called");
+  STARTUP_DEBUG("ampiParent> destructor called")
   finalize();
 }
 
@@ -2046,7 +2038,6 @@ void ampi::ckJustMigrated() noexcept
 
 void ampi::ckJustRestored() noexcept
 {
-  FUNCCALL_DEBUG(CkPrintf("Call just restored from ampi[%d]\n", thisIndex);)
   findParentAfterMigration();
   ArrayElement1D::ckJustRestored();
 }
@@ -2079,7 +2070,7 @@ void ampi::findParentAfterCreation(const ampiCommStruct &s) noexcept {
 //The following method should be called on the first element of the
 //ampi array
 void ampi::allInitDone() noexcept {
-  FUNCCALL_DEBUG(CkPrintf("All mpi_init have been called!\n");)
+  STARTUP_DEBUG("ampi> all mpi_init have been called")
   thisProxy.setInitDoneFlag();
 }
 
@@ -4411,7 +4402,6 @@ AMPI_API_IMPL(int, MPI_Issend, const void *buf, int count, MPI_Datatype type, in
   }
 #endif
 
-  USER_CALL_DEBUG("AMPI_Issend("<<type<<","<<dest<<","<<tag<<","<<comm<<")");
   ampi* ptr = getAmpiInstance(comm);
   *request = ptr->send(tag, ptr->getRank(), buf, count, type, dest, comm, I_SSEND);
 
@@ -4538,7 +4528,6 @@ AMPI_API_IMPL(int, MPI_Imrecv, void* buf, int count, MPI_Datatype datatype, MPI_
   }
 #endif
 
-  USER_CALL_DEBUG("AMPI_Imrecv("<<datatype<<","<<src<<","<<tag<<","<<comm<<")");
   ampiParent* parent = getAmpiParent();
   AmpiMsg* msg = parent->getMatchedMsg(*message);
   CkAssert(msg);
@@ -7442,8 +7431,6 @@ AMPI_API_IMPL(int, MPI_Isend, const void *buf, int count, MPI_Datatype type, int
   }
 #endif
 
-  USER_CALL_DEBUG("AMPI_Isend("<<type<<","<<dest<<","<<tag<<","<<comm<<")");
-
   ampi *ptr = getAmpiInstance(comm);
   *request = ptr->send(tag, ptr->getRank(), buf, count, type, dest, comm, I_SEND);
 
@@ -7545,7 +7532,6 @@ AMPI_API_IMPL(int, MPI_Irecv, void *buf, int count, MPI_Datatype type, int src,
   }
 #endif
 
-  USER_CALL_DEBUG("AMPI_Irecv("<<type<<","<<src<<","<<tag<<","<<comm<<")");
   ampi *ptr = getAmpiInstance(comm);
 
   ptr->irecv(buf, count, type, src, tag, comm, request);

--- a/src/libs/ck-libs/ampi/ddt.h
+++ b/src/libs/ck-libs/ampi/ddt.h
@@ -56,9 +56,11 @@ enum CkDDT_Dir : bool {
 inline void serializeContig(char* userdata, char* buffer, size_t size, CkDDT_Dir dir) noexcept
 {
   if (dir == PACK) {
+    DDTDEBUG("CkDDT serializeContig packing %lu bytes from %p to %p\n", size, userdata, buffer);
     memcpy(buffer, userdata, size);
   }
   else {
+    DDTDEBUG("CkDDT serializeContig unpacking %lu bytes from %p to %p\n", size, buffer, userdata);
     memcpy(userdata, buffer, size);
   }
 }
@@ -152,7 +154,7 @@ class CkDDT_DataType
   virtual size_t serialize(char* userdata, char* buffer, int num, int msgLength, CkDDT_Dir dir) const noexcept
   {
     size_t bufSize = std::min((size_t)num * (size_t)size, (size_t)msgLength);
-    DDTDEBUG("CkDDT_Datatype::serialize %s %d objects of type %d (%d bytes)\n",
+    DDTDEBUG("CkDDT_Datatype::serialize %s %d objects of type %d (%lu bytes)\n",
              (dir==PACK)?"packing":"unpacking", num, datatype, bufSize);
     if (iscontig) {
       serializeContig(userdata, buffer, bufSize, dir);


### PR DESCRIPTION
Remove useless debug prints and add more info to DDT ones