### PR TITLE
AMPI: Try `main` as an entry point with fs/pip/pieglobals

### DIFF
--- a/src/libs/ck-libs/ampi/ampi.C
+++ b/src/libs/ck-libs/ampi/ampi.C
@@ -11766,6 +11766,10 @@ static ampi_maintype AMPI_Main_Get_C(SharedObject myexe)
   if (AMPI_Main_ptr)
     return AMPI_Main_ptr;
 
+  auto main_ptr = (ampi_maintype)dlsym(myexe, "main");
+  if (main_ptr)
+    return main_ptr;
+
   return nullptr;
 }
 


### PR DESCRIPTION
This allows programs that do not include mpi.h before defining `main` to
run successfully with these methods, such as in some configure tests.

It also allows running Fortran programs with these methods without
renaming the `program` statement to `subroutine mpi_main`.