### PR TITLE
MPI layer: assert that Charm does not require msg ordering

### DIFF
--- a/src/arch/mpi/machine.C
+++ b/src/arch/mpi/machine.C
@@ -1423,9 +1423,16 @@ void LrtsInit(int *argc, char ***argv, int *numNodes, int *myNodeID) {
 
     largc = *argc;
     largv = *argv;
+
+    /* Create our communicator, with info hints (such as us not requiring
+     * message ordering) to enable possible MPI runtime optimizations. */
+    MPI_Info hints;
+    MPI_Info_create(&hints);
+    MPI_Info_set(hints, "mpi_assert_allow_overtaking", "true");
     if(!CharmLibInterOperate || userDrivenMode) {
-      MPI_Comm_dup(MPI_COMM_WORLD, &charmComm);
+      MPI_Comm_dup_with_info(MPI_COMM_WORLD, hints, &charmComm);
     }
+
     MPI_Comm_size(charmComm, numNodes);
     MPI_Comm_rank(charmComm, myNodeID);
 

--- a/src/arch/mpi/machine.C
+++ b/src/arch/mpi/machine.C
@@ -1424,12 +1424,12 @@ void LrtsInit(int *argc, char ***argv, int *numNodes, int *myNodeID) {
     largc = *argc;
     largv = *argv;
 
-    /* Create our communicator, with info hints (such as us not requiring
-     * message ordering) to enable possible MPI runtime optimizations. */
-    MPI_Info hints;
-    MPI_Info_create(&hints);
-    MPI_Info_set(hints, "mpi_assert_allow_overtaking", "true");
     if(!CharmLibInterOperate || userDrivenMode) {
+      /* Create our communicator, with info hints (such as us not requiring
+       * message ordering) to enable possible MPI runtime optimizations. */
+      MPI_Info hints;
+      MPI_Info_create(&hints);
+      MPI_Info_set(hints, "mpi_assert_allow_overtaking", "true");
       MPI_Comm_dup_with_info(MPI_COMM_WORLD, hints, &charmComm);
     }
 


### PR DESCRIPTION
The MPI-4.0 standard specifies the "mpi_assert_allow_overtaking" info
which users can pass to a communicator creation call in order to tell the
MPI implementation that they don't need msg ordering.