### PR TITLE
Add functionality to transform a group/nodegroup bcast callback

### DIFF
--- a/doc/charm++/manual.rst
+++ b/doc/charm++/manual.rst
@@ -5680,6 +5680,19 @@ the callback when the contribute operation has finished.
 For examples of how to use the various callback types, please see
 ``tests/charm++/megatest/callback.C``
 
+In addition to the above mechanisms for invoking a callback, it is possible
+that a library may want to accept a callback which broadcasts to a group
+or nodegroup, but then handles the exact logic for the broadcast manually.
+For example, if the data is already distributed across compute elements we
+can avoid performing the actual broadcast, or if we want to send different
+data to each member of the group. To accomplish this, users can invoke
+
+``void CkCallback::transformBcastToLocalElem(int elem = -1);``
+
+This will convert a callback that is broadcast to a group or nodegroup into
+a point-to-point callback for a particular element of the group (the local
+element if no element is passed).
+
 .. _sec:ckcallbackresumethread:
 
 Synchronous Execution with CkCallbackResumeThread

--- a/src/ck-core/ckcallback.h
+++ b/src/ck-core/ckcallback.h
@@ -295,6 +295,18 @@ public:
           d.group.refnum = 0;
 	}
 
+  void transformBcastToLocalElem() {
+    if(type == bcastGroup) {
+      type = sendGroup;
+      d.group.onPE = CkMyPe();
+    } else if(type == bcastNodeGroup) {
+      type = sendNodeGroup;
+      d.group.onPE = CkMyNode();
+    } else {
+      CkAbort("CkCallback type needs to be either bcastGroup or bcastNodeGroup to be transformed!");
+    }
+  }
+
     // Send to nodegroup element
 	CkCallback(int ep,int onPE,const CProxy_NodeGroup &ngp,bool forceInline=false);
 

--- a/src/ck-core/ckcallback.h
+++ b/src/ck-core/ckcallback.h
@@ -295,13 +295,21 @@ public:
           d.group.refnum = 0;
 	}
 
-  void transformBcastToLocalElem() {
+  void transformBcastToLocalElem(int elem = -1) {
     if(type == bcastGroup) {
       type = sendGroup;
-      d.group.onPE = CkMyPe();
+      if (elem == -1) {
+        d.group.onPE = CkMyPe();
+      } else {
+        d.group.onPE = elem;
+      }
     } else if(type == bcastNodeGroup) {
       type = sendNodeGroup;
-      d.group.onPE = CkMyNode();
+      if (elem == -1) {
+        d.group.onPE = CkMyNode();
+      } else {
+        d.group.onPE = elem;
+      }
     } else {
       CkAbort("CkCallback type needs to be either bcastGroup or bcastNodeGroup to be transformed!");
     }


### PR DESCRIPTION
This allows the manipulation of a group or a nodegroup bcast
callback to a local element callback targeted on the local PE for
a group bcast callback and the local node for a nodegroup bcast
callback.