### PR TITLE
Mitigate C++11 issues in charmxi

### DIFF
--- a/src/scripts/configure.ac
+++ b/src/scripts/configure.ac
@@ -768,8 +768,8 @@ for i in "-std=c++11" "--c++11" "-h std=c++11" "-hstd=c++11"; do
     test_cxx "whether C++ compiler supports C++11 with '$i'" "yes" "no" "$i"
     if test $strictpass -eq 1
     then
-      add_flag "$(echo OPTS_CXX=\"\$OPTS_CXX $i\")" "Enable C++11 support"
-      OPTS_CXX="$OPTS_CXX $i"
+      add_flag "$(echo CMK_CXX_FLAGS=\"\$CMK_CXX_FLAGS $i\")" "Enable C++11 support"
+      CMK_CXX_FLAGS="$CMK_CXX_FLAGS $i"
       got_cpp11="true"
       break
     fi

--- a/src/xlat-i/xi-Entry.C
+++ b/src/xlat-i/xi-Entry.C
@@ -2460,7 +2460,7 @@ void Entry::genReg(XStr& str) {
   str << "  " << epIdx(0) << ";\n";
   if (isReductionTarget()) str << "  " << epIdx(0, true) << ";\n";
 
-  const char* ifNot = nullptr;
+  const char* ifNot = NULL;
   if (isCreateHere()) ifNot = "CkArray_IfNotThere_createhere";
   else if (isCreateHome()) ifNot = "CkArray_IfNotThere_createhome";
 


### PR DESCRIPTION
4fd8c4b's use of `nullptr` in charmxi code broke autobuild because the older compilers used don't support C++11 natively without a flag. This PR fixes that for `buildold` by ensuring that `configure` adds the right flag for the native compiler. CMake is a stickier wicket in that it doesn't really have any awareness of the native compiler; I've spent a couple hours trying to find a way around it, but I wasn't able to come up with anything that's not very flaky, so I've just reverted the use of `nullptr` for now to get autobuild working in the meantime (Note that CI uses newer compilers that don't suffer from this, which is how this slipped in in the first place. I've verified that this PR fixes the issue on a lab machine.).

Do you have any ideas on how to address this, @matthiasdiener? I think the ultimate solution may be to make a second CMake project specifically for configuring the native compiler environment since it may be different from the main compiler and CMake doesn't seem to support configuring multiple compilers in the same file/project. 