### PR TITLE
Tracing: Don't write SMPMODE when not in SMP mode

### DIFF
--- a/src/ck-perf/trace-common.C
+++ b/src/ck-perf/trace-common.C
@@ -268,7 +268,7 @@ void traceWriteSTS(FILE *stsfp,int nUserEvents) {
 #else
   fprintf(stsfp, "PROCESSORS %d\n", CkNumPes());
 #endif
-#ifdef CMK_SMP
+#if CMK_SMP
   fprintf(stsfp, "SMPMODE %d %d\n", CkMyNodeSize(), CkNumNodes());
 #endif
 


### PR DESCRIPTION
Fixes issue introduced in #3225, it used an `#ifdef` where it should have used an `#if`.