### PR TITLE
Add warning for anytime migrations

### DIFF
--- a/src/ck-core/ckarray.h
+++ b/src/ck-core/ckarray.h
@@ -308,7 +308,13 @@ public:
   virtual char *ckDebugChareName(void);
   virtual int ckDebugChareID(char*, int);
 
-  void ckEmigrate(int toPe) {ckMigrate(toPe);}
+  void ckEmigrate(int toPe) {
+    if(!_isAnytimeMigration) {
+      CkPrintf("Charm++> WARNING: Attempted anytime migration is disabled.\n");
+      return;
+    }
+    ckMigrate(toPe);
+  }
 
 
 #ifdef _PIPELINED_ALLREDUCE_

--- a/tests/charm++/load_balancing/meta_lb_test/period_selection.C
+++ b/tests/charm++/load_balancing/meta_lb_test/period_selection.C
@@ -35,6 +35,7 @@ public:
     // TODO: Make a test that works with some empty PEs
     arrayProxy = CProxy_TestArray::ckNew(CkNumPes() * OBJS_PER_PE);
     arrayProxy.balance(iteration);
+    _isAnytimeMigration = false;
   }
 
   void resume() {
@@ -56,6 +57,7 @@ public:
       if (migrations != expected_migrations) {
         CkAbort("Did not do expected number of migrations!\n");
       }
+      _isAnytimeMigration = true;
       CkExit();
     }
   }

--- a/tests/charm++/megatest/migration.ci
+++ b/tests/charm++/megatest/migration.ci
@@ -3,5 +3,6 @@ module migration {
     entry mig_Element();
     entry void arrive(void);
     entry void done(void);
+    entry void checkDisabledMigration(void);
   };
 };

--- a/tests/charm++/megatest/migration.h
+++ b/tests/charm++/megatest/migration.h
@@ -10,6 +10,7 @@ class mig_Element : public CBase_mig_Element
   mig_Element();
   mig_Element(CkMigrateMessage *msg){}
   void done(void);
+  void checkDisabledMigration(void);
   void arrive(void);
   void pup(PUP::er &p);
   void ckJustMigrated();


### PR DESCRIPTION
Does not allow anytime migration if corresponding flag is turned off and throws a warning when attempting to migrate.