### PR TITLE
Revert change to CMK_SYSLIBS in CMakeLists

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -280,7 +280,7 @@ endif()
 
 if(${CMK_USE_ZLIB})
   find_package(ZLIB REQUIRED)
-  set(CMK_SYSLIBS "${CMK_SYSLIBS} -lz")
+  set(CMK_SYSLIBS "$CMK_SYSLIBS -lz")
 endif()
 
 set(CMK_USE_LIBJPEG 0)


### PR DESCRIPTION
Fixes builds (including PAMILRTS on Summit) from breaking by reverting a change by PR #3511.
Snippet of errors before fix:
```
[100%] Linking CXX executable bin/ckhello
/ccs/home/jchoi/work/charm-shmem/pamilrts-linux-ppc64le-smp/lib/libconverse.a(machine.C.o): In function `CmiNotifyStillIdle(CmiIdleState*)':
machine.C:(.text+0xf4): undefined reference to `PAMI_Context_advance'
/ccs/home/jchoi/work/charm-shmem/pamilrts-linux-ppc64le-smp/lib/libconverse.a(machine.C.o): In function `rzv_pkt_dispatch(void*, void*, void const*, unsigned long, void const*, unsigned long, unsigned int, pami_recv_t*)':
machine.C:(.text+0x1a8): undefined reference to `PAMI_Memregion_create'
machine.C:(.text+0x1ec): undefined reference to `PAMI_Get'
/ccs/home/jchoi/work/charm-shmem/pamilrts-linux-ppc64le-smp/lib/libconverse.a(machine.C.o): In function `LrtsSendFunc(int, int, int, char*, int) [clone .constprop.27]':
machine.C:(.text+0x310): undefined reference to `PAMI_Send_immediate'
machine.C:(.text+0x3dc): undefined reference to `PAMI_Send'
machine.C:(.text+0x414): undefined reference to `PAMI_Memregion_create'
machine.C:(.text+0x45c): undefined reference to `PAMI_Send_immediate'
...
/usr/bin/ld: link errors found, deleting executable `bin/ckhello'
collect2: error: ld returned 1 exit status
Fatal Error by charmc in directory /ccs/home/jchoi/work/charm-shmem/pamilrts-linux-ppc64le-smp
   Command g++ -ftls-model=initial-exec -rdynamic CMakeFiles/ckhello.dir/tests/charm++/simplearrayhello/hello.C.o moduleinit1256413.o -L/ccs/home/jchoi/work/charm-shmem/pamilrts-linux-ppc64le-smp/lib -lckmain -lck -lmemory-default -lthreads-default -lconverse -lm -lmemory-default -lthreads-default -lldb-rand -lconverse -lckqt -lckqt -lz -ldl -lmoduleNDMeshStreamer -lmodulecompletion -lz -lm /ccs/home/jchoi/work/charm-shmem/pamilrts-linux-ppc64le-smp/lib/conv-static.o -o bin/ckhello returned error code 1
charmc exiting...
make[2]: *** [CMakeFiles/ckhello.dir/build.make:97: bin/ckhello] Error 1
make[1]: *** [CMakeFiles/Makefile2:373: CMakeFiles/ckhello.dir/all] Error 2
make: *** [Makefile:136: all] Error 2
```