### PR TITLE
Tracing: Reduce memory usage in Projections tracing

### DIFF
--- a/src/ck-perf/trace-common.h
+++ b/src/ck-perf/trace-common.h
@@ -23,6 +23,7 @@
 #endif
 
 
+#define  INVALID            0
 #define  CREATION           1
 #define  BEGIN_PROCESSING   2
 #define  END_PROCESSING     3

--- a/src/ck-perf/trace-projections.C
+++ b/src/ck-perf/trace-projections.C
@@ -592,20 +592,14 @@ void LogPool::addUserBracketEventNestedID(unsigned char type, double time,
   }
 }
 
-  
-void LogPool::addMemoryUsage(unsigned char type,double time,double memUsage){
-  if (type == CREATION ||
-      type == CREATION_MULTICAST ||
-      type == CREATION_BCAST) {
-    lastCreationEvent = numEntries;
-  }
-  new (&pool[numEntries++])
-	LogEntry(type,time,memUsage);
-  if(poolSize == numEntries){
+void LogPool::addMemoryUsage(double time, double memUsage)
+{
+  new (&pool[numEntries++]) LogEntry(MEMORY_USAGE_CURRENT, time, memUsage);
+  if (poolSize == numEntries)
+  {
     flushLogBuffer();
   }
-	
-}  
+}
 
 void LogPool::addUserStat(double time, int pe, int e, double stat,
                           double statTime)
@@ -1158,8 +1152,7 @@ void TraceProjections::userSuppliedBracketedNote(char *note, int eventID, double
 void TraceProjections::memoryUsage(double m)
 {
   if (!computationStarted) return;
-  _logPool->addMemoryUsage(MEMORY_USAGE_CURRENT, TraceTimer(), m );
-  
+  _logPool->addMemoryUsage(TraceTimer(), m);
 }
 //Updates User stat value. Makes appropriate Call to LogPool updateStat function
 void TraceProjections::updateStatPair(int e, double stat, double statTime)

--- a/src/ck-perf/trace-projections.C
+++ b/src/ck-perf/trace-projections.C
@@ -584,19 +584,6 @@ void LogPool::add(UChar type, UShort mIdx, UShort eIdx,
   }
 }
 
-void LogPool::add(UChar type,double time,UShort funcID,int lineNum,char *fileName){
-  if (type == CREATION ||
-      type == CREATION_MULTICAST ||
-      type == CREATION_BCAST) {
-    lastCreationEvent = numEntries;
-  }
-  new (&pool[numEntries++])
-	LogEntry(time,type,funcID,lineNum,fileName);
-  if(poolSize == numEntries){
-    flushLogBuffer();
-  }
-}
-
 void LogPool::addUserBracketEventNestedID(unsigned char type, double time,
                                           UShort mIdx, int event, int nestedID) {
   new (&pool[numEntries++])

--- a/src/ck-perf/trace-projections.C
+++ b/src/ck-perf/trace-projections.C
@@ -492,6 +492,10 @@ void LogPool::flushLogBuffer()
   if (numEntries) {
     double writeTime = TraceTimer();
     writeLog();
+    for (int i = 0; i < numEntries; i++)
+    {
+      pool[i].~LogEntry();
+    }
     hasFlushed = true;
     numEntries = 0;
     lastCreationEvent = -1;

--- a/src/ck-perf/trace-projections.C
+++ b/src/ck-perf/trace-projections.C
@@ -611,12 +611,13 @@ void LogPool::addUserStat(double time, int pe, int e, double stat,
   }
 }
 
-void LogPool::addUserSupplied(int data){
-	// add an event
-	add(USER_SUPPLIED, 0, 0, TraceTimer(), -1, -1, 0, 0, 0, 0);
-
-	// set the user supplied value for the previously created event 
-	pool[numEntries-1].setUserSuppliedData(data);
+void LogPool::addUserSupplied(int data)
+{
+  new (&pool[numEntries++]) LogEntry(USER_SUPPLIED, TraceTimer(), data);
+  if (poolSize == numEntries)
+  {
+    flushLogBuffer();
+  }
 }
 
 void LogPool::addUserSuppliedNote(char* note)

--- a/src/ck-perf/trace-projections.C
+++ b/src/ck-perf/trace-projections.C
@@ -685,6 +685,8 @@ void LogEntry::pup(PUP::er &p)
 
   switch (type) {
     case USER_EVENT:
+      p|mIdx; p|itime; p|event; p|pe;
+      break;
     case USER_EVENT_PAIR:
     case BEGIN_USER_EVENT_PAIR:
     case END_USER_EVENT_PAIR:

--- a/src/ck-perf/trace-projections.C
+++ b/src/ck-perf/trace-projections.C
@@ -619,19 +619,20 @@ void LogPool::addUserSupplied(int data){
 	pool[numEntries-1].setUserSuppliedData(data);
 }
 
-
-void LogPool::addUserSuppliedNote(char *note){
-	// add an event
-	add(USER_SUPPLIED_NOTE, 0, 0, TraceTimer(), -1, -1, 0, 0, 0, 0);
-
-	// set the user supplied note for the previously created event 
-	pool[numEntries-1].setUserSuppliedNote(note);
+void LogPool::addUserSuppliedNote(char* note)
+{
+  new (&pool[numEntries++]) LogEntry(USER_SUPPLIED_NOTE, TraceTimer(), note);
+  if (poolSize == numEntries)
+  {
+    flushLogBuffer();
+  }
 }
 
-void LogPool::addUserSuppliedBracketedNote(char *note, int eventID, double bt, double et){
-  new (&pool[numEntries++])
-    LogEntry(bt, et, USER_SUPPLIED_BRACKETED_NOTE, note, eventID);
-  if(poolSize == numEntries){
+void LogPool::addUserSuppliedBracketedNote(char* note, int eventID, double bt, double et)
+{
+  new (&pool[numEntries++]) LogEntry(USER_SUPPLIED_BRACKETED_NOTE, bt, note, eventID, et);
+  if (poolSize == numEntries)
+  {
     flushLogBuffer();
   }
 }

--- a/src/ck-perf/trace-projections.C
+++ b/src/ck-perf/trace-projections.C
@@ -586,8 +586,7 @@ void LogPool::add(UChar type, UShort mIdx, UShort eIdx,
 
 void LogPool::addUserBracketEventNestedID(unsigned char type, double time,
                                           UShort mIdx, int event, int nestedID) {
-  new (&pool[numEntries++])
-  LogEntry(time, type, mIdx, 0, event, CkMyPe(), 0, 0, 0, 0, 0, 0, nestedID);
+  new (&pool[numEntries++]) LogEntry(type, time, mIdx, event, nestedID);
   if(poolSize == numEntries){
     flushLogBuffer();
   }

--- a/src/ck-perf/trace-projections.C
+++ b/src/ck-perf/trace-projections.C
@@ -639,26 +639,8 @@ void LogPool::addUserSuppliedNote(char *note){
 }
 
 void LogPool::addUserSuppliedBracketedNote(char *note, int eventID, double bt, double et){
-  //CkPrintf("LogPool::addUserSuppliedBracketedNote eventID=%d\n", eventID);
-#if MPI_TRACE_MACHINE_HACK
-  //This part of code is used  to combine the contiguous
-  //MPI_Test and MPI_Iprobe events to reduce the number of
-  //entries
-#define MPI_TEST_EVENT_ID 60
-#define MPI_IPROBE_EVENT_ID 70 
-  int lastEvent = pool[numEntries-1].event;
-  if((eventID==MPI_TEST_EVENT_ID || eventID==MPI_IPROBE_EVENT_ID) && (eventID==lastEvent)){
-    //just replace the endtime of last event
-    //CkPrintf("addUserSuppliedBracketNote: for event %d\n", lastEvent);
-    pool[numEntries].endTime = et;
-  }else{
-    new (&pool[numEntries++])
-      LogEntry(bt, et, USER_SUPPLIED_BRACKETED_NOTE, note, eventID);
-  }
-#else
   new (&pool[numEntries++])
     LogEntry(bt, et, USER_SUPPLIED_BRACKETED_NOTE, note, eventID);
-#endif
   if(poolSize == numEntries){
     flushLogBuffer();
   }

--- a/src/ck-perf/trace-projections.h
+++ b/src/ck-perf/trace-projections.h
@@ -208,6 +208,10 @@ class LogEntry {
           pes.~vector<int>();
           break;
       }
+      // Make destruction idempotent
+      // Elements may get destroyed twice (once from flush, again at program end if their
+      // slot hasn't been written over)
+      type = INVALID;
     }
 
     // complementary function for adding papi data

--- a/src/ck-perf/trace-projections.h
+++ b/src/ck-perf/trace-projections.h
@@ -55,7 +55,7 @@ class LogEntry {
     CmiObjId   id;
     std::vector<int> pes;
     unsigned long memUsage;
-    double stat;	//Used for storing User Stats
+    double stat;  // USER_STAT
     std::string userSuppliedNote;
 
     // this is taken out so as to provide a placeholder value for non-PAPI
@@ -74,7 +74,7 @@ class LogEntry {
 
     LogEntry(double tm, unsigned char t, unsigned short m=0, 
 	     unsigned short e=0, int ev=0, int p=0, int ml=0, 
-	     CmiObjId *d=NULL, double rt=0., double cputm=0., int numPe=0, double statVal=0.) {
+	     CmiObjId *d=NULL, double rt=0., double cputm=0., int numPe=0) {
       type = t; mIdx = m; eIdx = e; event = ev; pe = p; 
       time = tm; msglen = ml;
       if (d) id = *d; else {id.id[0]=id.id[1]=id.id[2]=id.id[3]=0; };
@@ -86,7 +86,6 @@ class LogEntry {
       //numPapiEvents = 0;
 #endif
       pes.resize(numPe);
-      stat=statVal;
     }
 
    // Constructor for bracketed user supplied note
@@ -126,6 +125,14 @@ class LogEntry {
     {
       CkAssert(type == USER_EVENT_PAIR || type == BEGIN_USER_EVENT_PAIR ||
                type == END_USER_EVENT_PAIR);
+    }
+
+    // Constructor for user stats
+    // TODO: Repurposes mIdx and cputime fields to store e and statTime, should clean up
+    LogEntry(unsigned char type, double time, int pe, int e, double stat, double statTime)
+        : type(type), time(time), pe(pe), mIdx(e), stat(stat), cputime(statTime)
+    {
+      CkAssert(type == USER_STAT);
     }
 
     // complementary function for adding papi data
@@ -288,7 +295,7 @@ class LogPool {
 
     void add(unsigned char type, unsigned short mIdx, unsigned short eIdx,
 	     double time, int event, int pe, int ml=0, CmiObjId* id=0, 
-	     double recvT=0.0, double cpuT=0.0, int numPe=0, double statVal=0.0);
+	     double recvT=0.0, double cpuT=0.0, int numPe=0);
 
     // complementary function to set papi info to current log entry
     // must be called after an add()
@@ -299,7 +306,7 @@ class LogPool {
 	/** add a record for a user supplied piece of data */
 	void addUserSupplied(int data);
 	/* Creates LogEntry for stat. Called by Trace-projections updateStat functions*/
-        void updateStat(unsigned char type,int e, double cputime,double time,double stat, int pe);
+	void addUserStat(double time, int pe, int e, double stat, double statTime);
 	/** add a record for a user supplied piece of data */
 	void addUserSuppliedNote(char *note);
 

--- a/src/ck-perf/trace-projections.h
+++ b/src/ck-perf/trace-projections.h
@@ -62,7 +62,6 @@ class LogEntry {
 #if CMK_HAS_COUNTER_PAPI
     LONG_LONG_PAPI papiValues[NUMPAPIEVENTS];
 #endif
-    std::string fName;
     int userSuppliedData;
     unsigned char type;
 
@@ -88,35 +87,6 @@ class LogEntry {
       stat=statVal;
     }
 
-    LogEntry(double _time,unsigned char _type,unsigned short _funcID,
-	     int _lineNum,char *_fileName){
-      time = _time;
-      type = _type;
-      mIdx = _funcID;
-      event = _lineNum;
-      setFName(_fileName);
-    }
-
-    // Constructor for User Supplied Data
-    LogEntry(double _time,unsigned char _type, int value,
-	     int _lineNum,char *_fileName){
-      time = _time;
-      type = _type;
-      userSuppliedData = value;
-      setFName(_fileName);
-    }
-
-    // Constructor for User Supplied Data
-    LogEntry(double _time,unsigned char _type, char* note,
-	     int _lineNum,char *_fileName){
-      time = _time;
-      type = _type;
-      setFName(_fileName);
-      if(note != NULL)
-	setUserSuppliedNote(note);
-    }
-
-
    // Constructor for bracketed user supplied note
     LogEntry(double bt, double et, unsigned char _type, char *note, int eventID){
       time = bt;
@@ -126,7 +96,6 @@ class LogEntry {
       if(note != NULL)
 	setUserSuppliedNote(note);
     }
-
 
     // Constructor for multicast data
     LogEntry(double tm, unsigned short m, unsigned short e, int ev, int p,
@@ -146,14 +115,6 @@ class LogEntry {
         pes.assign(pelist, pelist + numPe);
       else
         pes.resize(numPe);
-    }
-
-    void setFName(char *_fileName){
-      if(_fileName == NULL){
-        fName.clear();
-      }else{
-        fName = _fileName;
-      }	
     }
 
     // complementary function for adding papi data
@@ -334,9 +295,6 @@ class LogPool {
         void addUserBracketEventNestedID(unsigned char type, double time,
                                          UShort mIdx, int event, int nestedID);
 
-
-	void add(unsigned char type,double time,unsigned short funcID,int lineNum,char *fileName);
-  
   	void addMemoryUsage(unsigned char type,double time,double memUsage);
 	void addUserSuppliedBracketedNote(char *note, int eventID, double bt, double et);
 

--- a/src/ck-perf/trace-projections.h
+++ b/src/ck-perf/trace-projections.h
@@ -14,6 +14,7 @@
 #include <string>
 #include <algorithm>
 
+#include "charm.h"
 #include "trace.h"
 #include "trace-common.h"
 #include "ckhashtable.h"
@@ -49,7 +50,8 @@ class LogEntry {
     unsigned short mIdx;
     unsigned short eIdx;
     int msglen;
-    int nestedID; // Nested thread ID, e.g. virtual AMPI rank number
+    int nestedID;  // USER_EVENT_PAIR, BEGIN_USER_EVENT_PAIR, END_USER_EVENT_PAIR
+                   // Nested thread ID, e.g. virtual AMPI rank number
     CmiObjId   id;
     std::vector<int> pes;
     unsigned long memUsage;
@@ -72,9 +74,9 @@ class LogEntry {
 
     LogEntry(double tm, unsigned char t, unsigned short m=0, 
 	     unsigned short e=0, int ev=0, int p=0, int ml=0, 
-	     CmiObjId *d=NULL, double rt=0., double cputm=0., int numPe=0, double statVal=0., int _nestedID=0) {
+	     CmiObjId *d=NULL, double rt=0., double cputm=0., int numPe=0, double statVal=0.) {
       type = t; mIdx = m; eIdx = e; event = ev; pe = p; 
-      time = tm; msglen = ml; nestedID=_nestedID;
+      time = tm; msglen = ml;
       if (d) id = *d; else {id.id[0]=id.id[1]=id.id[2]=id.id[3]=0; };
       recvTime = rt; cputime = cputm;
       // initialize for papi as well as non papi versions.
@@ -115,6 +117,15 @@ class LogEntry {
         pes.assign(pelist, pelist + numPe);
       else
         pes.resize(numPe);
+    }
+
+    // Constructor for user event pairs
+    LogEntry(unsigned char type, double time, unsigned short mIdx, int event,
+             int nestedID)
+        : type(type), time(time), mIdx(mIdx), event(event), nestedID(nestedID)
+    {
+      CkAssert(type == USER_EVENT_PAIR || type == BEGIN_USER_EVENT_PAIR ||
+               type == END_USER_EVENT_PAIR);
     }
 
     // complementary function for adding papi data

--- a/src/ck-perf/trace-projections.h
+++ b/src/ck-perf/trace-projections.h
@@ -56,7 +56,7 @@ class LogEntry {
     std::vector<int> pes;  // CREATION_BCAST, CREATION_MULTICAST
     unsigned long memUsage;  // MEMORY_USAGE_CURRENT
     double stat;  // USER_STAT
-    std::string userSuppliedNote;
+    std::string userSuppliedNote;  // USER_SUPPLIED_NOTE, USER_SUPPLIED_BRACKETED_NOTE
 
     // this is taken out so as to provide a placeholder value for non-PAPI
     // versions (whose value is *always* zero).
@@ -87,14 +87,21 @@ class LogEntry {
 #endif
     }
 
-   // Constructor for bracketed user supplied note
-    LogEntry(double bt, double et, unsigned char _type, char *note, int eventID){
-      time = bt;
-      endTime = et;
-      type = _type;
-      event = eventID;
-      if(note != NULL)
-	setUserSuppliedNote(note);
+    // Constructor for user supplied note and bracketed user supplied note,
+    // event and endTime are only used for the bracketed version
+    LogEntry(unsigned char type, double time, char* note, int event = 0,
+             double endTime = 0)
+        : type(type), time(time), event(event), endTime(endTime)
+    {
+      CkAssert(type == USER_SUPPLIED_NOTE || type == USER_SUPPLIED_BRACKETED_NOTE);
+      if (note == nullptr)
+      {
+        userSuppliedNote.clear();
+        return;
+      }
+      userSuppliedNote = note;
+      std::replace(userSuppliedNote.begin(), userSuppliedNote.end(), '\n', ' ');
+      std::replace(userSuppliedNote.begin(), userSuppliedNote.end(), '\r', ' ');
     }
 
     // Constructor for multicast data
@@ -168,15 +175,6 @@ class LogEntry {
       userSuppliedData = data;
     }
 
-    void setUserSuppliedNote(char *note){
-      if (note == nullptr) {
-        userSuppliedNote.clear();
-        return;
-      }
-      userSuppliedNote = note;
-      std::replace(userSuppliedNote.begin(), userSuppliedNote.end(), '\n', ' ');
-      std::replace(userSuppliedNote.begin(), userSuppliedNote.end(), '\r', ' ');
-    }
 
     void *operator new(size_t s) {void*ret=malloc(s);_MEMCHECK(ret);return ret;}
     void *operator new(size_t, void *ptr) { return ptr; }

--- a/src/ck-perf/trace-projections.h
+++ b/src/ck-perf/trace-projections.h
@@ -64,7 +64,7 @@ class LogEntry {
 #if CMK_HAS_COUNTER_PAPI
     LONG_LONG_PAPI papiValues[NUMPAPIEVENTS];
 #endif
-    int userSuppliedData;
+    int userSuppliedData;  // USER_SUPPLIED
     unsigned char type;
 
   public:
@@ -85,6 +85,23 @@ class LogEntry {
 #else
       //numPapiEvents = 0;
 #endif
+    }
+
+    // Constructor for user supplied data or memory usage record
+    // Shared constructor to avoid ambiguity issues (userSuppliedData is int, memUsage is
+    // long)
+    LogEntry(unsigned char type, double time, long value) : type(type), time(time)
+    {
+      CkAssert(type == USER_SUPPLIED || type == MEMORY_USAGE_CURRENT);
+      switch (type)
+      {
+        case USER_SUPPLIED:
+          userSuppliedData = (int)value;
+          break;
+        case MEMORY_USAGE_CURRENT:
+          memUsage = value;
+          break;
+      }
     }
 
     // Constructor for user supplied note and bracketed user supplied note,
@@ -158,23 +175,12 @@ class LogEntry {
       CkAssert(type == USER_STAT);
     }
 
-    // Constructor for memory usage record
-    LogEntry(unsigned char type, double time, long memUsage)
-        : type(type), time(time), memUsage(memUsage)
-    {
-    }
-
     // complementary function for adding papi data
     void addPapi(LONG_LONG_PAPI *papiVals){
 #if CMK_HAS_COUNTER_PAPI
    	memcpy(papiValues, papiVals, sizeof(LONG_LONG_PAPI)*CkpvAccess(numEvents));
 #endif
     }
-   
-    void setUserSuppliedData(int data){
-      userSuppliedData = data;
-    }
-
 
     void *operator new(size_t s) {void*ret=malloc(s);_MEMCHECK(ret);return ret;}
     void *operator new(size_t, void *ptr) { return ptr; }

--- a/src/ck-perf/trace-projections.h
+++ b/src/ck-perf/trace-projections.h
@@ -54,7 +54,7 @@ class LogEntry {
                    // Nested thread ID, e.g. virtual AMPI rank number
     CmiObjId   id;
     std::vector<int> pes;  // CREATION_BCAST, CREATION_MULTICAST
-    unsigned long memUsage;
+    unsigned long memUsage;  // MEMORY_USAGE_CURRENT
     double stat;  // USER_STAT
     std::string userSuppliedNote;
 
@@ -151,6 +151,12 @@ class LogEntry {
       CkAssert(type == USER_STAT);
     }
 
+    // Constructor for memory usage record
+    LogEntry(unsigned char type, double time, long memUsage)
+        : type(type), time(time), memUsage(memUsage)
+    {
+    }
+
     // complementary function for adding papi data
     void addPapi(LONG_LONG_PAPI *papiVals){
 #if CMK_HAS_COUNTER_PAPI
@@ -171,15 +177,6 @@ class LogEntry {
       std::replace(userSuppliedNote.begin(), userSuppliedNote.end(), '\n', ' ');
       std::replace(userSuppliedNote.begin(), userSuppliedNote.end(), '\r', ' ');
     }
-	
-
-    /// A constructor for a memory usage record
-    LogEntry(unsigned char _type, double _time, long _memUsage) {
-      time = _time;
-      type = _type;
-      memUsage = _memUsage;
-    }
-
 
     void *operator new(size_t s) {void*ret=malloc(s);_MEMCHECK(ret);return ret;}
     void *operator new(size_t, void *ptr) { return ptr; }
@@ -329,7 +326,7 @@ class LogPool {
         void addUserBracketEventNestedID(unsigned char type, double time,
                                          UShort mIdx, int event, int nestedID);
 
-  	void addMemoryUsage(unsigned char type,double time,double memUsage);
+  	void addMemoryUsage(double time, double memUsage);
 	void addUserSuppliedBracketedNote(char *note, int eventID, double bt, double et);
 
     void addCreationBroadcast(unsigned short mIdx, unsigned short eIdx, double time,


### PR DESCRIPTION
The crux of this is the change to use a `union` inside `LogEntry`, a lot of the other cleanup is in support of making that change. All in all, this changes the size of a `LogEntry` from 184 bytes to 88 bytes (as measured via `clangd` on x86_64 Linux). We could also change the `std::string` and `std::vector` to their size + pointer equivalents to save an additional 20 bytes (assuming we also start using 64-bit ID, otherwise the ID becomes the size constraint and we'd only save 16 bytes), if we decide the space tradeoff is worth using raw pointers.