### PR TITLE
Add support for directing node-branch sends to PEs

### DIFF
--- a/src/ck-core/charm++.h
+++ b/src/ck-core/charm++.h
@@ -67,6 +67,7 @@ class CkMarshalledMessage {
  * It is only used with parameter marshalling.
  */
 class CkEntryOptions : public CkNoncopyable {
+	int destPe; // for directing node-group sends
 	int queueingtype; //CK_QUEUEING type
 	int prioBits; //Number of bits of priority to use
 	typedef unsigned int prio_t; //Datatype used to represent priorities
@@ -74,8 +75,9 @@ class CkEntryOptions : public CkNoncopyable {
 	prio_t prioStore; //For short priorities, stores the priority value
 	std::vector<CkGroupID> depGroupIDs;  // group dependencies
 public:
-	CkEntryOptions(void): queueingtype(CK_QUEUEING_FIFO), prioBits(0), 
-                              prioPtr(NULL), prioStore(0) {
+	CkEntryOptions(void)
+	: destPe(CK_PE_ANY), queueingtype(CK_QUEUEING_FIFO),
+	  prioBits(0), prioPtr(NULL), prioStore(0) {
 	}
 
 	~CkEntryOptions() {
@@ -147,6 +149,9 @@ public:
 	inline int getGroupDepSize() const { return sizeof(CkGroupID)*(depGroupIDs.size()); }
 	inline int getGroupDepNum() const { return depGroupIDs.size(); }
 	inline const CkGroupID *getGroupDepPtr() const { return &(depGroupIDs[0]); }
+
+	inline int getNodeGroupPe() const { return this->destPe; }
+	inline void setNodeGroupPe(int pe) { this->destPe = pe; }
 };
 
 #include "ckmarshall.h"

--- a/src/ck-core/charm.h
+++ b/src/ck-core/charm.h
@@ -395,6 +395,7 @@ extern void CkSendMsgBranchMulti(int eIdx, void *msg, CkGroupID gID, int npes, c
 extern void CkSendMsgBranchGroup(int eIdx,void *msg,CkGroupID gID,CmiGroup grp, int opts CK_MSGOPTIONAL);
 extern void CkSendMsgNodeBranch(int eIdx, void *msg, int destNode, CkGroupID gID, int opts CK_MSGOPTIONAL);
 extern void CkSendMsgNodeBranchInline(int eIdx, void *msg, int destNode, CkGroupID gID, int opts CK_MSGOPTIONAL);
+extern void CkSendMsgNodeBranchPe(int eIdx, void *msg, int destPe, CkGroupID gID, int opts CK_MSGOPTIONAL);
 extern void CkSendMsgNodeBranchMulti(int eIdx, void *msg, CkGroupID gID, int npes, const int *nodes, int opts CK_MSGOPTIONAL);
 extern void CkBroadcastWithinNode(int eIdx, void *msg, CkGroupID gID, int opts CK_MSGOPTIONAL);
 extern void CkBroadcastMsgBranch(int eIdx, void *msg, CkGroupID gID, int opts CK_MSGOPTIONAL);

--- a/src/ck-core/ck.C
+++ b/src/ck-core/ck.C
@@ -2087,6 +2087,24 @@ void CkSendMsgNodeBranch(int eIdx, void *msg, int node, CkGroupID gID, int opts)
   CkpvAccess(_coreState)->create();
 }
 
+void CkSendMsgNodeBranchPe(int eIdx, void *msg, int pe, CkGroupID gID, int opts) {
+  // TODO ( expand support for these options at some point... )
+  CkAssertMsg(!((opts & CK_MSG_INLINE) || (opts & CK_MSG_IMMEDIATE)),
+              "pe-level inline and immediate sends to node branchs unsupported");
+  int numPes = (pe == CK_PE_ALL) ? CkNumPes() : 1;
+  envelope *env = _prepareMsgBranch(eIdx, msg, gID, ForNodeBocMsg);
+  _TRACE_ONLY(numPes);
+  _TRACE_CREATION_N(env, numPes);
+  if (opts & CK_MSG_SKIP_OR_IMM) {
+    _noCldEnqueue(pe, env);
+  } else {
+    _skipCldEnqueue(pe, env, _infoIdx);
+  }
+  _TRACE_CREATION_DONE(numPes);
+  _STATS_RECORD_SEND_NODE_BRANCH_1();
+  CkpvAccess(_coreState)->create();
+}
+
 void CkSendMsgNodeBranchMultiImmediate(int eIdx,void *msg,CkGroupID gID,int npes,const int *nodes)
 {
 #if CMK_IMMEDIATE_MSG && ! CMK_SMP

--- a/src/xlat-i/xi-Entry.C
+++ b/src/xlat-i/xi-Entry.C
@@ -934,6 +934,12 @@ void Entry::genGroupDefs(XStr& str) {
           str << "     ckDelegatedTo()->" << node << "GroupSend(ckDelegatedPtr(),"
               << parampg << ");\n";
         }
+        if (container->isNodeGroup() && !param->isMessage()) {
+          str << "  } else if (impl_e_opts && (impl_e_opts->getNodeGroupPe() != CK_PE_ANY)) {\n";
+          str << "    int impl_pe = impl_e_opts->getNodeGroupPe();\n";
+          str << "    CkAssert(CkNodeOf(impl_pe) == this->ckGetGroupPe());\n";
+          str << "    CkSendMsgNodeBranchPe(" << epIdx() << ",impl_msg,impl_pe,ckGetGroupID()" << opts << ");\n";
+        }
         str << "  } else {\n";
         str << "    CkSendMsg" << node << "Branch"
             << "(" << parampg << opts << ");\n";


### PR DESCRIPTION
This PE adds support for directing sends to particular PEs for node-groups via `CkEntryOptions::setNodeGroupPe` and/or `CkSendMsgNodeBranchPe`. Example use-case shown here:
[https://gist.github.com/jszaday/486ee195180c42eed2a6f7b14462b123](https://gist.github.com/jszaday/486ee195180c42eed2a6f7b14462b123)

TODOs:

- [ ] Decide on names for all added methods.
- [ ] Decide whether we need support for inline/immediate sends via this new procedure? 
- [ ] Update documentation.