### PR TITLE
Add CthIsMainThread to Consolidate Logic

### DIFF
--- a/src/conv-core/convcore.C
+++ b/src/conv-core/convcore.C
@@ -2126,11 +2126,15 @@ void CthResumeNormalThread(CthThreadToken* token)
 #endif
 }
 
+int CthIsMainThread(CthThread t) {
+  return t == CpvAccess(CthMainThread);
+}
+
 void CthResumeSchedulingThread(CthThreadToken  *token)
 {
   CthThread t = token->thread;
   CthThread me = CthSelf();
-  if (me == CpvAccess(CthMainThread)) {
+  if (CthIsMainThread(me)) {
     CthEnqueueSchedulingThread(CthGetToken(me),CQS_QUEUEING_FIFO, 0, 0);
   } else {
     CthSetNext(me, CpvAccess(CthSleepingStandins));

--- a/src/conv-core/converse.h
+++ b/src/conv-core/converse.h
@@ -1551,6 +1551,7 @@ typedef CthThread   (*CthThFn)(void);
 
 void       CthSetSerialNo(CthThread t, int no);
 int        CthImplemented(void);
+int        CthIsMainThread(CthThread t);
 
 CthThread  CthSelf(void);
 CthThread  CthCreate(CthVoidFn, void *, int);

--- a/src/conv-core/threads.C
+++ b/src/conv-core/threads.C
@@ -793,8 +793,7 @@ void CthScheduledDecrement() {
     if (!B(prevCurrent))
       return;
     CthDebug("[%f][%d] scheduled before decremented: %d\n", CmiWallTimer(), CmiMyRank(), B(prevCurrent)->scheduled);
-    /* CthMainThread should have empty stack(stack == NULL) and never scheduled(scheduled == 0) */
-    if (B(prevCurrent)->stack && B(prevCurrent)->scheduled > 0) {
+    if (!CthIsMainThread(prevCurrent)) {
         CmiMemoryAtomicDecrement(B(prevCurrent)->scheduled, memory_order_release);
         CthDebug("[%f][%d] scheduled decremented: %d\n", CmiWallTimer(), CmiMyRank(), B(prevCurrent)->scheduled);
     }


### PR DESCRIPTION
This adds a library-accessible function for detecting whether the currently executing thread is the main thread. The motivations for this are two-fold: (a) to determine whether or not the currently executing thread should be suspended, and (b) to determine whether the currently executing entry method is `[threaded]`. For libraries that overload aspects of Charm++'s initialization routines (i.e., group creation), (a) pertains to writing threading-agnostic yield routines like:

```cpp
inline void yield(void) {
  auto th = CthSelf();
  if (CthIsMainThread(th)) {
    CsdScheduler(0);
  } else {
    CthYield();
  }
}
```

While the complex machinations in `convcore.C` suggest that the main thread can be suspended (and that other threads will inherit its role of running the scheduler while it is suspended), I have found that, in practice, the main thread should _not_ be suspended. Rudimentary screening suggests that crashes can occur and, more generally, there are concerns wrt migrations since it is not bound to a particular chare.

Previously, this information was restricted to `convcore.C`; this means it had to be inferred (through known properties of the main thread) in `threads.C`. This PR breaks this encapsulation, making the information publicly available. Whether or not this is "harmful" is a matter for discussion; however, I believe that it is benign since it is only useful to expert users.