### PR TITLE
CMake: Do not substitute empty CMK_LUSTREAPI with 0

### DIFF
--- a/cmake/detect-features.cmake
+++ b/cmake/detect-features.cmake
@@ -155,7 +155,7 @@ set(optfile ${CMAKE_BINARY_DIR}/include/conv-autoconfig.h)
 file(REMOVE ${optfile})
 
 foreach (v ${_variableNames})
-    if(("${v}" MATCHES "^CMK_"  OR "${v}" MATCHES "^SIZEOF_" OR "${v}" MATCHES "^CHARM_" OR "${v}" MATCHES "^QLOGIC$") AND NOT "${v}" MATCHES "_CODE$")
+    if(("${v}" MATCHES "^CMK_"  OR "${v}" MATCHES "^SIZEOF_" OR "${v}" MATCHES "^CHARM_" OR "${v}" MATCHES "^QLOGIC$") AND NOT "${v}" MATCHES "_CODE$" AND NOT "${v}" MATCHES "^CMK_LUSTREAPI")
         if("${${v}}" STREQUAL "" OR "${${v}}" STREQUAL "FALSE")
             set(${v} 0)
         elseif("${${v}}" STREQUAL "TRUE")


### PR DESCRIPTION
CMK_LUSTREAPI holds the library argument for linking with the Lustre API, "-llustreapi" when it is detected, otherwise "". Special case the replacement that sets empty variables to 0 so that CMK_LUSTREAPI should remain set to "" when Lustre is not detected, otherwise using -module CkIO causes a spurious attempt to link with "0".