### PR TITLE
Add more cmake flags to CharmConfig.cmake

### DIFF
--- a/cmake/templates/CharmConfig.cmake.in
+++ b/cmake/templates/CharmConfig.cmake.in
@@ -25,6 +25,15 @@ set(CHARM_CMK_COMPILER @CMK_COMPILER@)
 # Set Charm build type
 set(CHARM_BUILD_TYPE @CMAKE_BUILD_TYPE@)
 
+# Set Charm Network type
+set(CHARM_WITH_NETWORK @NETWORK@)
+
+# Set Charm TARGET type
+set(CHARM_WITH_TARGET @TARGET@)
+
+# Set Charm ARCH type
+set(CHARM_WITH_ARCH @ARCH@)
+
 # Set SMP option
 set(CHARM_WITH_SMP @SMP@)
 


### PR DESCRIPTION
This PR adds 3 more crucial flags to list of Charm++ related flags in CharmConfig.cmake template. The 3 flags are:
1. CHARM_WITH_NETWORK - Sets up the NETWORK flag from cmake
2. CHARM_WITHT_TARGET - Sets up the TARGET flag from cmake
3. CHARM_WITH_ARCH - Sets up the ARCH flag from cmake