### PR TITLE
CI: Trigger on "merge_group" event to support GitHub merge queues

### DIFF
--- a/.github/workflows/buildold.yml
+++ b/.github/workflows/buildold.yml
@@ -1,6 +1,6 @@
 name: NetLRTS Linux buildold
 
-on: pull_request
+on: [pull_request, merge_group]
 
 jobs:
   build:

--- a/.github/workflows/changa.yml
+++ b/.github/workflows/changa.yml
@@ -1,6 +1,6 @@
 name: ChaNGa
 
-on: pull_request
+on: [pull_request, merge_group]
 
 jobs:
   build:

--- a/.github/workflows/charm4py.yml
+++ b/.github/workflows/charm4py.yml
@@ -1,6 +1,6 @@
 name: Charm4py
 
-on: pull_request
+on: [pull_request, merge_group]
 
 jobs:
   build:

--- a/.github/workflows/cuda.yml
+++ b/.github/workflows/cuda.yml
@@ -2,7 +2,7 @@ name: NetLRTS Linux CUDA buildonly
 
 # Buildonly test, as CUDA needs an actual device to run.
 
-on: pull_request
+on: [pull_request, merge_group]
 
 jobs:
   build:

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -4,6 +4,7 @@ name: Sphinx-doc
 # in doc/ is changed.
 
 on:
+  merge_group:
   pull_request:
     paths: 
       - 'doc/**'

--- a/.github/workflows/mpi_linux_smp.yml
+++ b/.github/workflows/mpi_linux_smp.yml
@@ -1,6 +1,6 @@
 name: MPI Linux SMP
 
-on: pull_request
+on: [pull_request, merge_group]
 
 jobs:
   build:

--- a/.github/workflows/multicore_darwin.yml
+++ b/.github/workflows/multicore_darwin.yml
@@ -1,6 +1,6 @@
 name: Multicore Darwin tracing
 
-on: pull_request
+on: [pull_request, merge_group]
 
 jobs:
   build:

--- a/.github/workflows/namd.yml
+++ b/.github/workflows/namd.yml
@@ -1,6 +1,6 @@
 name: NAMD
 
-on: pull_request
+on: [pull_request, merge_group]
 
 jobs:
   # Not named 'build' since 'build' is used by our CI for builds that must succeed before merge.

--- a/.github/workflows/netlrts_darwin.yml
+++ b/.github/workflows/netlrts_darwin.yml
@@ -1,6 +1,6 @@
 name: NetLRTS Darwin
 
-on: pull_request
+on: [pull_request, merge_group]
 
 jobs:
   build:

--- a/.github/workflows/netlrts_linux_i386.yml
+++ b/.github/workflows/netlrts_linux_i386.yml
@@ -1,6 +1,6 @@
 name: NetLRTS Linux i386
 
-on: pull_request
+on: [pull_request, merge_group]
 
 jobs:
   build:

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -3,7 +3,7 @@ name: ShellCheck
 # See https://github.com/koalaman/shellcheck/wiki
 # for explanations of ShellCheck error codes
 
-on: pull_request
+on: [pull_request, merge_group]
 
 jobs:
   build:

--- a/.github/workflows/spack.yml
+++ b/.github/workflows/spack.yml
@@ -1,6 +1,6 @@
 name: Spack
 
-on: pull_request
+on: [pull_request, merge_group]
 
 jobs:
   build:
@@ -27,7 +27,10 @@ jobs:
         sed -i -e 's,="main",="${{ github.head_ref }}",' var/spack/repos/builtin/packages/charmpp/package.py
 
         # Use a fork, not the main repo
-        sed -i -e 's,UIUC-PPL/charm.git,${{github.event.pull_request.head.repo.full_name}},' var/spack/repos/builtin/packages/charmpp/package.py
+        # If in merge_group mode, the branch should be created in the main repo
+        if [[ ${{ github.event_name }} == 'pull_request' ]]; then
+          sed -i -e 's,UIUC-PPL/charm.git,${{github.event.pull_request.head.repo.full_name}},' var/spack/repos/builtin/packages/charmpp/package.py
+        fi
 
         # Compile with debug symbols
         sed -i -e 's,build(target,options.append("-g"); build(target,' var/spack/repos/builtin/packages/charmpp/package.py

--- a/.github/workflows/syncft_mpi.yml
+++ b/.github/workflows/syncft_mpi.yml
@@ -1,6 +1,6 @@
 name: MPI Linux SyncFT
 
-on: pull_request
+on: [pull_request, merge_group]
 
 jobs:
   build:

--- a/.github/workflows/syncft_netlrts.yml
+++ b/.github/workflows/syncft_netlrts.yml
@@ -1,6 +1,6 @@
 name: NetLRTS Linux SyncFT
 
-on: pull_request
+on: [pull_request, merge_group]
 
 jobs:
   build:

--- a/.github/workflows/ucx.yml
+++ b/.github/workflows/ucx.yml
@@ -1,6 +1,6 @@
 name: UCX Linux
 
-on: pull_request
+on: [pull_request, merge_group]
 
 jobs:
   build:

--- a/.github/workflows/verbs.yml
+++ b/.github/workflows/verbs.yml
@@ -4,7 +4,7 @@ name: Verbs Linux Buildonly Tarball
 # Also test packaging a tarball and building from it.
 # Since it is buildonly, test both build and buildold with the tarball.
 
-on: pull_request
+on: [pull_request, merge_group]
 
 jobs:
   build:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -1,6 +1,6 @@
 name: NetLRTS Windows
 
-on: pull_request
+on: [pull_request, merge_group]
 
 jobs:
   build:


### PR DESCRIPTION
Separately, I've created a request with CircleCI to enable testing the branches created by the merge queue feature (as per https://github.com/community/community/discussions/38199 and https://circleci.com/docs/github-integration/, I've asked them to add `gh\-readonly\-queue.\*` to the allow list for Charm).

_Update: CircleCI support have added support for testing merge queue branches to our account, so it should all be in working order now._