### PR TITLE
Modifies converse schedeuler to prioritize so nodeGroup messages

### DIFF
--- a/src/conv-core/converse.h
+++ b/src/conv-core/converse.h
@@ -1145,6 +1145,12 @@ typedef struct {
   void *localQ;
   Queue nodeQ;
   Queue schedQ;
+  unsigned short iter; // counting number of sched iterations (hopefully of for it to roll over	 
+  unsigned short nodeGrpFreq; // call nodegroup queue once every 2^nodeGrpFreq iterations with high prio 
+	// should add a function to change this from the program for advanced users. One obstacle: 
+        // it is inside a struct that is on stack, and so not accessible for standalone functions. Need to
+        // resolve this by making a schedule a c++ object, but even then we need a ptr to the currently-running scheduler
+	// 0 means do not check nodegroup queue with high prio.. will be checked with low prio after other Qs
   int *localCounter;
 #if CMK_OBJECT_QUEUE_AVAILABLE
   Queue objQ;


### PR DESCRIPTION
Modifies converse schedeuler's getNextMessage so nodeGroup messages can run with higher priority over local
closes #3674
As it is, nodeGroup messages are not checked until all local and regular Charm queue (prio Q) messages are checked, which cause issues when the applicaiton is using nodeGroup messages in the hope that *some* PE will attend to it quickly. The change makes getNextMessage check nodeGroup queue every 2^nodeGrpFreq iterations with high priority in addition to its usual check after exhasuting local queues (except task Q). This commit has not been tested at all. But pusing it to allow others to help me test/fix it.