### PR TITLE
Deprecate "atomic" SDAG keyword

### DIFF
--- a/doc/charm++/manual.rst
+++ b/doc/charm++/manual.rst
@@ -1659,17 +1659,14 @@ and code blocks that they define. These definitions appear in the
 ``.ci`` file definition of the enclosing chare class as a ‘body’ of an
 entry method following its signature.
 
-The most basic construct in SDAG is the ``serial`` (aka the ``atomic``)
-block. Serial blocks contain sequential C++ code. They’re also called
-atomic because the code within them executes without returning control
-to the Charm++ runtime scheduler, and thus avoiding interruption from
-incoming messages. The keywords atomic and serial are synonymous, and
-you can find example programs that use atomic. However, we recommend the
-use of serial and are considering the deprecation of the atomic keyword.
-Typically serial blocks hold the code that actually deals with incoming
-messages in a ``when`` statement, or to do local operations before a
-message is sent or after it’s received. The earlier example can be
-adapted to use serial blocks as follows:
+The most basic construct in SDAG is the ``serial`` block (previously also
+denoted by ``atomic``, this usage is now deprecated). Serial blocks contain
+sequential C++ code, and the code within them executes to completion without
+returning control to the Charm++ runtime scheduler, thus avoiding interruption
+from incoming messages. Typically, serial blocks hold the code that actually
+deals with incoming messages in a ``when`` statement or performs local
+operations before a message is sent or after it is received. The earlier example
+can be adapted to use serial blocks as follows:
 
 .. code-block:: charmci
 
@@ -12697,7 +12694,7 @@ and cannot appear as variable or entry method names in a ``.ci`` file:
 
 -  SDAG constructs
 
-   -  atomic
+   -  atomic (deprecated)
 
    -  serial
 

--- a/src/langs/sdag/examples/ex0/ex0.sdag
+++ b/src/langs/sdag/examples/ex0/ex0.sdag
@@ -1,16 +1,16 @@
 class example1
 sdagentry init (INIT *m)
 {
-  atomic
+  serial
   { 
     initialize(m); 
     i = 0;
     j = 1;
   }
   when rcv(MSG *m1)
-    atomic{process(m1);}
-  atomic { i++; }
-  atomic { j++; }
-  atomic { i--; }
+    serial{process(m1);}
+  serial { i++; }
+  serial { j++; }
+  serial { i--; }
 }
 

--- a/src/langs/sdag/examples/ex1/ex1.sdag
+++ b/src/langs/sdag/examples/ex1/ex1.sdag
@@ -1,21 +1,21 @@
 class example1
 sdagentry init (INIT *m)
 {
-  atomic { initialize(m); }
+  serial { initialize(m); }
   overlap
   {
     when e1(MSGTYPE1 *m1)
-      atomic {c1(m1);}
+      serial {c1(m1);}
     when e2(MSGTYPE2 *m2)
-      atomic {c2(m2);}
+      serial {c2(m2);}
     {
       when e3(MSGTYPE *m3)
-        atomic {c3(m3);}
+        serial {c3(m3);}
       when e4(MSGTYPE *m4)
-        atomic {c4(m4);}
+        serial {c4(m4);}
     }
   }
   when e3(MSGTYPE *m3)
-    atomic{c3(m3);}
+    serial{c3(m3);}
 }
 

--- a/src/langs/sdag/examples/ex2/ex2.sdag
+++ b/src/langs/sdag/examples/ex2/ex2.sdag
@@ -1,12 +1,12 @@
 class mult_chare
 sdagentry init(MSG *msg)
 {
-  atomic
+  serial
   {
     MyChareID(&mychareid);
     TblFind(ATable, msg->row_index, recv_row, &mychareid, TBL_NEVER_WAIT);
     TblFind(BTable, msg->col_index, revc_col, &mychareid, TBL_NEVER_WAIT);
   }
   when recv_row(TBL_MSG *row), recv_col(TBL_MSG *col)
-    atomic { multiply(row->data, col->data); }
+    serial { multiply(row->data, col->data); }
 }

--- a/src/langs/sdag/examples/ex3/ex3.sdag
+++ b/src/langs/sdag/examples/ex3/ex3.sdag
@@ -2,12 +2,12 @@ class jacobi
 
 sdagentry init(MSGINIT *msg)
 {
-  atomic {
+  serial {
     initialize();
     convdone = FALSE;
   }
   while(!convdone) {
-    atomic {
+    serial {
       for (dir=0; dir<4; dir++) {
         m[dir] = copy_boundary(dir);
         SendMsgBranch(entry_no[dir],m[dir],nbr[dir]);
@@ -15,13 +15,13 @@ sdagentry init(MSGINIT *msg)
     }
     when NORTH(BOUNDARY *north), SOUTH(BOUNDARY *south), 
          EAST(BOUNDARY *east), WEST(BOUNDARY *west) {
-      atomic {
+      serial {
         update(north, south, east, west);
         reduction(my_conv, CONVERGE, &mycid);
       }
     }
     when CONVERGE(CONV *conv)
-      atomic{convdone = conv->done;}
+      serial{convdone = conv->done;}
   }
-  atomic { print_results(); }
+  serial { print_results(); }
 }

--- a/src/langs/sdag/examples/ex4/ex4.sdag
+++ b/src/langs/sdag/examples/ex4/ex4.sdag
@@ -2,12 +2,12 @@ class Harlow_Welch
 
 sdagentry init(MSGINIT *msg)
 {
-  atomic { initialize(); }
+  serial { initialize(); }
   forall[i](0:Z-1,1)
-    atomic { convdone[i] = FALSE; }
+    serial { convdone[i] = FALSE; }
   forall[i](0:Z-1,1) {
     while(!convdone[i]) {
-      atomic {
+      serial {
         for (dir=0; dir<4; dir++) {
           m[i][dir] = copy_boundary(i,dir);
           SendMsgBranch(entry_no[dir],m[i][dir],nbr[i][dir]);
@@ -15,15 +15,15 @@ sdagentry init(MSGINIT *msg)
       }
       when NORTH(BOUNDARY *north), SOUTH(BOUNDARY *south), 
            EAST(BOUNDARY *east), WEST(BOUNDARY *west) {
-        atomic {
+        serial {
           update(i, north, south, east, west);
           reduction(my_conv, i, CONVERGE, &mycid);
         }
       }
       when CONVERGE[i](CONV *conv)
-        atomic{convdone[i] = conv->done;}
+        serial{convdone[i] = conv->done;}
     }
   }
-  atomic { print_results(); }
+  serial { print_results(); }
 }
 

--- a/src/langs/sdag/examples/ex5/ex5.sdag
+++ b/src/langs/sdag/examples/ex5/ex5.sdag
@@ -2,7 +2,7 @@ class example
 
 sdagentry sample (M *msg)
 {
-  atomic{
+  serial{
     i=0;
     MyChareID(&thisID);
     buf1 = (M *) CkAllocMsg(M);
@@ -14,11 +14,11 @@ sdagentry sample (M *msg)
   }
   overlap {
     when ep1(M *m1), ep2(M *m2) {
-      atomic { i++; }
+      serial { i++; }
     }
     when ep3(M *m3) {
-      atomic { i += 2; }
+      serial { i += 2; }
     }
   }
-  atomic{CkPrintf("i = %d\n");}
+  serial{CkPrintf("i = %d\n");}
 }

--- a/src/langs/sdag/examples/lu/lu.sdag
+++ b/src/langs/sdag/examples/lu/lu.sdag
@@ -2,7 +2,7 @@ class cube
 
 sdagentry iterations (InitMessage *mesg)
 {
-  atomic {
+  serial {
     Initialization(); 
     SendMessage(xmnbr,rhs_entry_xp1,xmmsg); 
     SendMessage(xpnbr,rhs_entry_xm1,xpmsg);
@@ -12,23 +12,23 @@ sdagentry iterations (InitMessage *mesg)
     SendMessage(zpnbr,rhs_entry_zm1,zpmsg);
   }
   while(iter<maxiter) {
-    atomic { rhs_init(); }
+    serial { rhs_init(); }
     overlap {
       when rhs_entry_xm1(Boundary *xm1), 
            rhs_entry_xp1(Boundary *xp1) {
-        atomic {rhs_x(xm1,xp1);}
+        serial {rhs_x(xm1,xp1);}
       }
       when rhs_entry_ym1(Boundary *ym1), 
            rhs_entry_yp1(Boundary *yp1) {
-        atomic {rhs_y(ym1,yp1); }
+        serial {rhs_y(ym1,yp1); }
       }
       when rhs_entry_zm1(Boundary *zm1), 
            rhs_entry_yp1(Boundary *zp1) {
-        atomic {rhs_z(zm1,zp1); }
+        serial {rhs_z(zm1,zp1); }
       }
     }
     if(x==0 && y==0 && z==0) {
-      atomic {
+      serial {
         SendMessage(xpnbr,XmBoundary,xmsg);
         SendMessage(ypnbr,YmBoundary,ymsg);
         SendMessage(zpnbr,ZmBoundary,zmsg);
@@ -36,16 +36,16 @@ sdagentry iterations (InitMessage *mesg)
     }
     overlap {
       when XmBoundary(Boundary *xmmsg) {
-        atomic {CopyMessageX(xmmsg); }
+        serial {CopyMessageX(xmmsg); }
       }
       when YmBoundary(Boundary *ymmsg) {
-        atomic {CopyMessageY(ymmsg); }
+        serial {CopyMessageY(ymmsg); }
       }
       when ZmBoundary(Boundary *zmmsg) {
-        atomic {CopyMessageZ(zmmsg); }
+        serial {CopyMessageZ(zmmsg); }
       }
     }
-    atomic {
+    serial {
       blts();
       jacld();
       SendMessage(xpnbr);
@@ -53,7 +53,7 @@ sdagentry iterations (InitMessage *mesg)
       SendMessage(zpnbr);
     }
     if(x==maxx && y==maxy && z==maxz) {
-      atomic {
+      serial {
         SendMessage(xmnbr,XpBoundary,xmsg);
         SendMessage(ymnbr,YpBoundary,ymsg);
         SendMessage(zmnbr,ZpBoundary,zmsg);
@@ -61,16 +61,16 @@ sdagentry iterations (InitMessage *mesg)
     }
     overlap {
       when XpBoundary(Boundary *xmsg) {
-        atomic {CopyMessageX(xmsg); }
+        serial {CopyMessageX(xmsg); }
       }
       when YpBoundary(Boundary *ymsg) {
-        atomic {CopyMessageY(ymsg); }
+        serial {CopyMessageY(ymsg); }
       }
       when ZpBoundary(Boundary *zmsg) {
-        atomic {CopyMessageZ(zmsg); }
+        serial {CopyMessageZ(zmsg); }
       }
     }
-    atomic {
+    serial {
       buts();
       jacu();
       SendMessage(xmnbr);

--- a/src/langs/sdag/examples/ring/ring.sdag
+++ b/src/langs/sdag/examples/ring/ring.sdag
@@ -1,7 +1,7 @@
 class example 
 sdagentry sample (M *msg)
 {
-  atomic {
+  serial {
     i=0;
     MyChareID(&thisID);
     buf1 = (M *) CkAllocMsg(M);
@@ -10,11 +10,11 @@ sdagentry sample (M *msg)
   while(i<NITER)
   {
     when ep1(M *m1){
-      atomic {SendMsg(ep2, m1, &thisID);}
+      serial {SendMsg(ep2, m1, &thisID);}
     }
     when ep2(M *m2) {
-      atomic{SendMsg(ep1, m2, &thisID);}
+      serial{SendMsg(ep1, m2, &thisID);}
     }
-    atomic { i++; }
+    serial { i++; }
   }
 }

--- a/src/libs/ck-libs/completion/completion.ci
+++ b/src/libs/ck-libs/completion/completion.ci
@@ -10,7 +10,7 @@ module completion {
     entry void start_detection(int num_producers,
                                CkCallback start, CkCallback allProduced, CkCallback finish,
                                int prio_) {
-      atomic {
+      serial {
         CkAssert(!running);
         running = true;
         prio = prio_;
@@ -20,23 +20,23 @@ module completion {
       }
 
       while (producers_done_global < producers_total) {
-        atomic {
+        serial {
           contribute(sizeof(int), &producers_done_local, CkReduction::sum_int,
                      CkCallback(CkReductionTarget(CompletionDetector, producers_done),
                                 thisgroup));
         }
-        when producers_done(int producers_done_global_) atomic {
+        when producers_done(int producers_done_global_) serial {
           producers_done_global = producers_done_global_;
         }
       }
 
-      atomic {
+      serial {
         if (CkMyPe() == 0 && !allProduced.isInvalid())
           allProduced.send();
       }
 
       while (unconsumed > 0) {
-        atomic {
+        serial {
           int counts[2];
           counts[0] = produced; // Move up to first reduction loop
           counts[1] = consumed;
@@ -44,12 +44,12 @@ module completion {
                      CkCallback(CkReductionTarget(CompletionDetector, count_consumed),
                                 thisgroup));
         }
-        when count_consumed(int produced_global, int consumed_global) atomic {
+        when count_consumed(int produced_global, int consumed_global) serial {
           unconsumed = produced_global - consumed_global;
         }
       }
 
-      atomic "completion finished" {
+      serial "completion finished" {
         init();
         CkAssert(!finish.isInvalid());
         contribute(finish);


### PR DESCRIPTION
From @stwhite91's suggestion here: https://github.com/UIUC-PPL/charm/discussions/3682#discussioncomment-4768759. This is the only `.ci` file my grep found that used `atomic`. Are there other examples that use it, @stwhite91?