### PR TITLE
Add Copy Constructor to CProxyElement_ArrayBase

### DIFF
--- a/src/ck-core/ckarray.h
+++ b/src/ck-core/ckarray.h
@@ -170,6 +170,11 @@ public:
   }
   CProxyElement_ArrayBase(const ArrayElement* e);
 
+  CProxyElement_ArrayBase& operator=(const CProxyElement_ArrayBase& other)
+  {
+    return *this = CProxyElement_ArrayBase(other);
+  }
+
   bool operator==(const CProxyElement_ArrayBase& other)
   {
     return ckGetArrayID() == other.ckGetArrayID() && ckGetIndex() == other.ckGetIndex();

--- a/src/ck-core/ckarray.h
+++ b/src/ck-core/ckarray.h
@@ -164,6 +164,10 @@ public:
       : CProxy_ArrayBase(aid), _idx(idx)
   {
   }
+  CProxyElement_ArrayBase(const CProxyElement_ArrayBase& other)
+      : CProxy_ArrayBase(other.ckGetArrayID()), _idx(other.ckGetIndex())
+  {
+  }
   CProxyElement_ArrayBase(const ArrayElement* e);
 
   bool operator==(const CProxyElement_ArrayBase& other)


### PR DESCRIPTION
This feature's omission is curious. As it stands, users attempting to copy array element proxies may bounce up to `CProxy::CProxy(const CProxy&)`; this can result in surprises, e.g., unexpected delegation. Thus, this PR attempts to make the results more in line with user expectations (i.e., simple/direct copying of the relevant fields).

Motivation:
This was discovered in Hypercomm wherein I attempted to use a copy constructor for both node/group and chare-array elements. This led to strange crashes pertaining to delegation, which I circumvented with the addition of `ckUndelegate`; while this avoided the crashes, doing so has a significant performance impact and is suboptimal from various perspectives. Availability of a copy constructor would resolve [this issue](https://github.com/jszaday/hypercomm/pull/48) and preserve the syntactic niceness of the current solution.