### PR TITLE
Use dynamic_cast in unique_ptr serialization

### DIFF
--- a/src/util/pup_stl.h
+++ b/src/util/pup_stl.h
@@ -474,9 +474,9 @@ using Requires = typename requires_impl<
     PUP::able* t1 = nullptr;
     if (p.isUnpacking()) {
       p | t1;
-      t.reset((T*)t1);
+      t.reset(dynamic_cast<T*>(t1));
     } else {
-      t1 = (PUP::able*)t.get();
+      t1 = dynamic_cast<PUP::able*>(t.get());
       p | t1;
     }
   }


### PR DESCRIPTION
Diamond inheritance patterns like:
```
    PUP::able
  /   \
/       \
A      B
 \     /
  \   /
   C
```

Don't work with a `static_cast` (or C-style cast), and need to be resolved dynamically. While a dynamic_cast is slower than a static_cast, this cost is likely completely negligible compared to the data copying and network transfer that serialization needs.

Fixes #3657