### PR TITLE
Add PRETESTOPTS makefile variable to common.mk

### DIFF
--- a/benchmarks/common.mk
+++ b/benchmarks/common.mk
@@ -1,13 +1,13 @@
 ifneq ($(wildcard ../../../bin/.),)
-	run = ../../../bin/testrun $(1) $(TESTOPTS)
+	run = ../../../bin/testrun $(PRETESTOPTS) $(1) $(TESTOPTS)
 else
 	ifneq ($(wildcard ../../../../bin/.),)
-		run = ../../../../bin/testrun $(1) $(TESTOPTS)
+		run = ../../../../bin/testrun $(PRETESTOPTS) $(1) $(TESTOPTS)
 	else
 		ifneq ($(wildcard ../../../../../bin/.),)
-			run = ../../../../../bin/testrun $(1) $(TESTOPTS)
+			run = ../../../../../bin/testrun $(PRETESTOPTS) $(1) $(TESTOPTS)
 		else
-			run = ../../../../../../bin/testrun $(1) $(TESTOPTS)
+			run = ../../../../../../bin/testrun $(PRETESTOPTS) $(1) $(TESTOPTS)
 		endif
 	endif
 endif

--- a/examples/common.mk
+++ b/examples/common.mk
@@ -1,13 +1,13 @@
 ifneq ($(wildcard ../../../bin/.),)
-	run = ../../../bin/testrun $(1) $(TESTOPTS)
+	run = ../../../bin/testrun $(PRETESTOPTS) $(1) $(TESTOPTS)
 else
 	ifneq ($(wildcard ../../../../bin/.),)
-		run = ../../../../bin/testrun $(1) $(TESTOPTS)
+		run = ../../../../bin/testrun $(PRETESTOPTS) $(1) $(TESTOPTS)
 	else
 		ifneq ($(wildcard ../../../../../bin/.),)
-			run = ../../../../../bin/testrun $(1) $(TESTOPTS)
+			run = ../../../../../bin/testrun $(PRETESTOPTS) $(1) $(TESTOPTS)
 		else
-			run = ../../../../../../bin/testrun $(1) $(TESTOPTS)
+			run = ../../../../../../bin/testrun $(PRETESTOPTS) $(1) $(TESTOPTS)
 		endif
 	endif
 endif

--- a/tests/common.mk
+++ b/tests/common.mk
@@ -1,13 +1,13 @@
 ifneq ($(wildcard ../../bin/.),)
-	run = ../../bin/testrun $(1) $(TESTOPTS)
+	run = ../../bin/testrun $(PRETESTOPTS) $(1) $(TESTOPTS)
 else
 	ifneq ($(wildcard ../../../bin/.),)
-		run = ../../../bin/testrun $(1) $(TESTOPTS)
+		run = ../../../bin/testrun $(PRETESTOPTS) $(1) $(TESTOPTS)
 	else
 		ifneq ($(wildcard ../../../../bin/.),)
-			run = ../../../../bin/testrun $(1) $(TESTOPTS)
+			run = ../../../../bin/testrun $(PRETESTOPTS) $(1) $(TESTOPTS)
 		else
-			run = ../../../../../bin/testrun $(1) $(TESTOPTS)
+			run = ../../../../../bin/testrun $(PRETESTOPTS) $(1) $(TESTOPTS)
 		endif
 	endif
 endif


### PR DESCRIPTION
This enables easy execution of benchmarks, examples, and tests
with arguments that should be passed before the executable,
like valgrind and gdb.