### PR TITLE
Include information about uncaught exceptions in user code

### DIFF
--- a/src/ck-core/init.C
+++ b/src/ck-core/init.C
@@ -1274,10 +1274,10 @@ void _sendReadonlies() {
 */
 void _initCharm(int unused_argc, char **argv)
 { 
-	int inCommThread = (CmiMyRank() == CmiMyNodeSize());
+  int inCommThread = (CmiMyRank() == CmiMyNodeSize());
 
-	DEBUGF(("[%d,%.6lf ] _initCharm started\n",CmiMyPe(),CmiWallTimer()));
-	std::set_terminate([](){
+  DEBUGF(("[%d,%.6lf ] _initCharm started\n",CmiMyPe(),CmiWallTimer()));
+  std::set_terminate([](){
     std::exception_ptr exptr = std::current_exception();
     if (exptr)
     {

--- a/src/ck-core/init.C
+++ b/src/ck-core/init.C
@@ -1279,21 +1279,21 @@ void _initCharm(int unused_argc, char **argv)
 	DEBUGF(("[%d,%.6lf ] _initCharm started\n",CmiMyPe(),CmiWallTimer()));
 	std::set_terminate([](){
     std::exception_ptr exptr = std::current_exception();
-    if(exptr)
+    if (exptr)
+    {
+      try
       {
-        try
-          {
-            std::rethrow_exception(exptr);
-          }
-        catch (std::exception &ex)
-          {
-            CkAbort("Unhandled C++ exception in user code: %s.\n", ex.what());
-          }
+        std::rethrow_exception(exptr);
       }
+      catch (std::exception &ex)
+      {
+        CkAbort("Unhandled C++ exception in user code: %s.\n", ex.what());
+      }
+    }
     else
-      {
-        CkAbort("Unhandled C++ exception in user code.\n");
-      }
+    {
+      CkAbort("Unhandled C++ exception in user code.\n");
+    }
   });
 
 	CkpvInitialize(size_t *, _offsets);


### PR DESCRIPTION
Currently, uncaught C++ exceptions in user code cause the following error message to be created:
```
------------- Processor 6 Exiting: Called CmiAbort ------------
Reason: Unhandled C++ exception in user code.
```

This patch attempts to retrieve the exception that was thrown and includes the result of ```exception.what()```, as shown below:
```
------------- Processor 6 Exiting: Called CmiAbort ------------
Reason: Unhandled C++ exception in user code: vector::_M_default_append.
```

The hope is that this information will be useful in debugging user code (it was useful for me). If the exception cannot be retrieved, the first message above is printed.
Further information about exception_ptr: https://en.cppreference.com/w/cpp/error/exception_ptr