### PR TITLE
Doc: Specify docs are in English to Sphinx

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -58,7 +58,7 @@ master_doc = 'index'
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = 'en'
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.


### PR DESCRIPTION
From version 5.0.0, Sphinx now no longer accepts `None` as a language.