### PR TITLE
Trace communication to inline entry methods for LB

### DIFF
--- a/src/ck-core/ck.C
+++ b/src/ck-core/ck.C
@@ -1181,7 +1181,7 @@ static void _processArrayEltMsg(CkCoreState *ck,envelope *env) {
     if (mgr) {
       _SET_USED(env, 0);
       ck->process(); // ck->process() updates mProcessed count used in QD
-      mgr->deliver((CkArrayMessage *)EnvToUsr(env), CkDeliver_inline, false);
+      mgr->deliver((CkArrayMessage *)EnvToUsr(env), CkDeliver_inline);
     }
   }
 }

--- a/src/ck-core/ck.C
+++ b/src/ck-core/ck.C
@@ -1181,7 +1181,7 @@ static void _processArrayEltMsg(CkCoreState *ck,envelope *env) {
     if (mgr) {
       _SET_USED(env, 0);
       ck->process(); // ck->process() updates mProcessed count used in QD
-      mgr->deliver((CkArrayMessage *)EnvToUsr(env), CkDeliver_inline);
+      mgr->deliver((CkArrayMessage *)EnvToUsr(env), CkDeliver_inline, false);
     }
   }
 }

--- a/src/ck-core/ckarray.C
+++ b/src/ck-core/ckarray.C
@@ -1118,7 +1118,7 @@ void CkArray::remoteBeginInserting(void)
   }
 }
 
-void CkArray::demandCreateElement(const CkArrayIndex &idx, int ctor)
+void CkArray::demandCreateElement(const CkArrayIndex& idx, int ctor)
 {
   CkArrayMessage* m = (CkArrayMessage*)CkAllocSysMsg();
   envelope* env = UsrToEnv(m);

--- a/src/ck-core/ckarray.C
+++ b/src/ck-core/ckarray.C
@@ -1036,7 +1036,7 @@ void CkArray::remoteBeginInserting(void)
   }
 }
 
-void CkArray::demandCreateElement(const CkArrayIndex &idx, int ctor, CkDeliver_t type)
+void CkArray::demandCreateElement(const CkArrayIndex &idx, int ctor)
 {
 	CkArrayMessage *m=(CkArrayMessage *)CkAllocSysMsg();
         envelope *env = UsrToEnv(m);

--- a/src/ck-core/ckarray.ci
+++ b/src/ck-core/ckarray.ci
@@ -12,8 +12,7 @@ module CkArray {
     // Insertion
     entry [inline] void insertElement(CkMarshalledMessage, CkArrayIndex,
         int listenerData[CK_ARRAYLISTENER_MAXLEN]);
-    entry [inline] void demandCreateElement(const CkArrayIndex &idx, int ctor,
-        CkDeliver_t type);
+    entry [inline] void demandCreateElement(const CkArrayIndex &idx, int ctor);
     entry void remoteBeginInserting(void);
     entry void sendZCBroadcast(MsgPointerWrapper p);
     entry void remoteDoneInserting(void);

--- a/src/ck-core/ckarray.h
+++ b/src/ck-core/ckarray.h
@@ -596,8 +596,8 @@ public:
   /// doFree if is local
   inline void deliver(CkMessage *m, const CkArrayIndex &idx, CkDeliver_t type,int opts=0)
   { locMgr->sendMsg((CkArrayMessage*)m, thisgroup, idx, type, opts); }
-  inline int deliver(CkArrayMessage *m, CkDeliver_t type)
-  { return locMgr->deliverMsg(m, thisgroup, m->array_element_id(), NULL, type); }
+  inline int deliver(CkArrayMessage *m, CkDeliver_t type, bool firstAttempt = true)
+  { return locMgr->deliverMsg(m, thisgroup, m->array_element_id(), NULL, type, firstAttempt); }
   /// Fetch a local element via its ID (return NULL if not local)
   inline ArrayElement *lookup(const CmiUInt8 id) { return (ArrayElement*) getEltFromArrMgr(id); }
   /// Fetch a local element via its index (return NULL if not local)

--- a/src/ck-core/ckarray.h
+++ b/src/ck-core/ckarray.h
@@ -598,7 +598,7 @@ public:
   /// Deliver message to this element (directly if local)
   /// doFree if is local
   inline void deliver(CkMessage *m, const CkArrayIndex &idx, CkDeliver_t type,int opts=0)
-  { locMgr->sendMsg((CkArrayMessage*)m, thisgroup, idx, type, opts); }
+  { locMgr->prepMsg((CkArrayMessage*)m, thisgroup, idx, type, opts); }
   inline int deliver(CkArrayMessage *m, CkDeliver_t type, bool firstAttempt = true)
   { return locMgr->deliverMsg(m, thisgroup, m->array_element_id(), NULL, type, firstAttempt); }
   /// Fetch a local element via its ID (return NULL if not local)

--- a/src/ck-core/ckarray.h
+++ b/src/ck-core/ckarray.h
@@ -680,7 +680,7 @@ public:
 
 /// Demand-creation:
   /// Demand-create an element at this index on this processor
-  void demandCreateElement(const CkArrayIndex &idx, int ctor, CkDeliver_t type);
+  void demandCreateElement(const CkArrayIndex &idx, int ctor);
 
 /// Broadcast communication:
   void sendBroadcast(CkMessage *msg);

--- a/src/ck-core/ckarray.h
+++ b/src/ck-core/ckarray.h
@@ -599,8 +599,8 @@ public:
   /// doFree if is local
   inline void deliver(CkMessage *m, const CkArrayIndex &idx, CkDeliver_t type,int opts=0)
   { locMgr->prepMsg((CkArrayMessage*)m, thisgroup, idx, type, opts); }
-  inline int deliver(CkArrayMessage *m, CkDeliver_t type, bool firstAttempt = true)
-  { return locMgr->deliverMsg(m, thisgroup, m->array_element_id(), NULL, type, firstAttempt); }
+  inline int deliver(CkArrayMessage *m, CkDeliver_t type)
+  { return locMgr->deliverMsg(m, thisgroup, m->array_element_id(), NULL, type); }
   /// Fetch a local element via its ID (return NULL if not local)
   inline ArrayElement *lookup(const CmiUInt8 id) { return (ArrayElement*) getEltFromArrMgr(id); }
   /// Fetch a local element via its index (return NULL if not local)

--- a/src/ck-core/cklocation.C
+++ b/src/ck-core/cklocation.C
@@ -3033,7 +3033,7 @@ int CkLocMgr::deliverMsg(CkArrayMessage* msg, CkArrayID mgr, CmiUInt8 id,
 // may be necessary due to migrations, etc.
 void CkLocMgr::sendMsg(CkArrayMessage* msg, CkArrayID mgr, CmiUInt8 id,
                        const CkArrayIndex* idx, CkDeliver_t type,
-                       int opts)
+                       int opts /* = 0 */)
 {
   // Trace this send for LB
   recordSend(idx, id, UsrToEnv(msg)->getTotalsize(), opts);

--- a/src/ck-core/cklocation.C
+++ b/src/ck-core/cklocation.C
@@ -2959,7 +2959,7 @@ int CkLocMgr::deliverMsg(CkArrayMessage* msg, CkArrayID mgr, CmiUInt8 id,
       return true;
     }
     // unknown location
-    deliverUnknown(msg, idx, type, opts);
+    deliverUnknown(msg, idx, opts);
     return true;
   }
 
@@ -2982,7 +2982,7 @@ int CkLocMgr::deliverMsg(CkArrayMessage* msg, CkArrayID mgr, CmiUInt8 id,
   {  // That sibling of this object isn't created yet!
     if (msg->array_ifNotThere() != CkArray_IfNotThere_buffer)
     {
-      return demandCreateElement(msg, rec->getIndex(), CkMyPe(), type);
+      return demandCreateElement(msg, rec->getIndex(), CkMyPe());
     }
     else
     {  // BUFFERING message for nonexistent element
@@ -3093,15 +3093,14 @@ void CkLocMgr::sendMsg(CkArrayMessage* msg, CkArrayID mgr, const CkArrayIndex& i
       // If requested, demand-create the element:
       if (msg->array_ifNotThere() != CkArray_IfNotThere_buffer)
       {
-        demandCreateElement(msg, idx, -1, type);
+        demandCreateElement(msg, idx, -1);
       }
     }
   }
 }
 
 /// This index is not hashed-- somehow figure out what to do.
-void CkLocMgr::deliverUnknown(CkArrayMessage* msg, const CkArrayIndex* idx,
-                              CkDeliver_t type, int opts)
+void CkLocMgr::deliverUnknown(CkArrayMessage* msg, const CkArrayIndex* idx, int opts)
 {
   CK_MAGICNUMBER_CHECK
   CmiUInt8 id = msg->array_element_id();
@@ -3193,11 +3192,10 @@ void CkLocMgr::demandCreateElement(const CkArrayIndex& idx, int chareType, int o
   // Find the manager and build the element
   DEBC((AA "Demand-creating element %s on pe %d\n" AB, idx2str(idx), onPe));
   inform(idx, getNewObjectID(idx), onPe);
-  CProxy_CkArray(mgr)[onPe].demandCreateElement(idx, ctor, CkDeliver_inline);
+  CProxy_CkArray(mgr)[onPe].demandCreateElement(idx, ctor);
 }
 
-bool CkLocMgr::demandCreateElement(CkArrayMessage* msg, const CkArrayIndex& idx, int onPe,
-                                   CkDeliver_t type)
+bool CkLocMgr::demandCreateElement(CkArrayMessage* msg, const CkArrayIndex& idx, int onPe)
 {
   CK_MAGICNUMBER_CHECK
   int chareType = _entryTable[msg->array_ep()]->chareIdx;
@@ -3224,7 +3222,7 @@ bool CkLocMgr::demandCreateElement(CkArrayMessage* msg, const CkArrayIndex& idx,
   // Find the manager and build the element
   DEBC((AA "Demand-creating element %s on pe %d\n" AB, idx2str(idx), onPe));
   CkArrayID mgr = UsrToEnv((void*)msg)->getArrayMgr();
-  CProxy_CkArray(mgr)[onPe].demandCreateElement(idx, ctor, type);
+  CProxy_CkArray(mgr)[onPe].demandCreateElement(idx, ctor);
   return onPe == CkMyPe();
 }
 

--- a/src/ck-core/cklocation.C
+++ b/src/ck-core/cklocation.C
@@ -2693,7 +2693,7 @@ void CkLocMgr::processDeliverBufferedMsgs(CmiUInt8 id, MsgBuffer& buffer)
 }
 
 void CkLocMgr::processPrepBufferedMsgs(const CkArrayIndex& idx, CmiUInt8 id,
-				       IndexMsgBuffer& buffer)
+                                       IndexMsgBuffer& buffer)
 {
   auto itr = buffer.find(idx);
   // If there are no buffered msgs, don't do anything

--- a/src/ck-core/cklocation.C
+++ b/src/ck-core/cklocation.C
@@ -3033,7 +3033,7 @@ int CkLocMgr::deliverMsg(CkArrayMessage* msg, CkArrayID mgr, CmiUInt8 id,
   return result;
 }
 
-void CkLocMgr::sendMsg(CkArrayMessage* msg, CkArrayID mgr, const CkArrayIndex& idx,
+void CkLocMgr::prepMsg(CkArrayMessage* msg, CkArrayID mgr, const CkArrayIndex& idx,
                        CkDeliver_t type, int opts)
 {
   CK_MAGICNUMBER_CHECK

--- a/src/ck-core/cklocation.h
+++ b/src/ck-core/cklocation.h
@@ -386,8 +386,7 @@ private:
   typedef void (CkMigratable::*CkMigratable_voidfn_arg_t)(void*);
   void callMethod(CkLocRec* rec, CkMigratable_voidfn_arg_t fn, void*);
 
-  void deliverUnknown(CkArrayMessage* msg, const CkArrayIndex* idx, CkDeliver_t type,
-                      int opts);
+  void deliverUnknown(CkArrayMessage* msg, const CkArrayIndex* idx, int opts);
 
   // Create a new local record at this array index.
   CkLocRec* createLocal(const CkArrayIndex& idx, bool forMigration, bool ignoreArrival,
@@ -679,8 +678,7 @@ public:
   void reclaim(CkLocRec* rec);
 
   void requestDemandCreation(const CkArrayIndex&, int, int, int, CkArrayID);
-  bool demandCreateElement(CkArrayMessage* msg, const CkArrayIndex& idx, int onPe,
-                           CkDeliver_t type);
+  bool demandCreateElement(CkArrayMessage* msg, const CkArrayIndex& idx, int onPe);
   void demandCreateElement(const CkArrayIndex& idx, int chareType, int onPe,
                            CkArrayID mgr);
 

--- a/src/ck-core/cklocation.h
+++ b/src/ck-core/cklocation.h
@@ -651,6 +651,8 @@ public:
   // type, int opts = 0);
   int deliverMsg(CkArrayMessage* m, CkArrayID mgr, CmiUInt8 id, const CkArrayIndex* idx,
                  CkDeliver_t type, bool firstAttempt = true, int opts = 0);
+  void sendMsg(CkArrayMessage* m, CkArrayID mgr, CmiUInt8 id, const CkArrayIndex* idx,
+                 CkDeliver_t type, bool firstAttempt = true, int opts = 0);
   void prepMsg(CkArrayMessage* msg, CkArrayID mgr, const CkArrayIndex& idx,
                CkDeliver_t type, int opts);
 

--- a/src/ck-core/cklocation.h
+++ b/src/ck-core/cklocation.h
@@ -460,8 +460,8 @@ public:
   IndexMsgBuffer bufferedIndexMsgs;
   IndexMsgBuffer bufferedDemandMsgs;
 
-  void deliverAnyBufferedMsgs(CmiUInt8, MsgBuffer& buffer);
-  void deliverAnyBufferedMsgs(const CkArrayIndex&, CmiUInt8, IndexMsgBuffer&);
+  void deliverAnyBufferedMsgs(CmiUInt8, MsgBuffer& buffer, bool firstAttempt = true);
+  void deliverAnyBufferedMsgs(const CkArrayIndex&, CmiUInt8, IndexMsgBuffer&, bool firstAttempt = true);
 
   bool addElementToRec(CkLocRec* rec, CkArray* m, CkMigratable* elt, int ctorIdx,
                        void* ctorMsg);
@@ -639,7 +639,7 @@ public:
   // int deliverMsg(CkMessage *m, CkArrayID mgr, const CkArrayIndex &idx, CkDeliver_t
   // type, int opts = 0);
   int deliverMsg(CkArrayMessage* m, CkArrayID mgr, CmiUInt8 id, const CkArrayIndex* idx,
-                 CkDeliver_t type, int opts = 0);
+                 CkDeliver_t type, bool firstAttempt = true, int opts = 0);
   void sendMsg(CkArrayMessage* msg, CkArrayID mgr, const CkArrayIndex& idx,
                CkDeliver_t type, int opts);
 

--- a/src/ck-core/cklocation.h
+++ b/src/ck-core/cklocation.h
@@ -644,6 +644,9 @@ public:
   void sendMsg(CkArrayMessage* msg, CkArrayID mgr, const CkArrayIndex& idx,
                CkDeliver_t type, int opts);
 
+  void recordSend(const CkArrayIndex* idx, const CmiUInt8 id, const unsigned int bytes,
+                  const int opts = 0);
+
   // Map stores the CkMigratable elements that have active Rgets
   // ResumeFromSync is not called for these elements until the Rgets have completed
   ElemMap toBeResumeFromSynced;

--- a/src/ck-core/cklocation.h
+++ b/src/ck-core/cklocation.h
@@ -480,8 +480,8 @@ public:
   IndexMsgBuffer bufferedIndexMsgs;
   IndexMsgBuffer bufferedDemandMsgs;
 
-  void deliverAnyBufferedMsgs(CmiUInt8, MsgBuffer& buffer, bool firstAttempt = true);
-  void deliverAnyBufferedMsgs(const CkArrayIndex&, CmiUInt8, IndexMsgBuffer&, bool firstAttempt = true);
+  void processDeliverBufferedMsgs(CmiUInt8, MsgBuffer& buffer, bool firstAttempt = true);
+  void processPrepBufferedMsgs(const CkArrayIndex&, CmiUInt8, IndexMsgBuffer&, bool firstAttempt = true);
 
   bool addElementToRec(CkLocRec* rec, CkArray* m, CkMigratable* elt, int ctorIdx,
                        void* ctorMsg);
@@ -662,8 +662,8 @@ public:
   ElemMap toBeResumeFromSynced;
 
   // Deliver any buffered msgs to a newly created array element
-  void deliverAllBufferedMsgs(CmiUInt8);
-  void deliverAllBufferedMsgs(const CkArrayIndex&, CmiUInt8);
+  void processAllDeliverBufferedMsgs(CmiUInt8);
+  void processAllPrepBufferedMsgs(const CkArrayIndex&, CmiUInt8);
 
   // Advisories:
   /// This index now lives on the given processor-- update local records

--- a/src/ck-core/cklocation.h
+++ b/src/ck-core/cklocation.h
@@ -480,8 +480,8 @@ public:
   IndexMsgBuffer bufferedIndexMsgs;
   IndexMsgBuffer bufferedDemandMsgs;
 
-  void processDeliverBufferedMsgs(CmiUInt8, MsgBuffer& buffer, bool firstAttempt = true);
-  void processPrepBufferedMsgs(const CkArrayIndex&, CmiUInt8, IndexMsgBuffer&, bool firstAttempt = true);
+  void processDeliverBufferedMsgs(CmiUInt8, MsgBuffer& buffer);
+  void processPrepBufferedMsgs(const CkArrayIndex&, CmiUInt8, IndexMsgBuffer&);
 
   bool addElementToRec(CkLocRec* rec, CkArray* m, CkMigratable* elt, int ctorIdx,
                        void* ctorMsg);
@@ -650,9 +650,9 @@ public:
   // int deliverMsg(CkMessage *m, CkArrayID mgr, const CkArrayIndex &idx, CkDeliver_t
   // type, int opts = 0);
   int deliverMsg(CkArrayMessage* m, CkArrayID mgr, CmiUInt8 id, const CkArrayIndex* idx,
-                 CkDeliver_t type, bool firstAttempt = true, int opts = 0);
+                 CkDeliver_t type, int opts = 0);
   void sendMsg(CkArrayMessage* m, CkArrayID mgr, CmiUInt8 id, const CkArrayIndex* idx,
-                 CkDeliver_t type, bool firstAttempt = true, int opts = 0);
+                 CkDeliver_t type, int opts = 0);
   void prepMsg(CkArrayMessage* msg, CkArrayID mgr, const CkArrayIndex& idx,
                CkDeliver_t type, int opts);
 

--- a/src/ck-core/cklocation.h
+++ b/src/ck-core/cklocation.h
@@ -651,7 +651,7 @@ public:
   // type, int opts = 0);
   int deliverMsg(CkArrayMessage* m, CkArrayID mgr, CmiUInt8 id, const CkArrayIndex* idx,
                  CkDeliver_t type, bool firstAttempt = true, int opts = 0);
-  void sendMsg(CkArrayMessage* msg, CkArrayID mgr, const CkArrayIndex& idx,
+  void prepMsg(CkArrayMessage* msg, CkArrayID mgr, const CkArrayIndex& idx,
                CkDeliver_t type, int opts);
 
   void recordSend(const CkArrayIndex* idx, const CmiUInt8 id, const unsigned int bytes,

--- a/src/xlat-i/xi-Entry.C
+++ b/src/xlat-i/xi-Entry.C
@@ -570,7 +570,8 @@ void Entry::genArrayDefs(XStr& str) {
       inlineCall << "    const auto id = obj->ckGetID().getElementID();\n"
                  << "    const CkArrayIndex* idx = &ckGetIndex();\n";
       param->size(inlineCall); // Puts size of parameters in bytes into impl_off
-      inlineCall << "    ckLocMgr()->recordSend(idx, id, impl_off);\n";
+      inlineCall << "    impl_off += sizeof(envelope);\n"
+                 << "    ckLocMgr()->recordSend(idx, id, impl_off);\n";
     }
     inlineCall << "    LDObjHandle objHandle;\n"
                << "    int objstopped=0;\n"

--- a/src/xlat-i/xi-Entry.C
+++ b/src/xlat-i/xi-Entry.C
@@ -564,8 +564,15 @@ void Entry::genArrayDefs(XStr& str) {
           << "    _TRACE_BEGIN_EXECUTE_DETAILED(0,ForArrayEltMsg,(" << epIdx()
           << "),CkMyPe(), 0, ((CkArrayIndex&)ckGetIndex()).getProjectionID(), obj);\n";
     if (isAppWork()) inlineCall << "    _TRACE_BEGIN_APPWORK();\n";
-    inlineCall << "#if CMK_LBDB_ON\n"
-               << "    LDObjHandle objHandle;\n"
+    inlineCall << "#if CMK_LBDB_ON\n";
+    if (isInline())
+    {
+      inlineCall << "    const auto id = obj->ckGetID().getElementID();\n"
+                 << "    const CkArrayIndex* idx = &ckGetIndex();\n";
+      param->size(inlineCall); // Puts size of parameters in bytes into impl_off
+      inlineCall << "    ckLocMgr()->recordSend(idx, id, impl_off);\n";
+    }
+    inlineCall << "    LDObjHandle objHandle;\n"
                << "    int objstopped=0;\n"
                << "    objHandle = obj->timingBeforeCall(&objstopped);\n"
                << "#endif\n";

--- a/src/xlat-i/xi-Parameter.C
+++ b/src/xlat-i/xi-Parameter.C
@@ -243,6 +243,107 @@ void ParamList::callEach(rdmadevicefn_t f, XStr& str, int& index) {
 
 int ParamList::hasConditional() { return orEach(&Parameter::isConditional); }
 
+void ParamList::size(XStr& str)
+{
+  str << "  int impl_off=0;\n";
+  int hasArrays = orEach(&Parameter::isArray);
+  if (hasArrays)
+  {
+    str << "  int impl_arrstart=0;\n";
+    callEach(&Parameter::marshallRegArraySizes, str);
+  }
+
+  bool hasrdma = hasRdma();
+  bool hasrecvrdma = hasRecvRdma();
+
+  Chare* container = entry->getContainer();
+  bool isP2P = (container->isChare() || container->isForElement());
+
+  // Generate device-related code only when this condition is met
+  bool deviceRdmaSupported = (hasDevice() && isP2P);
+
+  if (hasrdma)
+  {
+    if (deviceRdmaSupported)
+    {
+      str << "  int impl_num_device_rdma_fields = " << entry->numRdmaDeviceParams
+          << ";\n";
+      str << "  int dest_pe;\n";
+      if (container->isChare())
+      {
+        // TODO: Following code doesn't work, don't support singleton chares for now
+        // str << "  dest_pe = CkRdmaGetDestPEChare(ckGetChareID().onPE,
+        // ckGetChareID().objPtr);\n";
+        str << "  CkAbort(\"Singleton chares are not supported\");\n";
+      }
+      else if (container->isArray())
+      {
+        str << "  dest_pe = ckLocMgr()->lastKnown(ckGetIndex());\n";
+      }
+      else if (container->isGroup() || container->isNodeGroup())
+      {
+        str << "  dest_pe = ckGetGroupPe();\n";
+      }
+      else
+      {
+        str << "  CkAbort(\"Unknown container type\");\n";
+      }
+      str << "  CkDeviceBuffer* device_buffers[" << entry->numRdmaDeviceParams << "];\n";
+      int device_rdma_index = 0;
+      callEach(&Parameter::marshallDeviceRdmaParameters, str, device_rdma_index);
+      str << "  CkRdmaDeviceOnSender(dest_pe, impl_num_device_rdma_fields, "
+             "device_buffers);\n";
+    }
+    else if (hasDevice())
+    {
+      // Abort ASAP if broadcast or has host-side zero-copy
+      if (!isP2P)
+      {
+        str << "  CkAbort(\"Broadcast not supported with device buffers\");\n";
+      }
+      if (hasSendRdma() || hasRecvRdma())
+      {
+        str << "  CkAbort(\"Host-side RDMA cannot be used along with device RDMA\");\n";
+      }
+    }
+    else
+    {
+      str << "  int impl_num_rdma_fields = "
+          << entry->numRdmaSendParams + entry->numRdmaRecvParams << ";\n";
+      // Root node is pupped on the source as it is required for ZC Bcast when the source
+      // is non-zero
+      str << "  int impl_num_root_node = CkMyNode();\n";
+      callEach(&Parameter::marshallRdmaParameters, str, true);
+    }
+  }
+  str << "  { //Find the size of the PUP'd data\n";
+  str << "    PUP::sizer implP;\n";
+  callEach(&Parameter::pup, str);
+  if (hasrdma)
+  {
+    if (deviceRdmaSupported)
+    {
+      str << "    implP|impl_num_device_rdma_fields;\n";
+      callEach(&Parameter::pupRdma, str, true, true);
+    }
+    else if (!hasDevice())
+    {
+      str << "    implP|impl_num_rdma_fields;\n";
+      str << "    implP|impl_num_root_node;\n";
+      // All rdma parameters have to be pupped at the start
+      callEach(&Parameter::pupRdma, str, true, false);
+    }
+  }
+  if (hasArrays)
+  { /*round up pup'd data length--that's the first array*/
+    str << "    impl_arrstart=CK_ALIGN(implP.size(),16);\n";
+    str << "    impl_off+=impl_arrstart;\n";
+  }
+  else /*No arrays--no padding*/
+    str << "    impl_off+=implP.size();\n";
+  str << "  }\n";
+}
+
 /** marshalling: pack fields into flat byte buffer **/
 void ParamList::marshall(XStr& str, XStr& entry_str) {
   if (isVoid())
@@ -252,12 +353,9 @@ void ParamList::marshall(XStr& str, XStr& entry_str) {
     print(str, 0);
     str << "\n";
     // First pass: find sizes
-    str << "  int impl_off=0;\n";
+    size(str);
+    // Now that we know the size, allocate the packing buffer
     int hasArrays = orEach(&Parameter::isArray);
-    if (hasArrays) {
-      str << "  int impl_arrstart=0;\n";
-      callEach(&Parameter::marshallRegArraySizes, str);
-    }
 
     bool hasrdma = hasRdma();
     bool hasrecvrdma = hasRecvRdma();
@@ -267,62 +365,6 @@ void ParamList::marshall(XStr& str, XStr& entry_str) {
 
     // Generate device-related code only when this condition is met
     bool deviceRdmaSupported = (hasDevice() && isP2P);
-
-    if (hasrdma) {
-      if (deviceRdmaSupported) {
-        str << "  int impl_num_device_rdma_fields = " << entry->numRdmaDeviceParams << ";\n";
-        str << "  int dest_pe;\n";
-        if (container->isChare()) {
-          // TODO: Following code doesn't work, don't support singleton chares for now
-          //str << "  dest_pe = CkRdmaGetDestPEChare(ckGetChareID().onPE, ckGetChareID().objPtr);\n";
-          str << "  CkAbort(\"Singleton chares are not supported\");\n";
-        } else if (container->isArray()) {
-          str << "  dest_pe = ckLocMgr()->lastKnown(ckGetIndex());\n";
-        } else if (container->isGroup() || container->isNodeGroup()) {
-          str << "  dest_pe = ckGetGroupPe();\n";
-        } else {
-          str << "  CkAbort(\"Unknown container type\");\n";
-        }
-        str << "  CkDeviceBuffer* device_buffers[" << entry->numRdmaDeviceParams << "];\n";
-        int device_rdma_index = 0;
-        callEach(&Parameter::marshallDeviceRdmaParameters, str, device_rdma_index);
-        str << "  CkRdmaDeviceOnSender(dest_pe, impl_num_device_rdma_fields, device_buffers);\n";
-      } else if (hasDevice()) {
-        // Abort ASAP if broadcast or has host-side zero-copy
-        if (!isP2P) {
-          str << "  CkAbort(\"Broadcast not supported with device buffers\");\n";
-        }
-        if (hasSendRdma() || hasRecvRdma()) {
-          str << "  CkAbort(\"Host-side RDMA cannot be used along with device RDMA\");\n";
-        }
-      } else {
-        str << "  int impl_num_rdma_fields = "<<entry->numRdmaSendParams + entry->numRdmaRecvParams<<";\n";
-        // Root node is pupped on the source as it is required for ZC Bcast when the source is non-zero
-        str << "  int impl_num_root_node = CkMyNode();\n";
-        callEach(&Parameter::marshallRdmaParameters, str, true);
-      }
-    }
-    str << "  { //Find the size of the PUP'd data\n";
-    str << "    PUP::sizer implP;\n";
-    callEach(&Parameter::pup, str);
-    if (hasrdma) {
-      if (deviceRdmaSupported) {
-        str << "    implP|impl_num_device_rdma_fields;\n";
-        callEach(&Parameter::pupRdma, str, true, true);
-      } else if (!hasDevice()) {
-        str << "    implP|impl_num_rdma_fields;\n";
-        str << "    implP|impl_num_root_node;\n";
-        // All rdma parameters have to be pupped at the start
-        callEach(&Parameter::pupRdma, str, true, false);
-      }
-    }
-    if (hasArrays) { /*round up pup'd data length--that's the first array*/
-      str << "    impl_arrstart=CK_ALIGN(implP.size(),16);\n";
-      str << "    impl_off+=impl_arrstart;\n";
-    } else /*No arrays--no padding*/
-      str << "    impl_off+=implP.size();\n";
-    str << "  }\n";
-    // Now that we know the size, allocate the packing buffer
     if (hasConditional())
       str << "  MarshallMsg_" << entry_str << " *impl_msg=CkAllocateMarshallMsgT<MarshallMsg_"
           << entry_str << ">(impl_off,impl_e_opts);\n";

--- a/src/xlat-i/xi-Parameter.C
+++ b/src/xlat-i/xi-Parameter.C
@@ -482,6 +482,8 @@ void Parameter::pupArray(XStr& str) {
 }
 
 void Parameter::pup(XStr& str) {
+  if (!name)
+    return;
   if (isArray()) {
     pupArray(str);
   } else if (!conditional) {

--- a/src/xlat-i/xi-Parameter.h
+++ b/src/xlat-i/xi-Parameter.h
@@ -174,6 +174,7 @@ class ParamList {
   void printMsg(XStr& str);
   void preprocess();
   int hasConditional();
+  void size(XStr& str);
   void marshall(XStr& str, XStr& entry);
   void beginUnmarshall(XStr& str);
   void beginUnmarshallSDAG(XStr& str);


### PR DESCRIPTION
As reported by the SpECTRE team, communication to `[inline]` entry methods was not being added to the comm graph. For some reason, the RTS code explicitly avoided adding this to the comm graph, and a newer optimization that called the target EP directly on the object pointer when it was local without ever going into the RTS code also skipped this step. This change removes the condition excluding remote messages to `[inline]` EPs from having their communication traced and adds an explicit call to record the communication when the `[inline]` EP is directly invoked locally on the object pointer (even though this case doesn't actually involve any communication, it should be in the comm graph so that the LB knows that they are communicating and won't separate them when running communication based strategies). 