### PR TITLE
Use PMI for topology on Cray EX

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -810,10 +810,12 @@ if(${NETWORK} MATCHES "ucx" OR ${NETWORK} MATCHES "ofi")
       configure_file(${filename} include/ COPYONLY)
   endforeach()
 
-  # FIXME: this should be in include/proc_management/simple_pmi
-  foreach(filename ${proc_management-simple_pmi-sources})
+  if(${LRTS_PMI} MATCHES "simplepmi")
+    # FIXME: this should be in include/proc_management/simple_pmi
+    foreach(filename ${proc_management-simple_pmi-sources})
       configure_file(${filename} include/ COPYONLY)
-  endforeach()
+    endforeach()
+  endif()
 endif()
 
 # Charmxi

--- a/cmake/detect-features-c.cmake
+++ b/cmake/detect-features-c.cmake
@@ -292,7 +292,7 @@ int main()
 " CMK_HAS_NUMACTRL)
 
 set(tmp ${CMAKE_REQUIRED_LIBRARIES})
-set(CMAKE_REQUIRED_LIBRARIES $ENV{CRAY_PMI_POST_LINK_OPTS} $ENV{CRAY_UGNI_POST_LINK_OPTS} -lugni -lpmi)
+set(CMAKE_REQUIRED_LIBRARIES $ENV{CRAY_PMI_POST_LINK_OPTS} -lpmi)
 check_c_source_compiles("
 #include <pmi.h>
 int main() {

--- a/src/arch/mpi-crayshasta/conv-mach.h
+++ b/src/arch/mpi-crayshasta/conv-mach.h
@@ -2,6 +2,8 @@
 #ifndef _CONV_MACH_H
 #define _CONV_MACH_H
 
+#define CMK_CRAYEX                                         1
+
 #define CMK_CONVERSE_MPI                                   1
 
 #define CMK_MEMORY_PREALLOCATE_HACK			   0

--- a/src/arch/ofi-crayshasta/conv-mach.h
+++ b/src/arch/ofi-crayshasta/conv-mach.h
@@ -1,7 +1,8 @@
 #ifndef _CONV_MACH_H
 #define _CONV_MACH_H
 
-#define CMK_OFI 1
+#define CMK_CRAYEX                                         1
+#define CMK_OFI                                            1
 
 /* define the default linker, together with its options */
 #define CMK_DLL_CC   "g++ -shared -O3 -o "

--- a/src/conv-core/cpuaffinity.C
+++ b/src/conv-core/cpuaffinity.C
@@ -799,7 +799,7 @@ static int search_pemap(char *pecoremap, int pe)
   return i;
 }
 
-#if CMK_CRAYXE || CMK_CRAYXC
+#if CMK_CRAYXE || CMK_CRAYXC || CMK_CRAYEX
 CLINKAGE int getXTNodeID(int mpirank, int nummpiranks);
 #endif
 
@@ -1144,7 +1144,7 @@ void CmiInitCPUAffinity(char **argv)
   }
   else
   {
-#if CMK_CRAYXE || CMK_CRAYXC
+#if CMK_CRAYXE || CMK_CRAYXC || CMK_CRAYEX
     int numCores = CmiNumCores();
 
     int myid = getXTNodeID(CmiMyNodeGlobal(), CmiNumNodesGlobal());

--- a/src/conv-core/cputopology.C
+++ b/src/conv-core/cputopology.C
@@ -32,7 +32,7 @@
 #include <stdlib.h>
 #include <stdio.h>
 
-#if CMK_CRAYXE || CMK_CRAYXC
+#if CMK_CRAYXE || CMK_CRAYXC || CMK_CRAYEX
 extern "C" int getXTNodeID(int mpirank, int nummpiranks);
 #endif
 
@@ -406,7 +406,7 @@ extern "C" void LrtsInitCpuTopo(char **argv)
       strcpy(hostname, "");
   }
 #endif
-#if CMK_CRAYXE || CMK_CRAYXC
+#if CMK_CRAYXE || CMK_CRAYXC || CMK_CRAYEX
   if(CmiMyRank() == 0) {
     int numPes = cpuTopo.numPes = CmiNumPes();
     int numNodes = CmiNumNodes();

--- a/src/util/topomanager/CrayNid.c
+++ b/src/util/topomanager/CrayNid.c
@@ -23,7 +23,7 @@
 # endif
 #endif
 
-#if CMK_CRAYXE || CMK_CRAYXC
+#if CMK_CRAYXE || CMK_CRAYXC || CMK_CRAYEX
 
 #if XT3_TOPOLOGY
 #else	/* if it is a XT4/5 or XE */
@@ -49,7 +49,7 @@ CLINKAGE int getXTNodeID(int mpirank, int nummpiranks)
   return nid;
 }
 
-#endif /* CMK_CRAYXE || CMK_CRAYXC */
+#endif /* CMK_CRAYXE || CMK_CRAYXC || CMK_CRAYEX */
 
 #if XT4_TOPOLOGY || XT5_TOPOLOGY || XE6_TOPOLOGY
 


### PR DESCRIPTION
- Use PMI to query topology information on Cray EX
- Check if simplepmi is used before copying headers
