### PR TITLE
Move MigrateDone from private to protected in DistBaseLB

### DIFF
--- a/src/ck-ldb/DistBaseLB.h
+++ b/src/ck-ldb/DistBaseLB.h
@@ -55,6 +55,7 @@ public:
 protected:
   virtual void Strategy(const LDStats* const myStats);
   void ProcessMigrationDecision(LBMigrateMsg* migrateMsg);
+  void MigrationDone(int balancing);  // Call when migration is complete
 
   LDStats myStats;
   int migrates_expected;
@@ -69,7 +70,6 @@ private:
   LBMigrateMsg** mig_msgs;
 
   void AssembleStats();
-  void MigrationDone(int balancing);  // Call when migration is complete
 };
 
 #endif /* _DISTBASELB_H */


### PR DESCRIPTION
With MigrateDone being protected, the DistributedLB strategies can call `lbmgr->Migrate` directly without setting the `migrates_expected` to reduce communication.

The DistributedLB strategies can call `CkWaitQD()` to wait for migrations and follow by  `MigrateDone(1)` to resume clients. 