### PR TITLE
Allow using `buildcmake` in another directory

### DIFF
--- a/buildcmake
+++ b/buildcmake
@@ -75,7 +75,7 @@ function parse_triplet() {
   # Extract extra options from the full_triplet, e.g.,
   # full_triplet='netlrts-darwin-x86_64-smp-omp'
   # becomes actual_triplet='netlrts-darwin-x86_64' and extra_triplet_opts='smp omp'
-  all_triplets=$(cd src/arch && find . -maxdepth 1 -name '*-*' -type d | sed 's,./,,')
+  all_triplets=$(cd $my_srcdir/src/arch && find . -maxdepth 1 -name '*-*' -type d | sed 's,./,,')
   extra_triplet_opts="$full_triplet"
   for t in $all_triplets; do
     extra_triplet_opts=${extra_triplet_opts#$t}

--- a/buildcmake
+++ b/buildcmake
@@ -75,7 +75,7 @@ function parse_triplet() {
   # Extract extra options from the full_triplet, e.g.,
   # full_triplet='netlrts-darwin-x86_64-smp-omp'
   # becomes actual_triplet='netlrts-darwin-x86_64' and extra_triplet_opts='smp omp'
-  all_triplets=$(cd $my_srcdir/src/arch && find . -maxdepth 1 -name '*-*' -type d | sed 's,./,,')
+  all_triplets=$(cd "$my_srcdir"/src/arch && find . -maxdepth 1 -name '*-*' -type d | sed 's,./,,')
   extra_triplet_opts="$full_triplet"
   for t in $all_triplets; do
     extra_triplet_opts=${extra_triplet_opts#$t}

--- a/doc/charm++/manual.rst
+++ b/doc/charm++/manual.rst
@@ -11580,6 +11580,12 @@ For example, to build Charm++ and AMPI on top of the MPI layer with SMP, the fol
 
    $ cmake .. -DNETWORK=mpi -DSMP=on -DTARGET=AMPI
 
+Alternatively, one could also specify other ``cmake`` configuration options via the 
+``../build`` command, for example, by replacing the above ``cmake ..`` command with
+
+.. code-block:: bash
+
+   $ ../build AMPI mpi-linux-x86_64 smp
 
 Charm++ installation directories
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
The `cmake` options are not as well documented as the `build` command. It is helpful to allow users to use the `build` command when cmaking `charm` in different folders by reusing the same source tree.