### PR TITLE
Make simplepmi the explicit default PMI

### DIFF
--- a/buildcmake
+++ b/buildcmake
@@ -471,7 +471,8 @@ for c in "$opt_lrts_pmi" "${opt_compiler[@]}"; do
   [[ -n "$c" ]] && builddir_extra+="-$c"
 done
 
-if [[ "$actual_triplet" = +(ofi|ucx)* && $opt_lrts_pmi == "" ]]; then
+is_ofi_ucx="+(ofi|ucx)*"
+if [[ $actual_triplet =~ $is_ofi_ucx && $opt_lrts_pmi == "" ]]; then
     opt_lrts_pmi="simplepmi"
 fi
 

--- a/buildcmake
+++ b/buildcmake
@@ -471,6 +471,10 @@ for c in "$opt_lrts_pmi" "${opt_compiler[@]}"; do
   [[ -n "$c" ]] && builddir_extra+="-$c"
 done
 
+if [[ "$actual_triplet" = +(ofi|ucx)* && $opt_lrts_pmi == "" ]]; then
+    opt_lrts_pmi="simplepmi"
+fi
+
 if [[ "$actual_triplet" = ofi-cray* && -z "$opt_lrts_pmi" ]]; then
     opt_lrts_pmi="slurmpmi2"
 fi


### PR DESCRIPTION
`simplepmi` should be the default PMI according to the documentation. Not setting this explicitly causes build failures for OFI and UCX builds on some machines (stampede2, campuscluster).