### PR TITLE
Allow Multiple System Libraries in Standalone Build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -283,14 +283,14 @@ endif()
 
 if(${CMK_USE_ZLIB})
   find_package(ZLIB REQUIRED)
-  set(CMK_SYSLIBS "$CMK_SYSLIBS -lz")
+  set(CMK_SYSLIBS "${CMK_SYSLIBS} -lz")
 endif()
 
 if(${CMK_USE_SHMEM})
   if(${CMK_HAS_XPMEM})
-    set(CMK_SYSLIBS "$CMK_SYSLIBS -lxpmem")
+    set(CMK_SYSLIBS "${CMK_SYSLIBS} -lxpmem")
   elseif(NOT CMAKE_SYSTEM_NAME STREQUAL "Darwin")
-    set(CMK_SYSLIBS "$CMK_SYSLIBS -lrt")
+    set(CMK_SYSLIBS "${CMK_SYSLIBS} -lrt")
   endif()
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -285,16 +285,19 @@ endif()
 
 if(${CMK_USE_ZLIB})
   find_package(ZLIB REQUIRED)
-  set(CMK_SYSLIBS "$CMK_SYSLIBS ${CMK_SYSLIBS} -lz")
+  set(CMK_SYSLIBS "${CMK_SYSLIBS} -lz")
 endif()
 
 if(${CMK_USE_SHMEM})
   if(${CMK_HAS_XPMEM})
-    set(CMK_SYSLIBS "$CMK_SYSLIBS ${CMK_SYSLIBS} -lxpmem")
+    set(CMK_SYSLIBS "${CMK_SYSLIBS} -lxpmem")
   elseif(NOT CMAKE_SYSTEM_NAME STREQUAL "Darwin")
-    set(CMK_SYSLIBS "$CMK_SYSLIBS ${CMK_SYSLIBS} -lrt")
+    set(CMK_SYSLIBS "${CMK_SYSLIBS} -lrt")
   endif()
 endif()
+
+# Ensure parity of bash and CMake variables
+set(CMK_SYSLIBS "$CMK_SYSLIBS ${CMK_SYSLIBS}")
 
 set(CMK_USE_LIBJPEG 0)
 find_package(JPEG)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -283,14 +283,14 @@ endif()
 
 if(${CMK_USE_ZLIB})
   find_package(ZLIB REQUIRED)
-  set(CMK_SYSLIBS "${CMK_SYSLIBS} -lz")
+  set(CMK_SYSLIBS "$CMK_SYSLIBS ${CMK_SYSLIBS} -lz")
 endif()
 
 if(${CMK_USE_SHMEM})
   if(${CMK_HAS_XPMEM})
-    set(CMK_SYSLIBS "${CMK_SYSLIBS} -lxpmem")
+    set(CMK_SYSLIBS "$CMK_SYSLIBS ${CMK_SYSLIBS} -lxpmem")
   elseif(NOT CMAKE_SYSTEM_NAME STREQUAL "Darwin")
-    set(CMK_SYSLIBS "${CMK_SYSLIBS} -lrt")
+    set(CMK_SYSLIBS "$CMK_SYSLIBS ${CMK_SYSLIBS} -lrt")
   endif()
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -296,7 +296,8 @@ if(${CMK_USE_SHMEM})
   endif()
 endif()
 
-# Ensure parity of bash and CMake variables
+# $CMK_SYSLIBS also gets updated in the charmc shell config files, therefore we need to include
+# a reference to $CMK_SYSLIBS here.
 set(CMK_SYSLIBS "$CMK_SYSLIBS ${CMK_SYSLIBS}")
 
 set(CMK_USE_LIBJPEG 0)


### PR DESCRIPTION
The current use of CMK_SYSLIBS doesn't allow multiple values in the standalone build. For example, currently ```zlib``` and ```shmem``` cannot be used together. This patch fixes this issue by correcting the way the variable is accessed in CMake.