### PR TITLE
Add support for find_package and --install-prefix to Charm++

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1142,11 +1142,42 @@ file(WRITE ${CMAKE_BINARY_DIR}/include/charm-version-git.h "#define CHARM_VERSIO
 configure_file(${CMAKE_SOURCE_DIR}/cmake/Makefile.tests ${CMAKE_BINARY_DIR}/include/Makefile COPYONLY)
 configure_file(${CMAKE_SOURCE_DIR}/cmake/Makefile.tests.common ${CMAKE_BINARY_DIR}/include/Makefile.tests.common COPYONLY)
 
+# Configure CharmConfig.cmake
+configure_file(
+  ${CMAKE_SOURCE_DIR}/cmake/templates/CharmConfig.cmake.in
+  "${CMAKE_BINARY_DIR}/lib/cmake/Charm/CharmConfig.cmake"
+  ESCAPE_QUOTES
+  @ONLY)
 
 # Installation rules
-install(DIRECTORY ${CMAKE_BINARY_DIR}/bin DESTINATION . PATTERN * PERMISSIONS OWNER_EXECUTE OWNER_WRITE OWNER_READ GROUP_EXECUTE GROUP_READ WORLD_READ WORLD_EXECUTE)
-install(DIRECTORY ${CMAKE_BINARY_DIR}/lib     DESTINATION .)
+
+# install all includes
+install(
+  DIRECTORY ${CMAKE_BINARY_DIR}/include
+  DESTINATION .)
+
+# install all libraries
+install(
+  DIRECTORY ${CMAKE_BINARY_DIR}/lib
+  DESTINATION .)
+
+# install shared libraries if present
 if (${BUILD_SHARED})
-  install(DIRECTORY ${CMAKE_BINARY_DIR}/lib_so  DESTINATION .)
+install(
+  DIRECTORY ${CMAKE_BINARY_DIR}/lib_so
+  DESTINATION .)
 endif()
-install(DIRECTORY ${CMAKE_BINARY_DIR}/include DESTINATION .)
+
+#install all executables
+install(
+  DIRECTORY ${CMAKE_BINARY_DIR}/bin
+  DESTINATION .
+  PATTERN *
+  PERMISSIONS
+    OWNER_EXECUTE
+    OWNER_WRITE
+    OWNER_READ
+    GROUP_EXECUTE
+    GROUP_READ
+    WORLD_READ
+    WORLD_EXECUTE)

--- a/buildcmake
+++ b/buildcmake
@@ -103,6 +103,7 @@ opt_charmdebug=0
 opt_controlpoint=0
 opt_cuda=0
 opt_destination=""
+opt_install_prefix=""
 opt_drone_mode=0
 opt_error_checking= #undef
 opt_extra_opts=()
@@ -409,6 +410,9 @@ function processArgs() {
       --destination=*)
         opt_destination=${arg#*=}
         ;;
+      --install-prefix=*)
+        opt_install_prefix=${arg#*=}
+        ;;
       --suffix=*)
         opt_suffix=-${arg#*=}
         ;;
@@ -504,6 +508,15 @@ then
   fi
 fi
 
+# Install directory set-up
+if [[ -n "$opt_install_prefix" ]]
+then
+  # Install directory provided by user - Update installdir to point to it instead.
+  installdir="$opt_install_prefix"
+else
+  # Default Install directory
+  installdir="$my_srcdir/$builddir-install"
+fi
 
 # Build option setup
 
@@ -574,13 +587,13 @@ if [[ ${#opt_incdir[@]} -ne 0 ]]; then
   echo "USER_OPTS_CXX='${opt_incdir[*]}'" >> "$ConvUsr"
 fi
 
-
 # Run configure step
 
 CC=$opt_CC CXX=$opt_CXX FC=$opt_FC cmake "$my_srcdir" \
   -G "Unix Makefiles" \
   -DARCH="$opt_arch" \
   -DCMAKE_BUILD_TYPE="$opt_production" \
+  -DCMAKE_INSTALL_PREFIX="$installdir" \
   -DCMK_AMPI_ONLY="$opt_ampi_only" \
   -DCMK_AMPI_WITH_ROMIO="$opt_romio" \
   -DAMPI_ERROR_CHECKING="$opt_ampi_error_checking" \
@@ -630,5 +643,11 @@ CC=$opt_CC CXX=$opt_CXX FC=$opt_FC cmake "$my_srcdir" \
 
 [[ $VERBOSE -eq 1 ]] && export VERBOSE
 make "$opt_parallel"
+
+# Only Install if the user provides an install-prefix
+if [[ -n "$opt_install_prefix" ]]
+then
+  make install
+fi
 
 echo 'Build successful.'

--- a/buildcmake
+++ b/buildcmake
@@ -644,7 +644,9 @@ CC=$opt_CC CXX=$opt_CXX FC=$opt_FC cmake "$my_srcdir" \
 [[ $VERBOSE -eq 1 ]] && export VERBOSE
 make "$opt_parallel"
 
-# Only Install if the user provides an install-prefix
+# Only Install if the user provides an install prefix with the 
+# `--install-prefix` option. Without this option, `make install` would be a
+# no-op.
 if [[ -n "$opt_install_prefix" ]]
 then
   make install

--- a/cmake/templates/CharmConfig.cmake.in
+++ b/cmake/templates/CharmConfig.cmake.in
@@ -1,3 +1,6 @@
+# Set the equivalent to Charm_DIR for dependent project to set-up the path
+# correctly in their cmake configs. This will be used to ease the set-up
+# of working with find_package.
 get_filename_component(CHARM_CMAKE_DIR "${CMAKE_CURRENT_LIST_FILE}" DIRECTORY)
 
 # Set Charm project version

--- a/cmake/templates/CharmConfig.cmake.in
+++ b/cmake/templates/CharmConfig.cmake.in
@@ -1,0 +1,109 @@
+get_filename_component(CHARM_CMAKE_DIR "${CMAKE_CURRENT_LIST_FILE}" DIRECTORY)
+
+# Set Charm project version
+set(CHARM_PROJECT_VERSION "@CHARM_VERSION@")
+
+# Set root for Charm installation
+get_filename_component(CHARM_ROOT "${CMAKE_CURRENT_LIST_DIR}/../../.." ABSOLUTE)
+
+# Set cmake standard flag
+set(CHARM_CXX_STANDARD @CMAKE_CXX_STANDARD@)
+
+# Set Charm compiler
+set(CHARM_CXX_COMPILER "${CHARM_ROOT}/bin/charmc")
+set(CHARM_C_COMPILER "${CHARM_ROOT}/bin/charmc")
+
+# Set charmrun path
+set(CHARM_CHARMRUN_PATH "${CHARM_ROOT}/bin/charmrun")
+
+# Set CMK compiler used
+set(CHARM_CMK_COMPILER @CMK_COMPILER@)
+
+# Set Charm build type
+set(CHARM_BUILD_TYPE @CMAKE_BUILD_TYPE@)
+
+# Set SMP option
+set(CHARM_WITH_SMP @SMP@)
+
+# Set OMP option
+set(CHARM_WITH_OMP @OMP@)
+
+# Set TCP option
+set(CHARM_WITH_TCP @TCP@)
+
+# Set Pthreads option
+set(CHARM_WITH_PTHREADS @PTHREADS@)
+
+# Set OOC option
+set(CHARM_WITH_OOC @OOC@)
+
+# Set SYNCFT option
+set(CHARM_WITH_SYNCFT @SYNCFT@)
+
+# Set PAPI option
+set(CHARM_WITH_PAPI @SYNCFT@)
+
+# Set STATS option
+set(CHARM_WITH_STATS @STATS@)
+
+# Set TRACING_COMMTHREAD option
+set(CHARM_WITH_TRACING_COMMTHREAD @TRACING_COMMTHREAD@)
+
+# Set CHARMDEBUG option
+set(CHARM_WITH_CHARMDEBUG @CHARMDEBUG@)
+
+# Set REPLAY option
+set(CHARM_WITH_REPLAY @REPLAY@)
+
+# Set CCS option
+set(CHARM_WITH_CCS @CCS@)
+
+# Set CONTROLPOINT option
+set(CHARM_WITH_CONTROLPOINT @CONTROLPOINT@)
+
+# Set PERSISTENT option
+set(CHARM_WITH_PERSISTENT @PERSISTENT@)
+
+# Set LBUSERDATA option
+set(CHARM_WITH_LBUSERDATA @LBUSERDATA@)
+
+# Set LOCKLESS_QUEUE option
+set(CHARM_WITH_LOCKLESS_QUEUE @LOCKLESS_QUEUE@)
+
+# Set SHRINKEXPAND option
+set(CHARM_WITH_SHRINKEXPAND @SHRINKEXPAND@)
+
+# Set NUMA option
+set(CHARM_WITH_NUMA @NUMA@)
+
+# Set NUMA option
+set(CHARM_WITH_NUMA @NUMA@)
+
+# Set QLOGIC option
+set(CHARM_WITH_QLOGIC @QLOGIC@)
+
+# Set RANDOMIZED_MSGQ option
+set(CHARM_WITH_RANDOMIZED_MSGQ @RANDOMIZED_MSGQ@)
+
+# Set ZLIB option
+set(CHARM_WITH_ZLIB @ZLIB@)
+
+# Set AMPI_MPICH_TESTS option
+set(CHARM_WITH_AMPI_MPICH_TESTS @AMPI_MPICH_TESTS@)
+
+# Set DRONE_MODE option
+set(CHARM_WITH_DRONE_MODE @DRONE_MODE@)
+
+# Set TASK_QUEUE option
+set(CHARM_WITH_TASK_QUEUE @TASK_QUEUE@)
+
+# Set BUILD_SHARED option
+set(CHARM_WITH_BUILD_SHARED @BUILD_SHARED@)
+
+# Set CUDA option
+set(CHARM_WITH_CUDA @CUDA@)
+
+# Set PXSHM option
+set(CHARM_WITH_PXSHM @PXSHM@)
+
+# TODO: Find more useful flags that can be used in dependant apps/libs


### PR DESCRIPTION
This PR adds on two important features:
1. Support for `--install-prefix` to *buildcmake*: The default location is set to `$builddir-install`. The user can set this flag
to install Charm++ in their desired folder.
2. Add _CharmConfig.cmake_ template: This CMake config file is configured by the build system. This file is further installed
with Charm++ along with other install files. Using this config file, any dependant project can use `find_project(Charm)` to
find a valid Charm installation. This file also collects important flags that are set at the time of building Charm++. Using this,
the dependent project can identify if the Charm++ installation can be used for the project. For instance, a Non-SMP project
will require a Non-SMP build of Charm++. Using the flag `CHARM_WITH_SMP`, the dependant project can identify the same.
Various other uses are also possible with this config file.

Future Support Options: Add support for `add_charm_executable` that takes .ci and .cpp files and generates the executable.