### PR TITLE
Fix default PMI on Cray OFI

### DIFF
--- a/buildcmake
+++ b/buildcmake
@@ -471,13 +471,13 @@ for c in "$opt_lrts_pmi" "${opt_compiler[@]}"; do
   [[ -n "$c" ]] && builddir_extra+="-$c"
 done
 
+if [[ "$actual_triplet" = ofi-cray* && -z "$opt_lrts_pmi" ]]; then
+    opt_lrts_pmi="slurmpmi2"
+fi
+
 is_ofi_ucx="^(ofi|ucx).*"
 if [[ $actual_triplet =~ $is_ofi_ucx && $opt_lrts_pmi == "" ]]; then
     opt_lrts_pmi="simplepmi"
-fi
-
-if [[ "$actual_triplet" = ofi-cray* && -z "$opt_lrts_pmi" ]]; then
-    opt_lrts_pmi="slurmpmi2"
 fi
 
 if [[ -n "$opt_destination" ]]; then

--- a/buildcmake
+++ b/buildcmake
@@ -471,10 +471,13 @@ for c in "$opt_lrts_pmi" "${opt_compiler[@]}"; do
   [[ -n "$c" ]] && builddir_extra+="-$c"
 done
 
+# Use slurmpmi2 by default for ofi builds on Cray platforms (e.g. Cray
+# Shasta/EX) since it matches the interface of cray-pmi
 if [[ "$actual_triplet" = ofi-cray* && -z "$opt_lrts_pmi" ]]; then
     opt_lrts_pmi="slurmpmi2"
 fi
 
+# Default to using simplepmi on non-Cray OFI platforms
 is_ofi_ucx="^(ofi|ucx).*"
 if [[ $actual_triplet =~ $is_ofi_ucx && $opt_lrts_pmi == "" ]]; then
     opt_lrts_pmi="simplepmi"


### PR DESCRIPTION
#3626 ordered the check to default to `simplepmi` before the check for using `slurmpmi2` on Cray OFI platforms, meaning that `simplepmi` was used by default on those platforms rather than `slurmpmi2`. Instead, do the check for Cray platforms first, and only use the `simplepmi` default if that fails.