### PR TITLE
Fix `unique_ptr` of `PUP::able` types

### DIFF
--- a/src/util/pup_stl.h
+++ b/src/util/pup_stl.h
@@ -471,12 +471,12 @@ using Requires = typename requires_impl<
 
   template <typename T, Requires<std::is_base_of<PUP::able, T>::value> = nullptr>
   inline void pup(PUP::er& p, std::unique_ptr<T>& t) {
-    T* t1 = nullptr;
+    PUP::able* t1 = nullptr;
     if (p.isUnpacking()) {
       p | t1;
-      t = std::unique_ptr<T>(t1);
+      t.reset((T*)t1);
     } else {
-      t1 = t.get();
+      t1 = (PUP::able*)t.get();
       p | t1;
     }
   }


### PR DESCRIPTION
The `operator|` is undefined for PUP::able derived types; need to cast to `PUP::able*` so it works. 