### PR TITLE
Tracing: Remove erroneous parameter in summary data collection function

### DIFF
--- a/src/ck-perf/trace-summaryBOC.h
+++ b/src/ck-perf/trace-summaryBOC.h
@@ -61,4 +61,4 @@ private:
   void write();
 };
 
-void startCollectData(void *data, double currT);
+void startCollectData(void *data);


### PR DESCRIPTION
Fixes bug introduced in 245542a99, the time parameter was not removed from the declaration in the header.