### PR TITLE
Converse: Strengthen locking in node reductions

### DIFF
--- a/src/conv-core/convcore.C
+++ b/src/conv-core/convcore.C
@@ -2736,7 +2736,6 @@ void CmiResetGlobalReduceSeqID(void) {
 }
 
 void CmiResetGlobalNodeReduceSeqID(void) {
-	CmiAssert(CmiMyRank() == 0);
 	CsvAccess(_nodereduce_seqID_global) = 0;
 }
 
@@ -2894,8 +2893,6 @@ void CmiGroupReduceStruct(CmiGroup grp, void *data, CmiReducePupFn pupFn,
 }
 
 void CmiNodeReduce(void *msg, int size, CmiReduceMergeFn mergeFn) {
-  CmiAssert(CmiMyRank() == 0);
-
   const CmiReductionID id = CmiGetNextNodeReductionID();
 #if CMK_SMP
   CmiNodeReduction & nodered = CsvAccess(_nodereduce_info)[CmiGetRedIndex(id)];
@@ -2913,8 +2910,6 @@ void CmiNodeReduce(void *msg, int size, CmiReduceMergeFn mergeFn) {
 void CmiNodeReduceStruct(void *data, CmiReducePupFn pupFn,
                          CmiReduceMergeFn mergeFn, CmiHandler dest,
                          CmiReduceDeleteFn deleteFn) {
-  CmiAssert(CmiMyRank() == 0);
-
   const CmiReductionID id = CmiGetNextNodeReductionID();
 #if CMK_SMP
   CmiNodeReduction & nodered = CsvAccess(_nodereduce_info)[CmiGetRedIndex(id)];
@@ -2930,8 +2925,6 @@ void CmiNodeReduceStruct(void *data, CmiReducePupFn pupFn,
 }
 
 void CmiNodeReduceID(void *msg, int size, CmiReduceMergeFn mergeFn, CmiReductionID id) {
-  CmiAssert(CmiMyRank() == 0);
-
 #if CMK_SMP
   CmiNodeReduction & nodered = CsvAccess(_nodereduce_info)[CmiGetRedIndex(id)];
   CmiLock(nodered.lock);
@@ -2948,8 +2941,6 @@ void CmiNodeReduceID(void *msg, int size, CmiReduceMergeFn mergeFn, CmiReduction
 void CmiNodeReduceStructID(void *data, CmiReducePupFn pupFn,
                            CmiReduceMergeFn mergeFn, CmiHandler dest,
                            CmiReduceDeleteFn deleteFn, CmiReductionID id) {
-  CmiAssert(CmiMyRank() == 0);
-
 #if CMK_SMP
   CmiNodeReduction & nodered = CsvAccess(_nodereduce_info)[CmiGetRedIndex(id)];
   CmiLock(nodered.lock);

--- a/src/conv-core/convcore.C
+++ b/src/conv-core/convcore.C
@@ -2492,8 +2492,11 @@ enum : CmiReductionID {
   CmiReductionID_requestOffset = 1, /* Reductions IDs that are requested by all the processors (i.e during intialization) */
   CmiReductionID_dynamicOffset = 2, /* Reductions IDs that are requested by only one processor (typically at runtime) */
 
-  CmiReductionID_multiplier = 4 /* MUST be a power of two because the ID counter may overflow and wrap to 0 */
+  CmiReductionID_multiplier = 4
 };
+
+static_assert(CmiIsPow2(CmiReductionID_multiplier),
+              "CmiReductionID_multiplier must be a power of two because seqID counters may overflow and wrap to 0");
 
 static inline unsigned int CmiGetRedIndex(CmiReductionID id) {
   return id & ~((~0u) << CmiLogMaxReductions);

--- a/src/conv-core/convcore.C
+++ b/src/conv-core/convcore.C
@@ -2736,6 +2736,7 @@ void CmiResetGlobalReduceSeqID(void) {
 }
 
 void CmiResetGlobalNodeReduceSeqID(void) {
+	CmiAssert(CmiMyRank() == 0);
 	CsvAccess(_nodereduce_seqID_global) = 0;
 }
 
@@ -2893,6 +2894,8 @@ void CmiGroupReduceStruct(CmiGroup grp, void *data, CmiReducePupFn pupFn,
 }
 
 void CmiNodeReduce(void *msg, int size, CmiReduceMergeFn mergeFn) {
+  CmiAssert(CmiMyRank() == 0);
+
   const CmiReductionID id = CmiGetNextNodeReductionID();
 #if CMK_SMP
   CmiNodeReduction & nodered = CsvAccess(_nodereduce_info)[CmiGetRedIndex(id)];
@@ -2910,6 +2913,8 @@ void CmiNodeReduce(void *msg, int size, CmiReduceMergeFn mergeFn) {
 void CmiNodeReduceStruct(void *data, CmiReducePupFn pupFn,
                          CmiReduceMergeFn mergeFn, CmiHandler dest,
                          CmiReduceDeleteFn deleteFn) {
+  CmiAssert(CmiMyRank() == 0);
+
   const CmiReductionID id = CmiGetNextNodeReductionID();
 #if CMK_SMP
   CmiNodeReduction & nodered = CsvAccess(_nodereduce_info)[CmiGetRedIndex(id)];
@@ -2925,6 +2930,8 @@ void CmiNodeReduceStruct(void *data, CmiReducePupFn pupFn,
 }
 
 void CmiNodeReduceID(void *msg, int size, CmiReduceMergeFn mergeFn, CmiReductionID id) {
+  CmiAssert(CmiMyRank() == 0);
+
 #if CMK_SMP
   CmiNodeReduction & nodered = CsvAccess(_nodereduce_info)[CmiGetRedIndex(id)];
   CmiLock(nodered.lock);
@@ -2941,6 +2948,8 @@ void CmiNodeReduceID(void *msg, int size, CmiReduceMergeFn mergeFn, CmiReduction
 void CmiNodeReduceStructID(void *data, CmiReducePupFn pupFn,
                            CmiReduceMergeFn mergeFn, CmiHandler dest,
                            CmiReduceDeleteFn deleteFn, CmiReductionID id) {
+  CmiAssert(CmiMyRank() == 0);
+
 #if CMK_SMP
   CmiNodeReduction & nodered = CsvAccess(_nodereduce_info)[CmiGetRedIndex(id)];
   CmiLock(nodered.lock);

--- a/src/conv-core/converse.h
+++ b/src/conv-core/converse.h
@@ -78,6 +78,9 @@
 
 #define CMI_MSG_NOKEEP(msg)                  ((CmiMsgHeaderBasic *)msg)->nokeep
 
+#define CmiIsPow2OrZero(v) (((v) & ((v) - 1)) == 0)
+#define CmiIsPow2(v) (CmiIsPow2OrZero(v) && (v))
+
 #define CMIALIGN(x,n)       (size_t)((~((size_t)n-1))&((x)+(n-1)))
 /*#define ALIGN8(x)        (size_t)((~7)&((x)+7)) */
 #define ALIGN8(x)          CMIALIGN(x,8)


### PR DESCRIPTION
It is possible for node reduction messages to arrive at the root before
it has completed its own CmiNodeReduce* call. Therefore, lock around
all accesses of _nodereduce_info.