### PR TITLE
Add newline to output of CmiDeprecateArgInt

### DIFF
--- a/src/conv-core/convcore.C
+++ b/src/conv-core/convcore.C
@@ -599,7 +599,7 @@ void CmiDeprecateArgInt(char **argv,const char *arg,const char *desc,const char 
   int dummy = 0, found = CmiGetArgIntDesc(argv, arg, &dummy, desc);
 
   if (found)
-    CmiPrintf("%s", warning);
+    CmiPrintf("%s\n", warning);
 }
 
 /*****************************************************************************


### PR DESCRIPTION
- Adds newline to the message printed by ```CmiDeprecateArgInt``` to match other functions such as ```CmiAbort```.