### PR TITLE
Csd: add CSD_NO_SCHEDLOOP build option

### DIFF
--- a/buildcmake
+++ b/buildcmake
@@ -494,11 +494,11 @@ fi
 # Build option setup
 
 if [[ $opt_ampi_only -eq 1 ]]; then
-    # AMPI doesn't use Charm-MPI interop or msg priorities of any kind.
+    # AMPI doesn't use Charm-MPI interop, msg priorities, non-FIFO queues, or CcdSCHEDLOOP.
     # AMPI creates O(NumVirtualRanks) chare arrays by default (for MPI_COMM_SELF),
     # so we bump up the number of bits reserved for the collection in the objid.
     opt_prio_type="char"
-    opt_extra_opts=('-DCMK_NO_INTEROP=1' '-DCMK_NO_MSG_PRIOS=1' '-DCMK_FIFO_QUEUE_ONLY=1' '-DCMK_OBJID_COLLECTION_BITS=29' "${opt_extra_opts[@]}")
+    opt_extra_opts=('-DCMK_NO_INTEROP=1' '-DCMK_NO_MSG_PRIOS=1' '-DCMK_FIFO_QUEUE_ONLY=1' '-DCSD_NO_SCHEDLOOP=1' '-DCMK_OBJID_COLLECTION_BITS=29' "${opt_extra_opts[@]}")
 fi
 
 # Special handling for gni-crayxc, gni-crayxe, mpi-crayxc, mpi-crayxe, mpi-crayshasta, ofi-crayshasta

--- a/buildold
+++ b/buildold
@@ -889,10 +889,10 @@ then
     echo "CMK_AMPI_ONLY:=1" >> "$ConvMak"
     echo '#define CMK_AMPI_ONLY 1' >> "$ConvHeader"
 
-    # AMPI doesn't use Charm-MPI interop or msg priorities of any kind.
+    # AMPI doesn't use Charm-MPI interop, msg priorities, non-FIFO queues, or CcdSCHEDLOOP.
     # AMPI creates O(NumVirtualRanks) chare arrays by default (for MPI_COMM_SELF),
     # so we bump up the number of bits reserved for the collection in the objid.
-    OPTS=('-DCMK_NO_INTEROP=1' '-DCMK_NO_MSG_PRIOS=1' '-DCMK_FIFO_QUEUE_ONLY=1' '-DCMK_OBJID_COLLECTION_BITS=29' "${OPTS[@]}")
+    OPTS=('-DCMK_NO_INTEROP=1' '-DCMK_NO_MSG_PRIOS=1' '-DCMK_FIFO_QUEUE_ONLY=1' '-DCSD_NO_SCHEDLOOP=1' '-DCMK_OBJID_COLLECTION_BITS=29' "${OPTS[@]}")
     CONFIG_OPTS=('--with-prio-type=char' "${CONFIG_OPTS[@]}")
 else
     echo "CMK_AMPI_ONLY=\"0\"" >> "$ConvSh"

--- a/src/arch/cuda/hybridAPI/hapi_impl.cpp
+++ b/src/arch/cuda/hybridAPI/hapi_impl.cpp
@@ -126,7 +126,7 @@ static void ipcHandleCreate();
 static void ipcHandleOpen();
 
 #ifndef HAPI_CUDA_CALLBACK
-static_assert(!CSD_NO_SCHEDLOOP);
+static_assert(!CSD_NO_SCHEDLOOP, "please disable CSD_NO_SCHEDLOOP to use HAPI");
 #endif
 
 // Called by all PEs in Charm++ layer init

--- a/src/arch/cuda/hybridAPI/hapi_impl.cpp
+++ b/src/arch/cuda/hybridAPI/hapi_impl.cpp
@@ -125,6 +125,10 @@ static void shmCleanup();
 static void ipcHandleCreate();
 static void ipcHandleOpen();
 
+#ifndef HAPI_CUDA_CALLBACK
+static_assert(!CSD_NO_SCHEDLOOP);
+#endif
+
 // Called by all PEs in Charm++ layer init
 void hapiInit(char** argv) {
   if (!CmiInCommThread()) {

--- a/src/arch/cuda/hybridAPI/hapi_impl.cpp
+++ b/src/arch/cuda/hybridAPI/hapi_impl.cpp
@@ -126,7 +126,9 @@ static void ipcHandleCreate();
 static void ipcHandleOpen();
 
 #ifndef HAPI_CUDA_CALLBACK
-static_assert(!CSD_NO_SCHEDLOOP, "please disable CSD_NO_SCHEDLOOP to use HAPI");
+#if CSD_NO_SCHEDLOOP
+#  error please disable CSD_NO_SCHEDLOOP to use HAPI
+#endif
 #endif
 
 // Called by all PEs in Charm++ layer init

--- a/src/conv-core/convcore.C
+++ b/src/conv-core/convcore.C
@@ -1932,8 +1932,10 @@ void CsdScheduleForever(void)
     }
 #endif
 
+#if !CSD_NO_SCHEDLOOP
     // Execute functions registered to be executed at every scheduler loop
     CcdRaiseCondition(CcdSCHEDLOOP);
+#endif
 
     msg = CsdNextMessage(&state);
     if (msg!=NULL) { /*A message is available-- process it*/


### PR DESCRIPTION
Add a build option to let users avoid the per-scheduling-loop overhead
associated with CcdSCHEDLOOP, and make AMPI-only builds use it.

This option combined with CSD_NO_IDLE_TRACING and CSD_NO_PERIODIC
greatly simplify the main scheduling loop, improving microbenchmark perf.