### PR TITLE
Add options to `CkCallback::send` and fix demand-creation

### DIFF
--- a/doc/charm++/manual.rst
+++ b/doc/charm++/manual.rst
@@ -5666,12 +5666,14 @@ then invokes it to return a result may have the following interface:
      cb.send(msg);
    }
 
-A CkCallback will accept any message type, or even NULL. The message is
+A *CkCallback* will accept any message type, even *nullptr*. The message is
 immediately sent to the user’s client function or entry point. A library
 which returns its result through a callback should have a clearly
 documented return message type. The type of the message returned by the
 library must be the same as the type accepted by the entry method
-specified in the callback.
+specified in the callback. Note that message flag(s) may be passed as an
+optional argument to “send;” for example, :code:`send(_, CK_MSG_EXPEDITED)`
+will send a message with expediency.
 
 As an alternative to “send”, the callback can be used in a *contribute*
 collective operation. This will internally invoke the “send” method on

--- a/doc/charm++/manual.rst
+++ b/doc/charm++/manual.rst
@@ -2029,7 +2029,7 @@ the runtime will not “commit” to this branch until the second arrives.
 If another dependency fully matches, the partial match will be ignored
 and can be used to trigger another ``when`` later in the execution.
 
-.. code-block:: charmci
+.. code-block:: text
 
    case {
      when a() { }

--- a/doc/charm++/manual.rst
+++ b/doc/charm++/manual.rst
@@ -2029,7 +2029,7 @@ the runtime will not “commit” to this branch until the second arrives.
 If another dependency fully matches, the partial match will be ignored
 and can be used to trigger another ``when`` later in the execution.
 
-.. code-block:: c++
+.. code-block:: charmci
 
    case {
      when a() { }

--- a/src/ck-core/charm.h
+++ b/src/ck-core/charm.h
@@ -192,9 +192,9 @@ typedef enum{
 // What to do if an entry method is invoked on
 // an array element that does not (yet) exist:
 typedef enum{
-	CkArray_IfNotThere_buffer = 0,			// Wait for it to be created
-	CkArray_IfNotThere_createhere = 1,	// Make it on sending Pe
-	CkArray_IfNotThere_createhome = 2		// Make it on (a) home Pe
+	CkArray_IfNotThere_buffer = 0,     // Wait for it to be created
+	CkArray_IfNotThere_createhere = 1, // Make it on sending Pe
+	CkArray_IfNotThere_createhome = 2  // Make it on (a) home Pe
 } CkArray_IfNotThere;
 
 /** A "call function" to invoke a method on an object. See EntryInfo */

--- a/src/ck-core/charm.h
+++ b/src/ck-core/charm.h
@@ -189,6 +189,15 @@ typedef enum{
 	TypeArray
 } ChareType;
 
+// What to do if an entry method is invoked on
+// an array element that does not (yet) exist:
+typedef enum : uint8_t
+{
+  CkArray_IfNotThere_buffer = 0,      // Wait for it to be created
+  CkArray_IfNotThere_createhere = 1,  // Make it on sending Pe
+  CkArray_IfNotThere_createhome = 2   // Make it on (a) home Pe
+} CkArray_IfNotThere;
+
 /** A "call function" to invoke a method on an object. See EntryInfo */
 typedef void  (*CkCallFnPtr) (void *msg, void *obj);
 /** Register this entry point, with this call function and flags.
@@ -215,6 +224,8 @@ extern void CkRegisterMigCtor(int chareIndex, int ctorEpIndex);
 extern void CkRegisterGroupIrr(int chareIndex,int isIrr);
 /** Register the chare baseIdx as a base class of the chare derivedIdx. */
 extern void CkRegisterBase(int derivedIdx, int baseIdx);
+/** Sets the ifNotThere policy of an EP **/
+extern void CkRegisterIfNotThere(int epIdx, CkArray_IfNotThere policy);
 #if CMK_CHARM4PY
 extern void CkRegisterMainChareExt(const char *s, int numEntryMethods, int *chareIdx, int *startEpIdx);
 extern void CkRegisterGroupExt(const char *s, int numEntryMethods, int *chareIdx, int *startEpIdx);

--- a/src/ck-core/charm.h
+++ b/src/ck-core/charm.h
@@ -7,7 +7,6 @@
 
 #include "converse.h"
 #include <sys/types.h> /* for size_t */
-#include <stdint.h> /* for uint8_t */
 
 #ifdef __cplusplus
 #include "conv-rdma.h"
@@ -192,11 +191,10 @@ typedef enum{
 
 // What to do if an entry method is invoked on
 // an array element that does not (yet) exist:
-typedef enum : uint8_t
-{
-  CkArray_IfNotThere_buffer = 0,      // Wait for it to be created
-  CkArray_IfNotThere_createhere = 1,  // Make it on sending Pe
-  CkArray_IfNotThere_createhome = 2   // Make it on (a) home Pe
+typedef enum{
+	CkArray_IfNotThere_buffer = 0,			// Wait for it to be created
+	CkArray_IfNotThere_createhere = 1,	// Make it on sending Pe
+	CkArray_IfNotThere_createhome = 2		// Make it on (a) home Pe
 } CkArray_IfNotThere;
 
 /** A "call function" to invoke a method on an object. See EntryInfo */

--- a/src/ck-core/charm.h
+++ b/src/ck-core/charm.h
@@ -7,6 +7,7 @@
 
 #include "converse.h"
 #include <sys/types.h> /* for size_t */
+#include <stdint.h> /* for uint8_t */
 
 #ifdef __cplusplus
 #include "conv-rdma.h"

--- a/src/ck-core/ckarray.C
+++ b/src/ck-core/ckarray.C
@@ -1234,12 +1234,12 @@ void CProxySection_ArrayBase::ckSend(CkArrayMessage* msg, int ep, int opts)
   }
 }
 
-void CkSetMsgArrayIfNotThere(void* msg, CkArray_IfNotThere* opts)
+void CkSetMsgArrayIfNotThere(void* msg, CkArray_IfNotThere policy)
 {
   envelope* env = UsrToEnv((void*)msg);
   env->setMsgtype(ForArrayEltMsg);
   CkArrayMessage* m = (CkArrayMessage*)msg;
-  m->array_setIfNotThere(opts ? *opts : CkArray_IfNotThere_buffer);
+  m->array_setIfNotThere(policy);
 }
 
 void CkSendMsgArray(int entryIndex, void* msg, CkArrayID aID, const CkArrayIndex& idx,

--- a/src/ck-core/ckarray.C
+++ b/src/ck-core/ckarray.C
@@ -1234,12 +1234,12 @@ void CProxySection_ArrayBase::ckSend(CkArrayMessage* msg, int ep, int opts)
   }
 }
 
-void CkSetMsgArrayIfNotThere(void* msg)
+void CkSetMsgArrayIfNotThere(void* msg, CkArray_IfNotThere* opts)
 {
   envelope* env = UsrToEnv((void*)msg);
   env->setMsgtype(ForArrayEltMsg);
   CkArrayMessage* m = (CkArrayMessage*)msg;
-  m->array_setIfNotThere(CkArray_IfNotThere_buffer);
+  m->array_setIfNotThere(opts ? *opts : CkArray_IfNotThere_buffer);
 }
 
 void CkSendMsgArray(int entryIndex, void* msg, CkArrayID aID, const CkArrayIndex& idx,

--- a/src/ck-core/ckarray.h
+++ b/src/ck-core/ckarray.h
@@ -322,7 +322,7 @@ public:
 };
 
 // Simple C-like API:
-void CkSetMsgArrayIfNotThere(void* msg);
+void CkSetMsgArrayIfNotThere(void* msg, CkArray_IfNotThere* opts = nullptr);
 void CkSendMsgArray(int entryIndex, void* msg, CkArrayID aID, const CkArrayIndex& idx,
                     int opts = 0);
 void CkSendMsgArrayInline(int entryIndex, void* msg, CkArrayID aID,

--- a/src/ck-core/ckarray.h
+++ b/src/ck-core/ckarray.h
@@ -322,7 +322,7 @@ public:
 };
 
 // Simple C-like API:
-void CkSetMsgArrayIfNotThere(void* msg, CkArray_IfNotThere* opts = nullptr);
+void CkSetMsgArrayIfNotThere(void* msg, CkArray_IfNotThere policy = CkArray_IfNotThere_buffer);
 void CkSendMsgArray(int entryIndex, void* msg, CkArrayID aID, const CkArrayIndex& idx,
                     int opts = 0);
 void CkSendMsgArrayInline(int entryIndex, void* msg, CkArrayID aID,

--- a/src/ck-core/ckcallback.C
+++ b/src/ck-core/ckcallback.C
@@ -326,7 +326,7 @@ void CkCallback::send(void *msg,int opts) const
   }
 #endif
 
-  // lookup an entry method's flags in table
+	// lookup an entry method's flags in table
 	auto ep = this->epIndex();
 	auto* entry = (ep >= 0) ? _entryTable[ep] : nullptr;
 	auto policy = CkArray_IfNotThere_buffer;
@@ -402,13 +402,13 @@ void CkCallback::send(void *msg,int opts) const
 	case sendArray: //Send message to an array element
 		if (!msg) msg=CkAllocSysMsg();
                 if (d.array.hasRefnum) CkSetRefNum(msg, d.array.refnum);
-		CkSetMsgArrayIfNotThere(msg, &policy);
+		CkSetMsgArrayIfNotThere(msg, policy);
 		CkSendMsgArray(d.array.ep, msg, d.array.id, d.array.idx.asChild(), opts);
 		break;
 	case isendArray: //inline send-to-array element
 		if (!msg) msg=CkAllocSysMsg();
                 if (d.array.hasRefnum) CkSetRefNum(msg, d.array.refnum);
-		CkSetMsgArrayIfNotThere(msg, &policy);
+		CkSetMsgArrayIfNotThere(msg, policy);
 		CkSendMsgArrayInline(d.array.ep, msg, d.array.id, d.array.idx.asChild(), opts);
 		break;
 	case bcastGroup:
@@ -424,7 +424,7 @@ void CkCallback::send(void *msg,int opts) const
 	case bcastArray:
 		if (!msg) msg=CkAllocSysMsg();
                 if (d.array.hasRefnum) CkSetRefNum(msg, d.array.refnum);
-		CkSetMsgArrayIfNotThere(msg, &policy);
+		CkSetMsgArrayIfNotThere(msg, policy);
 		CkBroadcastMsgArray(d.array.ep, msg, d.array.id, opts);
 		break;
 #if !CMK_CHARM4PY

--- a/src/ck-core/ckcallback.h
+++ b/src/ck-core/ckcallback.h
@@ -535,26 +535,27 @@ public:
                 }
         }
 
-int epIndex(void) const {
-  switch (type) {
-    case isendChare:
-    case sendChare:
-      return d.chare.ep;
-    case isendGroup:
-    case sendGroup:
-    case isendNodeGroup:
-    case sendNodeGroup:
-    case bcastNodeGroup:
-    case bcastGroup:
-      return d.group.ep;
-    case isendArray:
-    case sendArray:
-    case bcastArray:
-      return d.array.ep;
-    default:
-      return -1;
-  }
-}
+    // returns target EP's index (if one exists)
+    int epIndex(void) const {
+        switch (type) {
+            case isendChare:
+            case sendChare:
+                return d.chare.ep;
+            case isendGroup:
+            case sendGroup:
+            case isendNodeGroup:
+            case sendNodeGroup:
+            case bcastNodeGroup:
+            case bcastGroup:
+                return d.group.ep;
+            case isendArray:
+            case sendArray:
+            case bcastArray:
+                return d.array.ep;
+            default:
+                return -1;
+        }
+    }
 };
 //PUPbytes(CkCallback) //FIXME: write a real pup routine
 

--- a/src/ck-core/ckcallback.h
+++ b/src/ck-core/ckcallback.h
@@ -486,7 +486,7 @@ public:
  * It takes the given message and handles it appropriately.
  * After the send(), this callback is finished and cannot be reused.
  */
-	void send(void *msg=NULL) const;
+	void send(void *msg=NULL,int opts=0) const;
 	
 /**
  * Send this data, formatted as a CkDataMsg, back to the caller.
@@ -534,6 +534,27 @@ public:
                   CkAbort("Tried to set a refnum on a callback not directed at an entry method");
                 }
         }
+
+int epIndex(void) const {
+  switch (type) {
+    case isendChare:
+    case sendChare:
+      return d.chare.ep;
+    case isendGroup:
+    case sendGroup:
+    case isendNodeGroup:
+    case sendNodeGroup:
+    case bcastNodeGroup:
+    case bcastGroup:
+      return d.group.ep;
+    case isendArray:
+    case sendArray:
+    case bcastArray:
+      return d.array.ep;
+    default:
+      return -1;
+  }
+}
 };
 //PUPbytes(CkCallback) //FIXME: write a real pup routine
 

--- a/src/ck-core/cklocation.h
+++ b/src/ck-core/cklocation.h
@@ -54,14 +54,6 @@ public:
 // Forward declarations
 class CkArray;
 class ArrayElement;
-// What to do if an entry method is invoked on
-// an array element that does not (yet) exist:
-typedef enum : uint8_t
-{
-  CkArray_IfNotThere_buffer = 0,      // Wait for it to be created
-  CkArray_IfNotThere_createhere = 1,  // Make it on sending Pe
-  CkArray_IfNotThere_createhome = 2   // Make it on (a) home Pe
-} CkArray_IfNotThere;
 
 /// How to do a message delivery:
 typedef enum : uint8_t

--- a/src/ck-core/register.C
+++ b/src/ck-core/register.C
@@ -201,7 +201,7 @@ void CkRegisterMainChareExt(const char *s, int numEntryMethods, int *chareIdx, i
 #endif
 
 void CkRegisterIfNotThere(int epIdx, CkArray_IfNotThere policy) {
-  if ((epIdx >= -1) && (!__registerDone || CMK_CHARM4PY)) {
+  if ((epIdx >= 0) && (!__registerDone || CMK_CHARM4PY)) {
     _entryTable[epIdx]->ifNotThere = policy;
   }
 }

--- a/src/ck-core/register.C
+++ b/src/ck-core/register.C
@@ -200,6 +200,12 @@ void CkRegisterMainChareExt(const char *s, int numEntryMethods, int *chareIdx, i
 }
 #endif
 
+void CkRegisterIfNotThere(int epIdx, CkArray_IfNotThere policy) {
+  if ((epIdx >= -1) && (!__registerDone || CMK_CHARM4PY)) {
+    _entryTable[epIdx]->ifNotThere = policy;
+  }
+}
+
 void CkRegisterBase(int derivedIdx, int baseIdx)
 {
   if (baseIdx!=-1)

--- a/src/ck-core/register.h
+++ b/src/ck-core/register.h
@@ -100,6 +100,9 @@ class EntryInfo {
     /// Human-readable name of entry method, including parameters.
     const char *name;
 
+    /// Policy for demand-creation entry methods
+    CkArray_IfNotThere ifNotThere;
+
     EntryInfo(const char *n, CkCallFnPtr c, int m, int ci, bool ownsN=false) :
       call(c), msgIdx(m), chareIdx(ci),
       marshallUnpack(0)
@@ -107,7 +110,7 @@ class EntryInfo {
       ,messagePup(0)
 #endif
       ,traceEnabled(true), noKeep(false), isImmediate(false), isInline(false), inCharm(false), appWork(false),
-      ownsName(ownsN), name(n)
+      ownsName(ownsN), name(n), ifNotThere(CkArray_IfNotThere_buffer)
     {
       if (ownsName) initName(n);
 #if CMK_CHARMDEBUG

--- a/src/xlat-i/xi-Entry.C
+++ b/src/xlat-i/xi-Entry.C
@@ -2465,11 +2465,11 @@ void Entry::genReg(XStr& str) {
   else if (isCreateHome()) ifNot = "CkArray_IfNotThere_createhome";
 
   if (ifNot) {
-    auto regIfNot = [&](XStr&& idx) {
-      str << "  " << "CkRegisterIfNotThere(" << idx << ", " << ifNot << ");\n";
-    };
-    regIfNot(epIdx(0));
-    if (isReductionTarget()) regIfNot(epIdx(0, true));
+    str << "  " << "CkRegisterIfNotThere(" << epIdx(0) << ", " << ifNot << ");\n";
+    if (isReductionTarget()) {
+      str << "  " << "CkRegisterIfNotThere(" << epIdx(0, true)
+          << ", " << ifNot << ");\n";
+    }
   }
 
   if (isConstructor()) {

--- a/src/xlat-i/xi-Entry.C
+++ b/src/xlat-i/xi-Entry.C
@@ -2459,6 +2459,19 @@ void Entry::genReg(XStr& str) {
   str << "  // REG: " << *this;
   str << "  " << epIdx(0) << ";\n";
   if (isReductionTarget()) str << "  " << epIdx(0, true) << ";\n";
+
+  const char* ifNot = nullptr;
+  if (isCreateHere()) ifNot = "CkArray_IfNotThere_createhere";
+  else if (isCreateHome()) ifNot = "CkArray_IfNotThere_createhome";
+
+  if (ifNot) {
+    auto regIfNot = [&](XStr&& idx) {
+      str << "  " << "CkRegisterIfNotThere(" << idx << ", " << ifNot << ");\n";
+    };
+    regIfNot(epIdx(0));
+    if (isReductionTarget()) regIfNot(epIdx(0, true));
+  }
+
   if (isConstructor()) {
     if (container->isMainChare() && !isMigrationConstructor())
       str << "  CkRegisterMainChare(__idx, " << epIdx(0) << ");\n";


### PR DESCRIPTION
This PR adds more correctness and customization options for calls to `CkCallback::send`.

Currently, sends to array elements via `CkCallback::send` always use a `CkArray_IfNotThere_buffer` policy. Subsequently, sends to `[createhere]` or `[createhome]` EPs do not trigger demand-creation. This PR adds an `ifNotThere` policy field to `EntryInfo` and sets it using Charmxi; `CkCallback::send` now looks up this information and sets the policy accordingly.

A simple example that would fail is:
https://gist.github.com/jszaday/573276ada1b17258caab568c1aea7463