### PR TITLE
Rename NAMD CI so it can be optional

### DIFF
--- a/.github/workflows/namd.yml
+++ b/.github/workflows/namd.yml
@@ -3,6 +3,9 @@ name: NAMD
 on: pull_request
 
 jobs:
+  # Not named 'build' since 'build' is used by our CI for builds that must succeed before merge.
+  # Since NAMD requires a secret to download its source from Gitlab, CI builds from outside PPl
+  # always fail in this test since the secret is not available.
   build-and-test-namd:
     runs-on: ubuntu-latest
 

--- a/.github/workflows/namd.yml
+++ b/.github/workflows/namd.yml
@@ -3,7 +3,7 @@ name: NAMD
 on: pull_request
 
 jobs:
-  build:
+  build-and-test-namd:
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
GitHub branch protection rules use the name of the build (`build` in most of our CI cases) to require it to pass before being able to merge a PR. Since NAMD requires a secret token to download it from their Gitlab, it will fail on PRs that are opened from outside PPL. By renaming the NAMD build, it will become optional to pass before it can be merged.