### PR TITLE
Collide: Add a distributed client option to the collision detection library

### DIFF
--- a/examples/collide/collidecharm/Makefile
+++ b/examples/collide/collidecharm/Makefile
@@ -1,15 +1,18 @@
 -include ../../common.mk
 CHARMC=../../../bin/charmc $(OPTS)
 
-OBJS = hello_fn.o hello_cb.o
+OBJS = hello_fn.o hello_cb.o hello_dist.o
 
-all:	cifiles hello_fn hello_cb
+all:	cifiles hello_fn hello_cb hello_dist
 
 hello_fn: hello_fn.o
 	$(CHARMC) -language charm++ -module collidecharm -o hello_fn hello_fn.o
 
 hello_cb: hello_cb.o
 	$(CHARMC) -language charm++ -module collidecharm -o hello_cb hello_cb.o
+
+hello_dist: hello_dist.o
+	$(CHARMC) -language charm++ -module collidecharm -o hello_dist hello_dist.o
 
 cifiles: hello.ci
 	$(CHARMC)  hello.ci
@@ -23,6 +26,10 @@ hello_fn.o: hello.C
 hello_cb.o: hello.C
 	$(CHARMC) -DCOLLIDE_USE_CB=1 -c hello.C -o hello_cb.o
 
+hello_dist.o: hello.C
+	$(CHARMC) -DCOLLIDE_USE_DIST=1 -c hello.C -o hello_dist.o
+
 test: all
 	$(call run, ./hello_fn +p4 10 )
 	$(call run, ./hello_cb +p4 10 )
+	$(call run, ./hello_dist +p4 10 )

--- a/examples/collide/collidecharm/hello.ci
+++ b/examples/collide/collidecharm/hello.ci
@@ -8,6 +8,11 @@ mainmodule hello {
     entry void printCollisionCb(CkReductionMsg *);
   };
 
+  group collResultCollector {
+    entry collResultCollector();
+    entry void myColls(CkDataMsg *msg);
+  }
+
   array [1D] Hello {
     entry Hello(CollideHandle collide);
     entry void DoIt(void);

--- a/src/libs/ck-libs/collide/collidecharm.C
+++ b/src/libs/ck-libs/collide/collidecharm.C
@@ -415,6 +415,8 @@ collideMgr::collideMgr(const CollideGrid3d &gridMap_,
   nContrib=0;
   contribCount=0;
   msgsSent=msgsRecvd=0;
+  totalLocalVoxels = -1;
+  collisionStarted = false;
 }
 
 //Maintain contributor registration count
@@ -504,7 +506,44 @@ void collideMgr::reductionFinished(void)
 {
   CM_STATUS("collideMgr::reductionFinished");
   //Broadcast Collision start:
-  voxelProxy.startCollision(steps,gridMap,client);
+  thisProxy.determineNumVoxels();
+  voxelProxy.initiateCollision(thisProxy);
+}
+
+void collideMgr::checkRegistrationComplete() {
+  if(myVoxels.size() == totalLocalVoxels && collisionStarted == false) {
+    collisionStarted = true;
+    //CmiPrintf("[%d][%d][%d][%d] all voxels registered totalvox=%d\n", CmiMyPe(), CmiMyNode(), CmiMyRank(), thisIndex, totalLocalVoxels);
+    //fflush(stdout);
+    CollisionList colls;
+    for(int i =0 ; i<myVoxels.size(); i++) {
+      myVoxels[i]->startCollision(steps, gridMap, client, colls);
+    }
+    collideVoxel *vox;
+    client.ckLocalBranch()->collisions(vox,steps,colls);
+    collisionStarted = false;
+    myVoxels.clear();
+  }
+}
+
+void collideMgr::determineNumVoxels() {
+  if(totalLocalVoxels == -1 ) {
+    CkArray *array = voxelProxy.ckLocalBranch();
+    totalLocalVoxels = array->getNumLocalElems();
+  }
+  //CmiPrintf("[%d][%d][%d][%d] determineNumVoxels totalLocalVoxels=%d\n", CmiMyPe(), CmiMyNode(), CmiMyRank(), thisIndex, totalLocalVoxels);
+  //fflush(stdout);
+  checkRegistrationComplete();
+}
+
+void collideMgr::registerVoxel(collideVoxel *vox) {
+  if(totalLocalVoxels == -1 ) {
+    CkArrayID arrID = vox->ckGetArrayID();
+    CkArray *array = (CkArray *)CkLocalBranch(arrID);
+    totalLocalVoxels = array->getNumLocalElems();
+  }
+  myVoxels.push_back(vox);
+  checkRegistrationComplete();
 }
 
 
@@ -607,9 +646,15 @@ void collideVoxel::collide(const bbox3d &territory,CollisionList &dest)
 }
 
 
+void collideVoxel::initiateCollision(const CProxy_collideMgr &mgr)
+{
+  mgr.ckLocalBranch()->registerVoxel(this);
+}
+
 void collideVoxel::startCollision(int step,
     const CollideGrid3d &gridMap,
-    const CProxy_collideClient &client)
+    const CProxy_collideClient &client,
+    CollisionList &colls)
 {
   CC_STATUS("startCollision "<<step<<" on "<<msgs.length()<<" messages {");
 
@@ -617,10 +662,7 @@ void collideVoxel::startCollision(int step,
       gridMap.grid2world(1,rSeg1d(thisIndex.y,thisIndex.y+1)),
       gridMap.grid2world(2,rSeg1d(thisIndex.z,thisIndex.z+1))
       );
-  CollisionList colls;
   collide(territory,colls);
-  client.ckLocalBranch()->collisions(this,step,colls);
-
   emptyMessages();
   CC_STATUS("} startCollision");
 }
@@ -652,11 +694,11 @@ void serialCollideClient::collisions(ArrayElement *src,
     int step,CollisionList &colls)
 {
   if(useCb) { // Use user passed callback as reduction target
-    src->contribute(colls.length()*sizeof(Collision),colls.getData(),
+    contribute(colls.length()*sizeof(Collision),colls.getData(),
       CkReduction::concat, clientCb);
   } else { // Use client fn with reduction targetted at serialCollideClient::reductionDone
     CkCallback cb(CkIndex_serialCollideClient::reductionDone(0),0,thisgroup);
-    src->contribute(colls.length()*sizeof(Collision),colls.getData(),
+    contribute(colls.length()*sizeof(Collision),colls.getData(),
       CkReduction::concat,cb);
   }
 }

--- a/src/libs/ck-libs/collide/collidecharm.C
+++ b/src/libs/ck-libs/collide/collidecharm.C
@@ -45,6 +45,12 @@ CkGroupID CollideSerialClient(CkCallback clientCb)
   return cl;
 }
 
+CkGroupID CollideDistributedClient(CkCallback clientCb)
+{
+  CProxy_distributedCollideClient cl = CProxy_distributedCollideClient::ckNew(clientCb);
+  return cl;
+}
+
 /// Create a collider group to contribute objects to.
 ///  Should be called on processor 0.
 CollideHandle CollideCreate(const CollideGrid3d &gridMap,
@@ -667,6 +673,17 @@ void serialCollideClient::reductionDone(CkReductionMsg *msg)
   delete msg;
 }
 
+/********************** distributedCollideClient *****************/
+distributedCollideClient::distributedCollideClient(CkCallback clientCb_) {
+  clientCb = clientCb_;
+  clientCb.transformBcastToLocalElem();
+}
 
+void distributedCollideClient::collisions(ArrayElement *src,
+    int step,CollisionList &colls)
+{
+  // Invoke clientCb
+  clientCb.send(CkDataMsg::buildNew(colls.length()*sizeof(Collision), colls.getData()));
+}
 
 #include "collidecharm.def.h"

--- a/src/libs/ck-libs/collide/collidecharm.C
+++ b/src/libs/ck-libs/collide/collidecharm.C
@@ -439,8 +439,7 @@ void collideMgr::checkRegistrationComplete() {
     for(int i =0 ; i<myVoxels.size(); i++) {
       myVoxels[i]->startCollision(steps, gridMap, client, colls);
     }
-    collideVoxel *vox;
-    client.ckLocalBranch()->collisions(vox,steps,colls);
+    client.ckLocalBranch()->collisions(steps,colls);
     collisionStarted = false;
     myVoxels.clear();
   }
@@ -610,8 +609,7 @@ void serialCollideClient::setClient(CollisionClientFn clientFn_,void *clientPara
   clientParam=clientParam_;
 }
 
-void serialCollideClient::collisions(ArrayElement *src,
-    int step,CollisionList &colls)
+void serialCollideClient::collisions(int step,CollisionList &colls)
 {
   if(useCb) { // Use user passed callback as reduction target
     contribute(colls.length()*sizeof(Collision),colls.getData(),
@@ -641,8 +639,7 @@ distributedCollideClient::distributedCollideClient(CkCallback clientCb_) {
   clientCb.transformBcastToLocalElem();
 }
 
-void distributedCollideClient::collisions(ArrayElement *src,
-    int step,CollisionList &colls)
+void distributedCollideClient::collisions(int step,CollisionList &colls)
 {
   // Invoke clientCb
   clientCb.send(CkDataMsg::buildNew(colls.length()*sizeof(Collision), colls.getData()));

--- a/src/libs/ck-libs/collide/collidecharm.ci
+++ b/src/libs/ck-libs/collide/collidecharm.ci
@@ -9,6 +9,10 @@ module collidecharm {
     entry void reductionDone(CkReductionMsg *m);
   };
 
+  group distributedCollideClient : collideClient {
+    entry distributedCollideClient(CkCallback clientCb_);
+  }
+
   group syncReductionMgr {
     entry syncReductionMgr();
     entry void childProd(int stepCount);

--- a/src/libs/ck-libs/collide/collidecharm.ci
+++ b/src/libs/ck-libs/collide/collidecharm.ci
@@ -11,19 +11,15 @@ module collidecharm {
 
   group distributedCollideClient : collideClient {
     entry distributedCollideClient(CkCallback clientCb_);
-  }
-
-  group syncReductionMgr {
-    entry syncReductionMgr();
-    entry void childProd(int stepCount);
-    entry void childDone(int stepCount);
   };
-  group collideMgr : syncReductionMgr {
+
+  group collideMgr {
     entry collideMgr(CollideGrid3d gridMap,
         CProxy_collideClient client,
         CkArrayID cells);
     entry void voxelMessageRecvd(void);
     entry void determineNumVoxels();
+    entry [reductiontarget] void reductionFinished();
   };
 
   array [3D] collideVoxel {

--- a/src/libs/ck-libs/collide/collidecharm.ci
+++ b/src/libs/ck-libs/collide/collidecharm.ci
@@ -23,14 +23,13 @@ module collidecharm {
         CProxy_collideClient client,
         CkArrayID cells);
     entry void voxelMessageRecvd(void);
+    entry void determineNumVoxels();
   };
 
   array [3D] collideVoxel {
     entry collideVoxel(void);
     entry [createhere] void add(objListMsg *);
     //    entry [createhome] void add(objListMsg *);
-    entry void startCollision(int step,
-        CollideGrid3d gridMap,
-        CProxy_collideClient client);
+    entry void initiateCollision(CProxy_collideMgr mg);
   };
 };

--- a/src/libs/ck-libs/collide/collidecharm.h
+++ b/src/libs/ck-libs/collide/collidecharm.h
@@ -23,8 +23,7 @@
 class collideClient : public Group {
   public:
     virtual ~collideClient();
-    virtual void collisions(ArrayElement *src,
-        int step,CollisionList &colls) =0;
+    virtual void collisions(int step,CollisionList &colls) =0;
 };
 
 /********************** serialCollideClient *****************

--- a/src/libs/ck-libs/collide/collidecharm.h
+++ b/src/libs/ck-libs/collide/collidecharm.h
@@ -43,6 +43,8 @@ CkGroupID CollideSerialClient(CollisionClientFn clientFn,void *clientParam);
 /// complete Collision list.
 CkGroupID CollideSerialClient(CkCallback clientCb);
 
+CkGroupID CollideDistributedClient(CkCallback clientCb);
+
 /****************** Collision Interface ******************/
 typedef CkGroupID CollideHandle;
 

--- a/src/libs/ck-libs/collide/collidecharm_impl.h
+++ b/src/libs/ck-libs/collide/collidecharm_impl.h
@@ -237,6 +237,21 @@ class serialCollideClient : public collideClient {
   virtual void reductionDone(CkReductionMsg *m);
 };
 
+
+/********************** distributedCollideClient *****************
+  Invokes the callback passed on every PE with the collision list
+  */
+class distributedCollideClient : public collideClient {
+  CkCallback clientCb;
+  public:
+  distributedCollideClient(CkCallback clientCb_);
+
+  /// Called by voxel array on each processor:
+  virtual void collisions(ArrayElement *src,
+      int step,CollisionList &colls);
+};
+
+
 #if CMK_TRACE_ENABLED
 // List of COLLIDE functions to trace:
 static const char *funclist[] = {"COLLIDE_Init", "COLLIDE_Boxes",

--- a/src/libs/ck-libs/collide/collidecharm_impl.h
+++ b/src/libs/ck-libs/collide/collidecharm_impl.h
@@ -156,8 +156,14 @@ class collideMgr : public CBase_collideMgr
   CollideGrid3d gridMap; //Shape of 3D voxel grid
   CProxy_collideClient client; //Collision client group
 
+  std::vector<collideVoxel *> myVoxels;
+
   int nContrib;//Number of registered contributors
   int contribCount;//Number of contribute calls given this step
+
+  int totalLocalVoxels;
+
+  bool collisionStarted;
 
   CollisionAggregator aggregator;
   int msgsSent;//Messages sent out to voxels
@@ -187,6 +193,11 @@ class collideMgr : public CBase_collideMgr
 
   //collideVoxels send a return receipt here
   void voxelMessageRecvd(void);
+
+  void registerVoxel(collideVoxel *vox);
+
+  void checkRegistrationComplete();
+  void determineNumVoxels(void);
 };
 
 /********************** collideVoxel ********************
@@ -208,9 +219,12 @@ class collideVoxel : public CBase_collideVoxel
   void pup(PUP::er &p);
 
   void add(objListMsg *msg);
+  void initiateCollision(const CProxy_collideMgr &mgr);
+
   void startCollision(int step,
       const CollideGrid3d &gridMap,
-      const CProxy_collideClient &client);
+      const CProxy_collideClient &client,
+      CollisionList &colls);
 };
 
 

--- a/src/libs/ck-libs/collide/collidecharm_impl.h
+++ b/src/libs/ck-libs/collide/collidecharm_impl.h
@@ -199,8 +199,7 @@ class serialCollideClient : public collideClient {
   void setClient(CollisionClientFn clientFn,void *clientParam);
 
   /// Called by voxel array on each processor:
-  virtual void collisions(ArrayElement *src,
-      int step,CollisionList &colls);
+  virtual void collisions(int step,CollisionList &colls);
 
   /// Called after the reduction is complete:
   virtual void reductionDone(CkReductionMsg *m);
@@ -216,8 +215,7 @@ class distributedCollideClient : public collideClient {
   distributedCollideClient(CkCallback clientCb_);
 
   /// Called by voxel array on each processor:
-  virtual void collisions(ArrayElement *src,
-      int step,CollisionList &colls);
+  virtual void collisions(int step,CollisionList &colls);
 };
 
 

--- a/src/libs/ck-libs/collide/threadCollide.C
+++ b/src/libs/ck-libs/collide/threadCollide.C
@@ -79,7 +79,7 @@ class threadCollideMgr : public CBase_threadCollideMgr
 
   /// collideClient interface (called by voxels)
   /// Splits up collisions by destination PE
-  void collisions(ArrayElement *src,int step,CollisionList &colls);
+  void collisions(int step,CollisionList &colls);
 
   /// All voxels have now reported their collisions:
   ///  Send off the accumulated collisions to each destination PE
@@ -157,8 +157,7 @@ class threadCollide : public TCharmClient1D {
 
 /// collideClient interface (called by voxels)
 /// Splits up collisions by destination PE
-void threadCollideMgr::collisions(ArrayElement *src,int step,
-    CollisionList &colls) {
+void threadCollideMgr::collisions(int step, CollisionList &colls) {
   // Do a fake reduction, so we'll know when all voxels have reported:
   contribute(CkCallback(CkReductionTarget(threadCollideMgr, sendRemote),thisProxy));
 

--- a/src/libs/ck-libs/collide/threadCollide.ci
+++ b/src/libs/ck-libs/collide/threadCollide.ci
@@ -8,7 +8,7 @@ module collide {
 
   group threadCollideMgr : collideClient {
     entry threadCollideMgr(void);
-    entry void sendRemote(CkReductionMsg *m);
+    entry [reductiontarget] void sendRemote();
     entry void remoteCollisions(threadCollisions *m);
   };
   array[1D] threadCollide {


### PR DESCRIPTION
The current client for the collision detection library combines all collisions to a single list on PE 0 before returning the results to the calling program. This works fine for use cases with few collisions. For use cases with many collisions, a distributed scheme avoids bottlenecks.