### PR TITLE
CI: Use ubuntu-20.04 instead of ubuntu-latest

### DIFF
--- a/.github/workflows/buildold.yml
+++ b/.github/workflows/buildold.yml
@@ -6,7 +6,7 @@ jobs:
   build:
     timeout-minutes: 90
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
     - uses: actions/checkout@v1

--- a/.github/workflows/changa.yml
+++ b/.github/workflows/changa.yml
@@ -4,7 +4,7 @@ on: pull_request
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/charm4py.yml
+++ b/.github/workflows/charm4py.yml
@@ -4,7 +4,7 @@ on: pull_request
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/cuda.yml
+++ b/.github/workflows/cuda.yml
@@ -8,7 +8,7 @@ jobs:
   build:
     timeout-minutes: 45
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
     - uses: actions/checkout@v1

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   sphinx-build:
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/mpi_linux_smp.yml
+++ b/.github/workflows/mpi_linux_smp.yml
@@ -6,7 +6,7 @@ jobs:
   build:
     timeout-minutes: 60
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/namd.yml
+++ b/.github/workflows/namd.yml
@@ -7,7 +7,7 @@ jobs:
   # Since NAMD requires a secret to download its source from Gitlab, CI builds from outside PPl
   # always fail in this test since the secret is not available.
   build-and-test-namd:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/netlrts_linux_i386.yml
+++ b/.github/workflows/netlrts_linux_i386.yml
@@ -6,7 +6,7 @@ jobs:
   build:
     timeout-minutes: 60
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -9,7 +9,7 @@ jobs:
   build:
     timeout-minutes: 45
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/spack.yml
+++ b/.github/workflows/spack.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-20.04, macos-latest]
 
 
     steps:

--- a/.github/workflows/syncft_mpi.yml
+++ b/.github/workflows/syncft_mpi.yml
@@ -6,7 +6,7 @@ jobs:
   build:
     timeout-minutes: 90
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/syncft_netlrts.yml
+++ b/.github/workflows/syncft_netlrts.yml
@@ -6,7 +6,7 @@ jobs:
   build:
     timeout-minutes: 90
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
     - uses: actions/checkout@v1

--- a/.github/workflows/ucx.yml
+++ b/.github/workflows/ucx.yml
@@ -6,7 +6,7 @@ jobs:
   build:
     timeout-minutes: 60
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
     - uses: actions/checkout@v1

--- a/.github/workflows/verbs.yml
+++ b/.github/workflows/verbs.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     timeout-minutes: 45
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
     - uses: actions/checkout@v1


### PR DESCRIPTION
ubuntu-latest is now using 22.04, which has broken several builds, so
explicitly specify 20.04 for now until the issues with 22.04 builds are
fixed
