### PR TITLE
OFI: Change return type of registerDirectMemory to void

### DIFF
--- a/src/arch/ofi/machine-onesided.C
+++ b/src/arch/ofi/machine-onesided.C
@@ -1,12 +1,12 @@
 void registerDirectMemory(void *info, const void *addr, int size) {
   CmiOfiRdmaPtr_t *rdmaInfo = (CmiOfiRdmaPtr_t *)info;
   uint64_t requested_key = 0;
-  int ret;
+  int err;
 
   if(FI_MR_SCALABLE == context.mr_mode) {
     requested_key = __sync_fetch_and_add(&(context.mr_counter), 1);
   }
-  ret = fi_mr_reg(context.domain,
+  err = fi_mr_reg(context.domain,
                   addr,
                   size,
                   FI_REMOTE_READ | FI_REMOTE_WRITE | FI_READ | FI_WRITE,
@@ -15,7 +15,7 @@ void registerDirectMemory(void *info, const void *addr, int size) {
                   0ULL,
                   &(rdmaInfo->mr),
                   NULL);
-  if (ret) {
+  if (err) {
     CmiAbort("registerDirectMemory: fi_mr_reg failed!\n");
   }
   rdmaInfo->key = fi_mr_key(rdmaInfo->mr);
@@ -320,12 +320,12 @@ void LrtsIssueRput(NcpyOperationInfo *ncpyOpInfo) {
 // Method invoked to deregister memory handle
 void LrtsDeregisterMem(const void *ptr, void *info, int pe, unsigned short int mode){
   CmiOfiRdmaPtr_t *rdmaSrc = (CmiOfiRdmaPtr_t *)info;
-  int ret;
+  int err;
 
   if(mode != CMK_BUFFER_NOREG && rdmaSrc->mr) {
     // Deregister the buffer
-    ret = fi_close((struct fid *)rdmaSrc->mr);
-    if(ret)
+    err = fi_close((struct fid *)rdmaSrc->mr);
+    if(err)
       CmiAbort("LrtsDeregisterMem: fi_close(mr) failed!\n");
   }
 }

--- a/src/arch/ofi/machine-onesided.C
+++ b/src/arch/ofi/machine-onesided.C
@@ -1,4 +1,4 @@
-struct fid_mr* registerDirectMemory(void *info, const void *addr, int size) {
+void registerDirectMemory(void *info, const void *addr, int size) {
   CmiOfiRdmaPtr_t *rdmaInfo = (CmiOfiRdmaPtr_t *)info;
   uint64_t requested_key = 0;
   int ret;


### PR DESCRIPTION
This commit fixes the ofi autobuild crashes seen on Stampede2.
Previously, registerDirectMemory was defined to return a fid_mr
struct pointer but did not return any argument. This
caused a mysterious crash with SIGSEGV on Stampede2 with gcc 9.1.0.
This commit changes the return type to void, which is the correct
return type for that function, and this in turn fixes the crash.