### PR TITLE
CkArray: Fix semantics of initCallback/doneInserting

### DIFF
--- a/examples/charm++/array_map/array_map.C
+++ b/examples/charm++/array_map/array_map.C
@@ -56,8 +56,7 @@ public:
         mgr->insertInitial(CkArrayIndex1D(i), CkCopyMsg(&ctorMsg));
       }
 
-      // Inform the mgr that we are done creating elements, and free ctorMsg.
-      mgr->doneInserting();
+      // Free the ctorMsg.
       CkFreeMsg(ctorMsg);
     } else {
       // For higher dimension indices we fall back to the default behavior,

--- a/src/ck-core/ckarray.C
+++ b/src/ck-core/ckarray.C
@@ -1050,6 +1050,8 @@ bool CkArray::insertElement(CkArrayMessage* me, const CkArrayIndex& idx,
   if (!locMgr->addElement(thisgroup, idx, elt, ctorIdx, (void*)me))
     return false;
   CK_ARRAYLISTENER_LOOP(listeners, if (!l->ckElementCreated(elt)) return false;);
+  // The initCallback will only be valid if it was set in CkArrayOptions and this is the
+  // first wave of insertions.
   if (!initCallback.isInvalid()) elt->contribute(initCallback);
   return true;
 }
@@ -1090,6 +1092,8 @@ void CkArray::remoteBeginInserting(void)
 
   if (!isInserting)
   {
+    // After the first wave of insertions, the init callback should not be used
+    initCallback = CkCallback(CkCallback::invalid);
     isInserting = true;
     DEBC((AA "Begin inserting objects\n" AB));
     for (int l = 0; l < listeners.size(); l++) listeners[l]->ckBeginInserting();

--- a/src/ck-core/ckarray.C
+++ b/src/ck-core/ckarray.C
@@ -903,7 +903,7 @@ CkArray::CkArray(CkArrayOptions&& opts, CkMarshalledMessage&& initMsg)
   /// Set up initial elements (if any)
   locMgr->populateInitial(opts, initMsg.getMessage(), this);
   if (opts.isStaticInsertion())
-    initDone();
+    remoteDoneInserting();
 
   if (opts.reductionClient.type != CkCallback::invalid && CkMyPe() == 0)
     ckSetReductionClient(&opts.reductionClient);

--- a/src/ck-core/ckarray.ci
+++ b/src/ck-core/ckarray.ci
@@ -16,7 +16,6 @@ module CkArray {
     entry void remoteBeginInserting(void);
     entry void sendZCBroadcast(MsgPointerWrapper p);
     entry void remoteDoneInserting(void);
-    entry void initDone(void);
 
     //Broadcast
     entry void sendBroadcast(CkMessage *);

--- a/src/ck-core/ckarray.h
+++ b/src/ck-core/ckarray.h
@@ -766,7 +766,6 @@ public:
   virtual void beginInserting(void);
   void remoteDoneInserting(void);
   void remoteBeginInserting(void);
-  void initDone(void);
 
   /// Create manually:
   bool insertElement(CkArrayMessage*, const CkArrayIndex& idx,

--- a/src/ck-core/ckarrayoptions.C
+++ b/src/ck-core/ckarrayoptions.C
@@ -102,6 +102,7 @@ void CkArrayOptions::init() {
   anytimeMigration = _isAnytimeMigration;
   insertionType = InsertionType::UNSET;
   reductionClient.type = CkCallback::invalid;
+  initCallback = CkCallback(CkCallback::invalid);
   disableNotifyChildInRed = !_isNotifyChildInRed;
   broadcastViaScheduler = false;
   sectionAutoDelegate = true;

--- a/src/ck-core/cklocation.C
+++ b/src/ck-core/cklocation.C
@@ -269,7 +269,6 @@ void CkArrayMap::populateInitial(int arrayHdl, CkArrayOptions& options, void* ct
      how many of them are used */
   CKARRAYMAP_POPULATE_INITIAL(CMK_RANK_0(procNum(arrayHdl, idx)) == thisPe);
 
-  mgr->doneInserting();
   CkFreeMsg(ctorMsg);
 }
 
@@ -1280,7 +1279,6 @@ public:
     int numPes = CkNumPes();
 
     CKARRAYMAP_POPULATE_INITIAL(i % numPes == thisPe);
-    mgr->doneInserting();
     CkFreeMsg(ctorMsg);
   }
 };
@@ -1424,7 +1422,6 @@ public:
     }
     //        CKARRAYMAP_POPULATE_INITIAL(PE == thisPe);
 
-    mgr->doneInserting();
     CkFreeMsg(ctorMsg);
   }
 };


### PR DESCRIPTION
Array maps previously automatically called doneInserting on the array after initial insertion. This occurred even for arrays with 0 elements. For cases where users then did dynamic insertion and called doneInserting themselves, doneInserting was essentially a no-op (with some messaging). This change makes it so doneInserting is only automatically called for arrays with static insertion.