### PR TITLE
Enhance User-Accessibility of CkLocMgr Information

### DIFF
--- a/src/ck-core/cklocation.C
+++ b/src/ck-core/cklocation.C
@@ -2451,6 +2451,9 @@ void CkLocCache::recordEmigration(CmiUInt8 id, int pe)
 
   itr->second.pe = pe;
   itr->second.epoch++;
+
+  // inform listeners of the new location
+  notifyListeners(id, pe);
 }
 
 


### PR DESCRIPTION
Libraries/users may require more information than the current location manager interface exposes -- including access to (all) location updates and known indices. While (some) location updates can be derived from array listener events, they provide additional details that may be unnecessary. Additionally, array listener events only involve changes to elements on a given PE, whereas location manager updates may be for distant elements (e.g., when a PE receives an `informHome` update).

Secondly, there is currently no mechanism for sweeping the cache of known indices of an array. This is useful for spanning tree creation, wherein distant members of a section can be discovered through prior communication. 

Example usage:
```cpp
void on_location_update(const CkGroupID& gid, const CmiUInt8& id, const int& pe) {
  auto *loc = CProxy_CkLocMgr(gid).ckLocalBranch();

  CkPrintf("pe%d> got a location update, 0x%lx (with home %d) moved to %d!\n", CkMyPe(), id, loc->homePe(id), pe);

  auto found = false;
  loc->perKnown([&](const CkArrayIndex& idx) -> bool {
    found = id == loc->lookupID(idx);
    return !found; // continue search while elt not found
  });
  CkAssert(found);
}

void subscribe_to(CkArray* arr) {
  auto* locMgr = arr->getLocMgr();
  using namespace std::placeholders;
  locMgr->addListener(std::bind(
    &on_location_update,
    this,
    _1,
    _2,
    _3
  ));
}
```