### PR TITLE
Add epochs to array broadcasts

### DIFF
--- a/src/ck-core/ckarray.C
+++ b/src/ck-core/ckarray.C
@@ -1288,17 +1288,14 @@ CkArrayReducer::~CkArrayReducer() {}
 
 CkArrayBroadcaster::CkArrayBroadcaster(bool stableLocations_, bool broadcastViaScheduler_)
     : CkArrayListener(1),  // Each array element carries a broadcast number
-      oldBcastNo(0),
       stableLocations(stableLocations_),
       broadcastViaScheduler(broadcastViaScheduler_)
 {
-  setBcastNo(0);
 }
 
 CkArrayBroadcaster::CkArrayBroadcaster(CkMigrateMessage* m)
-    : CkArrayListener(m), oldBcastNo(-1), broadcastViaScheduler(false)
+    : CkArrayListener(m), broadcastViaScheduler(false)
 {
-  setBcastNo(-1);
 }
 
 void CkArrayBroadcaster::pup(PUP::er& p)
@@ -1306,55 +1303,96 @@ void CkArrayBroadcaster::pup(PUP::er& p)
   CkArrayListener::pup(p);
   /* Assumption: no migrants during checkpoint, so no need to
      save old broadcasts. */
-  int bcastNum = getBcastNo();
-  p | bcastNum;
   p | stableLocations;
   p | broadcastViaScheduler;
-  if (p.isUnpacking())
-  {
-    setBcastNo(bcastNum);
-    oldBcastNo = bcastNum; /* because we threw away oldBcasts */
-  }
+  p | bcastSendEpoch;
+  p | storedBcasts;
 }
 
-CkArrayBroadcaster::~CkArrayBroadcaster()
+// Processes the incoming broadcast message and buffers it for future delivery
+void CkArrayBroadcaster::ingestIncoming(CkArrayMessage* msg)
 {
-  CkArrayMessage* msg;
-  while (NULL != (msg = oldBcasts.deq())) delete msg;
-}
-
-int CkArrayBroadcaster::incrementBcastNo() { return 1 + incBcastNo(); }
-
-void CkArrayBroadcaster::incoming(CkArrayMessage* msg)
-{
-  if ((CMI_ZC_MSGTYPE(UsrToEnv(msg)) == CMK_ZC_BCAST_SEND_MSG ||
-       CMI_ZC_MSGTYPE(UsrToEnv(msg)) == CMK_ZC_BCAST_RECV_MSG) &&
-      getRootNode(UsrToEnv(msg)) != 0 && CkMyPe() == 0)
-  {
-    // Do not increment as it has already been incremented
-  }
-  else
-  {
-    incBcastNo();
-  }
-
-  DEBB((AA "Received broadcast %d\n" AB, getBcastNo()));
+  const int bcastEpoch = UsrToEnv(msg)->getGroupEpoch();
+  DEBB((AA "Received broadcast %d\n" AB, bcastEpoch));
 
   if (stableLocations)
     return;
 
   CmiMemoryMarkBlock(((char*)UsrToEnv(msg)) - sizeof(CmiChunkHeader));
-  oldBcasts.enq((CkArrayMessage*)msg);  // Stash the message for later use
+
+  // If this is a ZC all done msg, then the message should already be in storedMsgs, so
+  // check and return
+  if (CMI_ZC_MSGTYPE(UsrToEnv(msg)) == CMK_ZC_BCAST_RECV_ALL_DONE_MSG)
+  {
+    CkAssert(storedBcasts.hasBcast(bcastEpoch));
+    return;
+  }
+
+  storedBcasts.insert(msg, bcastEpoch);
 }
 
-/// Deliver a copy of the given broadcast to the given local element
-bool CkArrayBroadcaster::deliver(CkArrayMessage* bcast, ArrayElement* el, bool doFree)
+// Attempt to deliver the given broadcast to the given element, continuing to deliver
+// additional broadcasts to that element if possible
+bool CkArrayBroadcaster::attemptDelivery(CkArrayMessage* bcast, ArrayElement* el,
+                                         bool doFree)
 {
   int& elBcastNo = getData(el);
-  // if this array element already received this message, skip it
-  if (elBcastNo >= getBcastNo())
-    return false;
-  elBcastNo++;
+  const int bcastEpoch = UsrToEnv(bcast)->getGroupEpoch();
+
+  DEBB((AA "Attempting to deliver broadcast %d to element %s (el bcast#:%d)\n" AB,
+        bcastEpoch, idx2str(el), elBcastNo));
+
+  // If this is a ZC all done msg, then we should already have seen this epoch since we're
+  // now at the last part of the ZC delivery, so don't increment the elBcastNo
+  if (CMI_ZC_MSGTYPE(UsrToEnv(bcast)) == CMK_ZC_BCAST_RECV_ALL_DONE_MSG)
+  {
+    CkAssert(elBcastNo > bcastEpoch);
+  }
+  else if (!stableLocations)
+  {
+    // if this array element already received this message, skip it
+    // if this array element can move and hasn't reached this bcast epoch yet, also skip
+    // it for now, it'll be delivered when it catches up
+    if (elBcastNo != bcastEpoch)
+      return false;
+    elBcastNo++;
+  }
+
+  const bool deliveryStatus = performDelivery(bcast, el, doFree);
+  // If locations are stable, we deliver msgs as they come in, so only deliver one
+  if (stableLocations)
+  {
+    return deliveryStatus;
+  }
+  // Else, keep delivering broadcasts while we have the next one in sequence
+  return bringUpToDate(el);
+}
+
+// Deliver all deliverable stored broadcasts to the given element
+bool CkArrayBroadcaster::bringUpToDate(ArrayElement* el)
+{
+  if (stableLocations)
+      return true;
+  int& elBcastNo = getData(el);
+  // Keep delivering broadcasts while we have the next one in sequence
+  while (storedBcasts.hasBcast(elBcastNo))
+  {
+    CkArrayMessage* curBcast = storedBcasts.getBcast(elBcastNo);
+    elBcastNo++;
+    const bool curDoFree =
+        CMI_ZC_MSGTYPE(UsrToEnv(curBcast)) == CMK_ZC_BCAST_RECV_ALL_DONE_MSG;
+    const bool curStatus = performDelivery(curBcast, el, curDoFree);
+    if (!curStatus)
+      return false;
+  }
+  return true;
+}
+
+// Deliver broadcast to the given element without an epoch check
+bool CkArrayBroadcaster::performDelivery(CkArrayMessage* bcast, ArrayElement* el,
+                                         bool doFree)
+{
+  int& elBcastNo = getData(el);
   DEBB((AA "Delivering broadcast %d to element %s\n" AB, elBcastNo, idx2str(el)));
 
   CkAssert(UsrToEnv(bcast)->getMsgtype() == ArrayBcastFwdMsg);
@@ -1375,37 +1413,38 @@ bool CkArrayBroadcaster::deliver(CkArrayMessage* bcast, ArrayElement* el, bool d
   }
 }
 
-bool CkArrayBroadcaster::deliverAlreadyDelivered(CkArrayMessage *bcast, ArrayElement *el, bool doFree)
-{
-  int &elBcastNo=getData(el);
-  DEBB((AA "Delivering broadcast %d to element %s\n" AB,elBcastNo,idx2str(el)));
-
-  CkAssert(UsrToEnv(bcast)->getMsgtype() == ArrayBcastFwdMsg);
-
-  if (!broadcastViaScheduler)
-    return el->ckInvokeEntry(bcast->array_ep_bcast(), bcast, doFree);
-  else {
-    if (!doFree) {
-      CkArrayMessage *newMsg = (CkArrayMessage *)CkCopyMsg((void **)&bcast);
-      bcast = newMsg;
-    }
-    envelope *env = UsrToEnv(bcast);
-    env->setRecipientID(el->ckGetID());
-    CkArrayManagerDeliver(CkMyPe(), bcast, 0);
-    return true;
-  }
-}
-
 #if CMK_CHARM4PY
 
 extern void (*ArrayBcastRecvExtCallback)(int, int, int, int, int*, int, int, char*, int);
 
-void CkArrayBroadcaster::deliver(CkArrayMessage* bcast,
-                                 std::vector<CkMigratable*>& elements, int arrayId,
-                                 bool doFree)
+void CkArrayBroadcaster::deliverAndUpdate(CkArrayMessage* bcast,
+                                          std::vector<CkMigratable*>& elements,
+                                          int arrayId)
 {
-  if (elements.size() == 0)
+  if (elements.empty())
     return;
+
+  bool success = performDelivery(bcast, elements, arrayId);
+
+  if (stableLocations)
+    delete bcast;
+  else if (success)
+  {
+    int bcastEpoch = UsrToEnv(bcast)->getGroupEpoch() + 1;
+    while (storedBcasts.hasBcast(bcastEpoch))
+    {
+      success = performDelivery(storedBcasts.getBcast(bcastEpoch), elements, arrayId);
+      bcastEpoch++;
+    }
+  }
+}
+
+bool CkArrayBroadcaster::performDelivery(CkArrayMessage* bcast,
+                                         std::vector<CkMigratable*>& elements,
+                                         int arrayId)
+{
+  const int bcastEpoch = UsrToEnv(bcast)->getGroupEpoch();
+
   CkAssert(UsrToEnv(bcast)->getMsgtype() == ArrayBcastFwdMsg);
 
   ArrayElement* el = (ArrayElement*)elements[0];
@@ -1420,85 +1459,45 @@ void CkArrayBroadcaster::deliver(CkArrayMessage* bcast,
   for (CkMigratable* m : elements)
   {
     ArrayElement* el = (ArrayElement*)m;
-    int& elBcastNo = getData(el);
-    // if this array element already received this message, skip it
-    if (elBcastNo >= bcastNo)
-      continue;
-    elBcastNo++;
-    DEBB((AA "Delivering broadcast %d to element %s\n" AB, elBcastNo, idx2str(el)));
+    if (!stableLocations)
+    {
+      int& elBcastNo = getData(el);
+      // if this array element already received this message, skip it
+      // if this array element can move and hasn't reached this bcast epoch yet, also skip
+      // it for now, it'll be delivered when it catches up
+      if (elBcastNo != bcastEpoch)
+        continue;
+      elBcastNo++;
+    }
+    DEBB((AA "Delivering broadcast %d to element %s\n" AB, bcastEpoch, idx2str(el)));
     int* index = el->thisIndexMax.data();
     for (int i = 0; i < numInts; i++) validIndexes[j++] = index[i];
     numValidElements++;
   }
 
-  char* msg_buf = ((CkMarshallMsg*)bcast)->msgBuf;
-  PUP::fromMem implP(msg_buf);
-  int msgSize;
-  implP | msgSize;
-  int ep;
-  implP | ep;
-  int dcopy_start;
-  implP | dcopy_start;
-  ArrayBcastRecvExtCallback(arrayId, numDim, numInts, numValidElements,
-                            validIndexes.data(), ep, msgSize, msg_buf + (3 * sizeof(int)),
-                            dcopy_start);
-  if (doFree)
-    delete bcast;
+  if (numValidElements > 0)
+  {
+    char* msg_buf = ((CkMarshallMsg*)bcast)->msgBuf;
+    PUP::fromMem implP(msg_buf);
+    int msgSize;
+    implP | msgSize;
+    int ep;
+    implP | ep;
+    int dcopy_start;
+    implP | dcopy_start;
+    ArrayBcastRecvExtCallback(arrayId, numDim, numInts, numValidElements,
+                              validIndexes.data(), ep, msgSize,
+                              msg_buf + (3 * sizeof(int)), dcopy_start);
+  }
+
+  return numValidElements > 0;
 }
 
 #endif
 
-/// Deliver all needed broadcasts to the given local element
-bool CkArrayBroadcaster::bringUpToDate(ArrayElement* el)
-{
-  if (stableLocations)
-    return true;
-  int& elBcastNo = getData(el);
-  int bcastNum = getBcastNo();
-  if (elBcastNo < bcastNum)
-  {  // This element needs some broadcasts-- it must have
-     // been migrating during the broadcast.
-    int i, nDeliver = bcastNum - elBcastNo;
-    DEBM((AA "Migrator %s missed %d broadcasts--\n" AB, idx2str(el), nDeliver));
+void CkArrayBroadcaster::springCleaning(void) { storedBcasts.springCleaning(); }
 
-    // Skip the old junk at the front of the bcast queue
-    for (i = oldBcasts.length() - 1; i >= nDeliver; i--) oldBcasts.enq(oldBcasts.deq());
-
-    // Deliver the newest messages, in old-to-new order
-    for (i = nDeliver - 1; i >= 0; i--)
-    {
-      CkArrayMessage* msg = oldBcasts.deq();
-      if (msg == NULL)
-        continue;
-      oldBcasts.enq(msg);
-      if (!deliver(msg, el, false))
-        return false;  // Element migrated away
-    }
-  }
-  // Otherwise, the element survived
-  return true;
-}
-
-void CkArrayBroadcaster::springCleaning(void)
-{
-  int bcastNum = getBcastNo();
-  // Remove old broadcast messages
-  int nDelete = oldBcasts.length() - (bcastNum - oldBcastNo);
-  if (nDelete > 0)
-  {
-    DEBK((AA "Cleaning out %d old broadcasts\n" AB, nDelete));
-    for (int i = 0; i < nDelete; i++) delete oldBcasts.deq();
-  }
-  oldBcastNo = bcastNum;
-}
-
-void CkArrayBroadcaster::flushState()
-{
-  setBcastNo(0);
-  oldBcastNo = 0;
-  CkArrayMessage* msg;
-  while (NULL != (msg = oldBcasts.deq())) delete msg;
-}
+void CkArrayBroadcaster::flushState() { storedBcasts.clear(); }
 
 void CkBroadcastMsgArray(int entryIndex, void* msg, CkArrayID aID, int opts)
 {
@@ -1522,30 +1521,11 @@ void CProxy_ArrayBase::ckBroadcast(CkArrayMessage* msg, int ep, int opts) const
     _TRACE_CREATION_DETAILED(UsrToEnv(msg), ep);
     static constexpr int serializer = 0;
     int skipsched = opts & CK_MSG_EXPEDITED;
-    if (CkMyPe() == serializer)
-    {
-      DEBB((AA "Sending array broadcast\n" AB));
-      if (skipsched && _entryTable[ep]->noKeep)
-      {
-        CProxy_CkArray(_aid).recvNoKeepExpeditedBroadcast(msg);
-      }
-      else if (skipsched)
-      {
-        CProxy_CkArray(_aid).recvExpeditedBroadcast(msg);
-      }
-      else if (_entryTable[ep]->noKeep)
-      {
-        CProxy_CkArray(_aid).recvNoKeepBroadcast(msg);
-      }
-      else
-      {
-        CProxy_CkArray(_aid).recvBroadcast(msg);
-      }
-    }
-    else
+    CProxy_CkArray ap(_aid);
+
+    if (CkMyPe() != serializer)
     {
       DEBB((AA "Forwarding array broadcast to serializer node %d\n" AB, serializer));
-      CProxy_CkArray ap(_aid);
       if (CMI_ZC_MSGTYPE(env) == CMK_ZC_BCAST_SEND_MSG ||
           CMI_ZC_MSGTYPE(env) == CMK_ZC_BCAST_RECV_MSG)
       {
@@ -1559,32 +1539,34 @@ void CProxy_ArrayBase::ckBroadcast(CkArrayMessage* msg, int ep, int opts) const
         w.ep = ep;
         w.opts = opts;
         ap[serializer].incrementBcastNoAndSendBack(CkMyPe(), w);
+        return;
       }
-      else
-      {
-        // Regular Bcast (non ZC) is implemented on non-zero root nodes by
-        // forwarding the message to PE 0 and then having PE 0 perform the
-        // broadcast rooted at Node 0. This is done to ensure single delivery
-        // (and avoid multiple delivery or no delivery of the message) when
-        // load balancing occurs during a broadcast
-        DEBB((AA "Forwarding array broadcast to serializer node %d\n" AB, serializer));
-        if (skipsched && _entryTable[ep]->noKeep)
-        {
-          ap[serializer].sendNoKeepExpeditedBroadcast(msg);
-        }
-        else if (skipsched)
-        {
-          ap[serializer].sendExpeditedBroadcast(msg);
-        }
-        else if (_entryTable[ep]->noKeep)
-        {
-          ap[serializer].sendNoKeepBroadcast(msg);
-        }
-        else
-        {
-          ap[serializer].sendBroadcast(msg);
-        }
-      }
+    }
+    else
+    {
+      DEBB((AA "Sending array broadcast\n" AB));
+    }
+    // Regular Bcast (non ZC) is implemented on non-zero root nodes by
+    // forwarding the message to PE 0 and then having PE 0 perform the
+    // broadcast rooted at Node 0. This is done to ensure single delivery
+    // (and avoid multiple delivery or no delivery of the message) when
+    // load balancing occurs during a broadcast
+
+    if (skipsched && _entryTable[ep]->noKeep)
+    {
+      ap[serializer].sendNoKeepExpeditedBroadcast(msg);
+    }
+    else if (skipsched)
+    {
+      ap[serializer].sendExpeditedBroadcast(msg);
+    }
+    else if (_entryTable[ep]->noKeep)
+    {
+      ap[serializer].sendNoKeepBroadcast(msg);
+    }
+    else
+    {
+      ap[serializer].sendBroadcast(msg);
     }
   }
 }
@@ -1592,18 +1574,16 @@ void CProxy_ArrayBase::ckBroadcast(CkArrayMessage* msg, int ep, int opts) const
 void CkArray::incrementBcastNoAndSendBack(int srcPe, MsgPointerWrapper w)
 {
   // increment bcastNo
-  broadcaster->incrementBcastNo();
-
+  w.epoch = broadcaster->incBcastSendEpoch();
   // Send back to CkArray on that index
   thisProxy[srcPe].sendZCBroadcast(w);
 }
-
-void CkArray::incrementBcastNo() { int zcBcastNo = broadcaster->incrementBcastNo(); }
 
 void CkArray::sendZCBroadcast(MsgPointerWrapper w)
 {
   int skipsched = w.opts & CK_MSG_EXPEDITED;
   int nokeep = _entryTable[w.ep]->noKeep;
+  UsrToEnv(w.msg)->setGroupEpoch(w.epoch);
   if (skipsched && nokeep)
   {
     thisProxy.recvNoKeepExpeditedBroadcast((CkArrayMessage*)(w.msg));
@@ -1632,6 +1612,7 @@ void CkArray::sendBroadcast(CkMessage* msg)
   {
     // Broadcast the message to all processors
     UsrToEnv(msg)->setMsgtype(ArrayBcastMsg);
+    UsrToEnv(msg)->setGroupEpoch(broadcaster->incBcastSendEpoch());
     thisProxy.recvBroadcast(msg);
   }
   else
@@ -1645,6 +1626,7 @@ void CkArray::sendNoKeepExpeditedBroadcast(CkMessage* msg)
   CK_MAGICNUMBER_CHECK
   // Broadcast the message to all processors
   UsrToEnv(msg)->setMsgtype(ArrayBcastMsg);
+  UsrToEnv(msg)->setGroupEpoch(broadcaster->incBcastSendEpoch());
   thisProxy.recvNoKeepExpeditedBroadcast(msg);
 }
 
@@ -1653,6 +1635,7 @@ void CkArray::sendExpeditedBroadcast(CkMessage* msg)
   CK_MAGICNUMBER_CHECK
   // Broadcast the message to all processors
   UsrToEnv(msg)->setMsgtype(ArrayBcastMsg);
+  UsrToEnv(msg)->setGroupEpoch(broadcaster->incBcastSendEpoch());
   thisProxy.recvExpeditedBroadcast(msg);
 }
 
@@ -1661,6 +1644,7 @@ void CkArray::sendNoKeepBroadcast(CkMessage* msg)
   CK_MAGICNUMBER_CHECK
   // Broadcast the message to all processors
   UsrToEnv(msg)->setMsgtype(ArrayBcastMsg);
+  UsrToEnv(msg)->setGroupEpoch(broadcaster->incBcastSendEpoch());
   thisProxy.recvNoKeepBroadcast(msg);
 }
 
@@ -1673,12 +1657,14 @@ void CkArray::recvBroadcast(CkMessage* m)
   CkArrayMessage* msg = (CkArrayMessage*)m;
   envelope* env = UsrToEnv(msg);
 
-  broadcaster->incoming(msg);
+  // Process the incoming message, buffers if necessary
+  broadcaster->ingestIncoming(msg);
 
   int len = localElemVec.size();
   // extract this field here so we can still check it even if msg is freed
   const auto zc_msgtype = CMI_ZC_MSGTYPE(env);
 
+  // Attempt to actually deliver the broadcast
   if (zc_msgtype == CMK_ZC_BCAST_RECV_ALL_DONE_MSG && len > 0)
   {
     // Message contains pointers to the posted buffer, which contains the data
@@ -1687,7 +1673,7 @@ void CkArray::recvBroadcast(CkMessage* m)
     // deliver to the first element
 
     bool doFree = true;  // free it since all ops are done
-    broadcaster->deliver(msg, (ArrayElement*)localElemVec[0], doFree);
+    broadcaster->attemptDelivery(msg, (ArrayElement*)localElemVec[0], doFree);
   }
   else if (zc_msgtype == CMK_ZC_BCAST_RECV_MSG && len > 0)
   {
@@ -1699,12 +1685,12 @@ void CkArray::recvBroadcast(CkMessage* m)
     // be finally freed by the first element in the
     // CMK_ZC_BCAST_RECV_ALL_DONE_MSG branch
     bool doFree = false;
-    broadcaster->deliver(msg, (ArrayElement*)localElemVec[0], doFree);
+    broadcaster->attemptDelivery(msg, (ArrayElement*)localElemVec[0], doFree);
   }
   else
   {
 #if CMK_CHARM4PY
-    broadcaster->deliver(msg, localElemVec, thisgroup.idx, stableLocations);
+    broadcaster->deliverAndUpdate(msg, localElemVec, thisgroup.idx);
 #else
     // Do not free if CMK_ZC_BCAST_RECV_DONE_MSG, since it'll be freed by the
     // first element during CMK_ZC_BCAST_ALL_DONE_MSG
@@ -1721,7 +1707,7 @@ void CkArray::recvBroadcast(CkMessage* m)
       if (zc_msgtype == CMK_ZC_BCAST_RECV_DONE_MSG)
         doFree = false;
       CmiAssert(i < localElemVec.size());
-      broadcaster->deliver(msg, (ArrayElement*)localElemVec[i], doFree);
+      broadcaster->attemptDelivery(msg, (ArrayElement*)localElemVec[i], doFree);
     }
 
 #endif  // CMK_CHARM4PY
@@ -1747,14 +1733,14 @@ void CkArray::forwardZCMsgToOtherElems(envelope* env)
     if (stableLocations && i == len - 1 &&
         CMI_ZC_MSGTYPE(env) != CMK_ZC_BCAST_RECV_DONE_MSG)
       doFree = true;
-    broadcaster->deliver((CkArrayMessage*)EnvToUsr(env), (ArrayElement*)localElemVec[i],
+    broadcaster->attemptDelivery((CkArrayMessage*)EnvToUsr(env), (ArrayElement*)localElemVec[i],
                          doFree);
   }
 }
 
 void CkArray::forwardZCMsgToSpecificElem(envelope *env, CkMigratable *elem) {
   bool doFree = false;
-  broadcaster->deliverAlreadyDelivered((CkArrayMessage *)EnvToUsr(env), (ArrayElement*)elem, doFree);
+  broadcaster->performDelivery((CkArrayMessage *)EnvToUsr(env), (ArrayElement*)elem, doFree);
 }
 
 void CkArray::flushStates()

--- a/src/ck-core/ckarray.ci
+++ b/src/ck-core/ckarray.ci
@@ -18,16 +18,16 @@ module CkArray {
     entry void remoteDoneInserting(void);
 
     //Broadcast
-    entry void sendBroadcast(CkMessage *);
+    entry [inline] void sendBroadcast(CkMessage *);
     entry void recvBroadcast(CkMessage *);
     entry void recvBroadcastViaTree(CkMessage *);
-    entry [expedited] void sendExpeditedBroadcast(CkMessage *);
+    entry [inline, expedited] void sendExpeditedBroadcast(CkMessage *);
     entry [expedited] void recvExpeditedBroadcast(CkMessage *);
     entry [expedited] void incrementBcastNoAndSendBack(int srcPe, MsgPointerWrapper p);
     entry [nokeep] void recvNoKeepBroadcast(CkMessage *);
-    entry void sendNoKeepBroadcast(CkMessage *);
+    entry [inline] void sendNoKeepBroadcast(CkMessage *);
     entry [expedited,nokeep] void recvNoKeepExpeditedBroadcast(CkMessage *);
-    entry [expedited] void sendNoKeepExpeditedBroadcast(CkMessage *);
+    entry [inline, expedited] void sendNoKeepExpeditedBroadcast(CkMessage *);
 
     entry void ckDestroy();
   };

--- a/src/ck-core/ckarray.h
+++ b/src/ck-core/ckarray.h
@@ -901,15 +901,6 @@ public:
 // with usage in maps' populateInitial()
 typedef CkArray CkArrMgr;
 
-struct ncpyBcastNoMsg
-{
-  char cmicore[CmiMsgHeaderSizeBytes];
-  int srcPe;
-  void* ref;
-};
-
-void invokeNcpyBcastNoHandler(int serializerPe, ncpyBcastNoMsg* bcastNoMsg, int msgSize);
-
 /*@}*/
 
 /// This arrayListener is in charge of delivering broadcasts to the array.

--- a/src/ck-core/ckarray.h
+++ b/src/ck-core/ckarray.h
@@ -624,11 +624,13 @@ public:
   void* msg;
   int ep;
   int opts;
+  unsigned int epoch;
   void pup(PUP::er& p)
   {
     pup_pointer(&p, &msg);
     p | ep;
     p | opts;
+    p | epoch;
   }
 };
 
@@ -883,7 +885,6 @@ public:
   }
 
   void incrementBcastNoAndSendBack(int srcPe, MsgPointerWrapper w);
-  void incrementBcastNo();
 
 private:
   CkArrayReducer* reducer;          // Read-only copy of default reducer
@@ -912,10 +913,9 @@ public:
   CkArrayBroadcaster(bool _stableLocations, bool _broadcastViaScheduler);
   CkArrayBroadcaster(CkMigrateMessage* m);
   virtual void pup(PUP::er& p);
-  virtual ~CkArrayBroadcaster();
   PUPable_decl(CkArrayBroadcaster);
 
-  virtual void ckElementStamp(int* eltInfo) { *eltInfo = getBcastNo(); }
+  virtual void ckElementStamp(int* eltInfo) { *eltInfo = bcastSendEpoch; }
 
   /// Element was just created on this processor
   /// Return false if the element migrated away or deleted itself.
@@ -925,15 +925,15 @@ public:
   /// Return false if the element migrated away or deleted itself.
   virtual bool ckElementArriving(ArrayElement* elt) { return bringUpToDate(elt); }
 
-  void incoming(CkArrayMessage* msg);
+  void ingestIncoming(CkArrayMessage* msg);
 
-  int incrementBcastNo();
-
-  bool deliver(CkArrayMessage* bcast, ArrayElement* el, bool doFree);
-  bool deliverAlreadyDelivered(CkArrayMessage* bcast, ArrayElement* el, bool doFree);
+  bool attemptDelivery(CkArrayMessage* bcast, ArrayElement* el, bool doFree);
+  bool performDelivery(CkArrayMessage* bcast, ArrayElement* el, bool doFree);
 #if CMK_CHARM4PY
-  void deliver(CkArrayMessage* bcast, std::vector<CkMigratable*>& elements, int arrayId,
-               bool doFree);
+  void deliverAndUpdate(CkArrayMessage* bcast, std::vector<CkMigratable*>& elements,
+                        int arrayId);
+  bool performDelivery(CkArrayMessage* bcast, std::vector<CkMigratable*>& elements,
+                       int arrayId);
 #endif
 
   void springCleaning(void);
@@ -941,34 +941,134 @@ public:
   void flushState();
 
 private:
-  // Number of broadcasts received (also serial number)
-#if CMK_SMP
-  std::atomic<int> bcastNo;
-#else
-  int bcastNo;
-#endif
+  // A circular queue designed to store incoming broadcasts. Notably,
+  // it does not act like a FIFO, instead ordering and storing
+  // broadcasts by their stamped epoch.
+  class BcastQueue
+  {
+  private:
+    std::vector<CkArrayMessage*> storage{16};
+    int headEpoch = 0;
+    size_t headIndex = 0;
+    size_t mask = 0x0F;
+    int curMaxEpoch = 0;
+    int oldMaxEpoch = 0;  // Max epoch at last spring cleaning
 
-  int oldBcastNo;  // Above value last spring cleaning
-  // This queue stores old broadcasts (in case a migrant arrives
-  // and needs to be brought up to date)
-  CkQ<CkArrayMessage*> oldBcasts;
+    int getOffset(const int epoch) const { return epoch - headEpoch; }
+
+  public:
+    BcastQueue() = default;
+    BcastQueue(CkMigrateMessage* m) {}
+    ~BcastQueue()
+    {
+      for (CkArrayMessage* msg : storage)
+      {
+        if (msg != nullptr)
+          delete msg;
+      }
+    }
+
+    // Inserts msg into the slot corresponding to epoch
+    void insert(CkArrayMessage* const msg, const int epoch)
+    {
+      const int offset = getOffset(epoch);
+      if (offset >= storage.size())
+      {
+        // Size of storage is always a power of 2 to ease masking
+        const size_t oldSize = storage.size();
+        size_t newSize = oldSize * 2;
+        while (offset >= newSize) newSize *= 2;
+        storage.resize(newSize);
+        mask = newSize - 1;
+        if (headIndex != 0)
+        {
+          // Shuffle things around so that the queue starts at index 0
+          std::move(storage.begin(), storage.begin() + headIndex,
+                    storage.begin() + oldSize);
+          std::move(storage.begin() + headIndex, storage.begin() + oldSize,
+                    storage.begin());
+          std::move(storage.begin() + oldSize, storage.begin() + oldSize + headIndex,
+                    storage.begin() + oldSize - headIndex);
+          headIndex = 0;
+        }
+      }
+      CkAssert(storage[(headIndex + offset) & mask] == nullptr);
+      storage[(headIndex + offset) & mask] = msg;
+
+      curMaxEpoch = std::max(epoch, curMaxEpoch);
+    }
+
+    bool hasBcast(const int epoch) const
+    {
+      const int offset = getOffset(epoch);
+      if (offset < 0 || offset >= storage.size())
+        return false;
+      return storage[(headIndex + offset) & mask] != nullptr;
+    }
+
+    CkArrayMessage* getBcast(const int epoch) const
+    {
+      CkAssert(hasBcast(epoch));
+      return storage[(headIndex + getOffset(epoch)) & mask];
+    }
+
+    void springCleaning()
+    {
+      // Remove old broadcast messages
+      const int nDelete = oldMaxEpoch - headEpoch;
+      if (nDelete > 0)
+      {
+        // DEBK((AA "Cleaning out %d old broadcasts\n" AB, nDelete));
+        for (size_t i = headIndex; i < headIndex + nDelete; i++)
+        {
+          CkArrayMessage* bcast = storage[i & mask];
+          if (bcast)
+            delete bcast;
+          storage[i & mask] = nullptr;
+        }
+        headIndex = (headIndex + nDelete) & mask;
+        headEpoch += nDelete;
+      }
+      oldMaxEpoch = std::max(oldMaxEpoch, curMaxEpoch);
+    }
+
+    void clear()
+    {
+      for (CkArrayMessage* msg : storage)
+      {
+        if (msg)
+          delete msg;
+      }
+      storage.clear();
+      storage.resize(16);
+      headIndex = 0;
+      mask = 0x0F;
+      curMaxEpoch = 0;
+      oldMaxEpoch = 0;
+    }
+
+    void pup(PUP::er& p)
+    {
+      p | headEpoch;
+      if (p.isUnpacking())
+      {
+        curMaxEpoch = headEpoch;
+        oldMaxEpoch = headEpoch;
+      }
+    }
+  };
+
+  int bcastSendEpoch = 0;
   bool stableLocations;
   bool broadcastViaScheduler;
+  // This queue stores old broadcasts (in case a migrant arrives
+  // and needs to be brought up to date)
+  BcastQueue storedBcasts;
 
   bool bringUpToDate(ArrayElement* el);
 
 public:
-#if CMK_SMP
-  int getBcastNo() const { return bcastNo.load(std::memory_order_acquire); }
-  void setBcastNo(int r) { return bcastNo.store(r, std::memory_order_release); }
-  int incBcastNo() { return bcastNo.fetch_add(1, std::memory_order_release); }
-  int decBcastNo() { return bcastNo.fetch_sub(1, std::memory_order_release); }
-#else
-  int getBcastNo() const { return bcastNo; }
-  void setBcastNo(int r) { bcastNo = r; }
-  int incBcastNo() { return bcastNo++; }
-  int decBcastNo() { return bcastNo--; }
-#endif
+  int incBcastSendEpoch() { return bcastSendEpoch++; }
 };
 
 #endif

--- a/src/ck-core/envelope.h
+++ b/src/ck-core/envelope.h
@@ -142,10 +142,11 @@ namespace ck {
         UInt forAnyPe;  ///< Used only by newChare
         int  bype;      ///< created by this pe
       } chare;
-      struct s_group {         // NodeBocInitMsg, BocInitMsg, ForNodeBocMsg, ForBocMsg
+      struct s_group {         // NodeBocInitMsg, BocInitMsg, ForNodeBocMsg, ForBocMsg, ArrayBcastMsg, ArrayBcastFwdMsg
         CkGroupID g;           ///< GroupID
         CkNodeGroupID rednMgr; ///< Reduction manager for this group (constructor only!)
-        int epoch;             ///< "epoch" this group was created during (0--mainchare, 1--later)
+        int epoch;             ///< for init msgs, "epoch" this group was created during (0--mainchare, 1--later)
+                               ///  for arraybcast msgs, denotes send epoch from the serializer PE
         UShort arrayEp;        ///< Used only for array broadcasts
       } group;
       struct s_array{             ///< For arrays only (ArrayEltInitMsg, ForArrayEltMsg)
@@ -405,8 +406,18 @@ public:
           || getMsgtype() == ArrayBcastFwdMsg);
       type.group.g = g;
     }
-    void setGroupEpoch(int epoch) { CkAssert(getMsgtype()==BocInitMsg || getMsgtype()==NodeBocInitMsg); type.group.epoch=epoch; }
-    int getGroupEpoch(void) const { CkAssert(getMsgtype()==BocInitMsg || getMsgtype()==NodeBocInitMsg); return type.group.epoch; }
+    void setGroupEpoch(int epoch)
+    {
+      CkAssert(getMsgtype() == BocInitMsg || getMsgtype() == NodeBocInitMsg ||
+               getMsgtype() == ArrayBcastMsg);
+      type.group.epoch = epoch;
+    }
+    int getGroupEpoch(void) const
+    {
+      CkAssert(getMsgtype() == BocInitMsg || getMsgtype() == NodeBocInitMsg ||
+               getMsgtype() == ArrayBcastMsg || getMsgtype() == ArrayBcastFwdMsg);
+      return type.group.epoch;
+    }
     void setRednMgr(CkNodeGroupID r){ CkAssert(getMsgtype()==BocInitMsg || getMsgtype()==ForBocMsg
           || getMsgtype()==NodeBocInitMsg || getMsgtype()==ForNodeBocMsg);
  type.group.rednMgr = r; }

--- a/tests/charm++/load_balancing/Makefile
+++ b/tests/charm++/load_balancing/Makefile
@@ -1,6 +1,7 @@
 DIRS = \
   lb_test \
   meta_lb_test \
+  periodic_lb_broadcast_test
 
 TESTDIRS = $(DIRS)
 

--- a/tests/charm++/load_balancing/periodic_lb_broadcast_test/Makefile
+++ b/tests/charm++/load_balancing/periodic_lb_broadcast_test/Makefile
@@ -1,0 +1,24 @@
+-include ../../../common.mk
+CHARMC	= ../../../../bin/charmc $(OPTS)
+
+all: ping
+
+ping: ping.decl.h ping.C
+	$(CHARMC) ping.C -o ping -module CommonLBs
+
+ping.decl.h: ping.ci
+	$(CHARMC) ping.ci
+
+test: ping
+	$(call run, +p1 ./ping +balancer RotateLB +LBPeriod 0.1)
+	$(call run, +p2 ./ping +balancer RotateLB +LBPeriod 0.1)
+
+testp: ping
+	$(call run, +p$(P) ./ping +balancer RotateLB +LBPeriod 0.1)
+
+smptest: ping
+	$(call run, +p2 ./ping +balancer RotateLB +LBPeriod 0.1 ++ppn 2)
+	$(call run, +p4 ./ping +balancer RotateLB +LBPeriod 0.1 ++ppn 2)
+
+clean:
+	rm -rf *.decl.h *.def.h ping charmrun

--- a/tests/charm++/load_balancing/periodic_lb_broadcast_test/ping.C
+++ b/tests/charm++/load_balancing/periodic_lb_broadcast_test/ping.C
@@ -1,0 +1,170 @@
+// This test creates two array chares: the Pingers and the Pingees
+
+// Each Pinger performs a number of iterations in which it sends as a broadcast
+// to the Pingee array the index of the Pinger and the current iteration.
+// Notably, this test is called with periodic LB enabled, so chares can migrate
+// concurrently with these broadcasts.
+
+// Each Pingee starts with an empty std::unordered_map<int,
+// std::unordered_multiset<int>>>. Each time the Pingee is called, it inserts
+// the received array index of the Pinger into the std::unordered_multiset<int>
+// retrieved from the std::unordered_map at the received iteration.
+
+// At the end, it is checked that the std::unordered_map has an entry at each
+// iteration, and that for each iteration, the std::unordered_multiset contains
+// one entry for each Pinger.
+
+#include "ping.decl.h"
+
+#include <chrono>
+#include <unordered_map>
+#include <unordered_set>
+
+/*readonly*/ CProxy_Main mainProxy;
+/*readonly*/ CProxy_Pingers pingersProxy;
+/*readonly*/ CProxy_Pingees pingeesProxy;
+
+namespace
+{
+constexpr std::chrono::milliseconds SPIN_TIME(10);
+constexpr int NUM_PINGERS = 10;
+constexpr int NUMBER_OF_PINGEES = 1;
+constexpr int NUMBER_OF_ITERATIONS = 4;
+
+// wait `time_to_spin` milliseconds
+void spin(const std::chrono::milliseconds& timeToSpin)
+{
+  auto start = std::chrono::steady_clock::now();
+  while (std::chrono::steady_clock::now() - start < timeToSpin)
+  {
+  }
+}
+}  // namespace
+
+class Main : public CBase_Main
+{
+private:
+  int migrations{0};
+
+public:
+  Main(CkArgMsg* msg)
+  {
+    delete msg;
+
+    pingersProxy = CProxy_Pingers::ckNew(NUM_PINGERS);
+    pingeesProxy = CProxy_Pingees::ckNew(NUMBER_OF_PINGEES);
+    CkStartQD(CkCallback(CkIndex_Main::execute(), mainProxy));
+  }
+
+  void execute()
+  {
+    CkPrintf("Main is in phase execute\n");
+    pingersProxy.sendPings();
+    CkStartQD(CkCallback(CkIndex_Main::check(), mainProxy));
+  }
+
+  void check()
+  {
+    CkPrintf("Main is in phase check\n");
+    pingeesProxy.check(migrations);
+    CkStartQD(CkCallback(CkIndex_Main::exit(), mainProxy));
+  }
+
+  void exit()
+  {
+    CkPrintf("Main is in phase exit\n");
+    CkExit();
+  }
+
+  void migrated()
+  {
+    ++migrations;
+    CkPrintf("Migrations done: %i\n", migrations);
+  }
+
+  void countErrors(const int errors)
+  {
+    if (errors > 0)
+    {
+      CkPrintf("Errors: %i\n", errors);
+      CkAbort("Test failed!\n");
+    }
+  }
+};
+
+class Pingers : public CBase_Pingers
+{
+public:
+  Pingers() {}
+
+  Pingers(CkMigrateMessage* /*msg*/) {}
+
+  void sendPings()
+  {
+    for (int iteration = 1; iteration <= NUMBER_OF_ITERATIONS; ++iteration)
+    {
+      spin(SPIN_TIME);
+      pingeesProxy.receivePing(iteration, thisIndex);
+    }
+  }
+};
+
+class Pingees : public CBase_Pingees
+{
+private:
+  std::unordered_map<int, std::unordered_multiset<int>> pings{};
+  int migrations{0};
+  int initialProc{-1};
+
+public:
+  Pingees() : initialProc(CkMyPe()) {}
+
+  Pingees(CkMigrateMessage* /*msg*/) {}
+
+  void receivePing(const int iteration, const int indexOfPinger)
+  {
+    pings[iteration].insert(indexOfPinger);
+    CkAssert(pings.at(iteration).count(indexOfPinger) == 1);
+  }
+
+  void check(const int migrationsRecordedByMain)
+  {
+    CkAssert(migrations == migrationsRecordedByMain);
+    // RotateLB should increase proc at each migration
+    CkAssert(CkMyPe() == ((initialProc + migrations) % CkNumPes()));
+
+    int errors = 0;
+    for (int i = 1; i <= NUMBER_OF_ITERATIONS; ++i)
+    {
+      CkAssert(pings.count(i) == 1);
+      for (int p = 0; p < NUM_PINGERS; ++p)
+      {
+        if (pings.at(i).count(p) != 1)
+        {
+          ++errors;
+          CkPrintf(
+              "Pingee %i unexpected count %zu on iteration %i for pinger"
+              " %i\n",
+              thisIndex, pings.at(i).count(p), i, p);
+        }
+      }
+    }
+
+    contribute(sizeof(int), &errors, CkReduction::sum_int,
+               CkCallback(CkReductionTarget(Main, countErrors), mainProxy));
+  }
+
+  void pup(PUP::er& p)
+  {
+    p | pings;
+    p | migrations;
+    p | initialProc;
+    if (p.isUnpacking())
+    {
+      ++migrations;
+      contribute(CkCallback(CkReductionTarget(Main, migrated), mainProxy));
+    }
+  }
+};
+
+#include "ping.def.h"

--- a/tests/charm++/load_balancing/periodic_lb_broadcast_test/ping.ci
+++ b/tests/charm++/load_balancing/periodic_lb_broadcast_test/ping.ci
@@ -1,0 +1,26 @@
+mainmodule ping {
+
+  readonly CProxy_Main mainProxy;
+  readonly CProxy_Pingers pingersProxy;
+  readonly CProxy_Pingees pingeesProxy;
+
+  mainchare Main {
+    entry Main(CkArgMsg* msg);
+    entry void execute();
+    entry void check();
+    entry void exit();
+    entry [reductiontarget] void migrated();
+    entry [reductiontarget] void countErrors(const int errors);
+  };
+
+  array [1D] Pingers {
+    entry Pingers();
+    entry void sendPings();
+  };
+
+  array [1D] Pingees {
+    entry Pingees();
+    entry void receivePing(const int iteration, const int indexOfPinger);
+    entry void check(const int migrationsRecordedByMain);
+  };
+};


### PR DESCRIPTION
Implements in-order delivery for array broadcasts, fixes #3605.

@stwhite91 It seems like AMPI violates the contract to disable anytime migration, namely in the AMPI migration test, migrations were happening concurrently with an array broadcast (which I think was backing an `MPI_Scatter`), so I enabled anytime migration in AMPI in the first patch of this PR, which fixed the failure. Is there some way AMPI can guarantee when migrations/collectives can happen so that we don't have to use anytime migration for it?
@ZwFink One of the delivery pathways for this is specialized for Charm4py; I think my changes are correct, but it'd be good to get some eyes that are experienced with Charm4py on this. 