### PR TITLE
Converse: Fix and cleanup padding

### DIFF
--- a/src/arch/verbs/machine-ibverbs.C
+++ b/src/arch/verbs/machine-ibverbs.C
@@ -306,13 +306,12 @@ struct infiOtherNodeData{
 Memory management structures and types
 *****************/
 
-struct infiCmiChunkHeaderStruct;
 
 typedef struct infiCmiChunkMetaDataStruct {
 	struct ibv_mr *key;
 	int poolIdx;
 	void *nextBuf;
-	struct infiCmiChunkHeaderStruct *owner;
+	struct CmiChunkHeader *owner;
 	int count;
 
 #if THREAD_MULTI_POOL
@@ -323,14 +322,14 @@ typedef struct infiCmiChunkMetaDataStruct {
 
 
 
-#define METADATAFIELD(m) (((infiCmiChunkHeader *)m)[-1].metaData)
+#define METADATAFIELD(m) (((CmiChunkHeader *)m)[-1].metaData)
 
 #if CMK_ONESIDED_IMPL
 #include "machine-onesided.h"
 #endif
 
 typedef struct {
-	int size;//without infiCmiChunkHeader
+	int size;//without CmiChunkHeader
 	void *startBuf;
 	int count;
 } infiCmiChunkPool;
@@ -2439,8 +2438,8 @@ Register memory for a part of a received multisend message
 *************/
 infiCmiChunkMetaData *registerMultiSendMesg(char *msg,int size){
 	infiCmiChunkMetaData *metaData = (infiCmiChunkMetaData *)malloc(sizeof(infiCmiChunkMetaData));
-	char *res=msg-sizeof(infiCmiChunkHeader);
-	metaData->key = ibv_reg_mr(context->pd,res,(size+sizeof(infiCmiChunkHeader)),IBV_ACCESS_REMOTE_READ | IBV_ACCESS_LOCAL_WRITE | IBV_ACCESS_REMOTE_WRITE);
+	char *res=msg-sizeof(CmiChunkHeader);
+	metaData->key = ibv_reg_mr(context->pd,res,(size+sizeof(CmiChunkHeader)),IBV_ACCESS_REMOTE_READ | IBV_ACCESS_LOCAL_WRITE | IBV_ACCESS_REMOTE_WRITE);
 #if CMK_IBVERBS_STATS
 	numCurReg++;
 	numReg++;
@@ -2460,7 +2459,7 @@ infiCmiChunkMetaData *registerMultiSendMesg(char *msg,int size){
 static inline void fillBufferPools(void){
 	int nodeSize, poolIdx, thread;
 	infiCmiChunkMetaData *metaData;		
-	infiCmiChunkHeader *hdr;
+	CmiChunkHeader *hdr;
 	int allocSize;
 	int count=1;
 	int i;
@@ -2479,15 +2478,15 @@ static inline void fillBufferPools(void){
 			}else{
 				count = 1;
 			}
-			posix_memalign((void **)&res, ALIGN_BYTES, (allocSize+sizeof(infiCmiChunkHeader))*count);
-			hdr = (infiCmiChunkHeader *)res;
-			key = ibv_reg_mr(context->pd,res,(allocSize+sizeof(infiCmiChunkHeader))*count,IBV_ACCESS_REMOTE_READ | IBV_ACCESS_LOCAL_WRITE | IBV_ACCESS_REMOTE_WRITE);
+			posix_memalign((void **)&res, ALIGN_BYTES, (allocSize+sizeof(CmiChunkHeader))*count);
+			hdr = (CmiChunkHeader *)res;
+			key = ibv_reg_mr(context->pd,res,(allocSize+sizeof(CmiChunkHeader))*count,IBV_ACCESS_REMOTE_READ | IBV_ACCESS_LOCAL_WRITE | IBV_ACCESS_REMOTE_WRITE);
 			CmiAssert(key != NULL);
 #if CMK_IBVERBS_STATS
 		numCurReg++;
 		numReg++;
 #endif
-			res += sizeof(infiCmiChunkHeader);
+			res += sizeof(CmiChunkHeader);
 			for(i=0;i<count;i++){
 				metaData = METADATAFIELD(res) = (infiCmiChunkMetaData *)malloc(sizeof(infiCmiChunkMetaData));
 				metaData->key = key;
@@ -2497,16 +2496,16 @@ static inline void fillBufferPools(void){
 				if(i == 0){
 					metaData->owner->metaData->count = count;
 					metaData->nextBuf = NULL;
-                                        infiCmiChunkPools[thread][poolIdx].startBuf =  res - sizeof(infiCmiChunkHeader);
+                                        infiCmiChunkPools[thread][poolIdx].startBuf =  res - sizeof(CmiChunkHeader);
                                         infiCmiChunkPools[thread][poolIdx].count++;
 				}else{
-					void *startBuf = res - sizeof(infiCmiChunkHeader);
+					void *startBuf = res - sizeof(CmiChunkHeader);
 					metaData->nextBuf = infiCmiChunkPools[thread][poolIdx].startBuf;
 					infiCmiChunkPools[thread][poolIdx].startBuf = startBuf;
 					infiCmiChunkPools[thread][poolIdx].count++;
 				}
 				if(i != count-1){
-					res += (allocSize+sizeof(infiCmiChunkHeader));
+					res += (allocSize+sizeof(CmiChunkHeader));
 				}
 			}
 		}
@@ -2549,7 +2548,7 @@ static inline void *getInfiCmiChunkThread(int dataSize){
 
 	if((poolIdx < INFINUMPOOLS && infiCmiChunkPools[CmiMyRank()][poolIdx].startBuf == NULL) || poolIdx >= INFINUMPOOLS){
 		infiCmiChunkMetaData *metaData;		
-		infiCmiChunkHeader *hdr;
+		CmiChunkHeader *hdr;
 		int allocSize;
 		int count=1;
 		int i;
@@ -2566,11 +2565,11 @@ static inline void *getInfiCmiChunkThread(int dataSize){
 		if(poolIdx < blockThreshold){
 			count = blockAllocRatio;
 		}
-		posix_memalign((void **)&res, ALIGN_BYTES, (allocSize+sizeof(infiCmiChunkHeader))*count);
+		posix_memalign((void **)&res, ALIGN_BYTES, (allocSize+sizeof(CmiChunkHeader))*count);
 		_MEMCHECK(res);
-		hdr = (infiCmiChunkHeader *)res;
+		hdr = (CmiChunkHeader *)res;
 		
-		key = ibv_reg_mr(context->pd,res,(allocSize+sizeof(infiCmiChunkHeader))*count,IBV_ACCESS_REMOTE_READ | IBV_ACCESS_LOCAL_WRITE | IBV_ACCESS_REMOTE_WRITE);
+		key = ibv_reg_mr(context->pd,res,(allocSize+sizeof(CmiChunkHeader))*count,IBV_ACCESS_REMOTE_READ | IBV_ACCESS_LOCAL_WRITE | IBV_ACCESS_REMOTE_WRITE);
 	        if(key == NULL)
                     CmiAbort("ibv_reg_mr failed to pin memory\n");
 #if CMK_IBVERBS_STATS
@@ -2578,7 +2577,7 @@ static inline void *getInfiCmiChunkThread(int dataSize){
 		numReg++;
 #endif
 		
-		origres = (res += sizeof(infiCmiChunkHeader));
+		origres = (res += sizeof(CmiChunkHeader));
 
 		for(i=0;i<count;i++){
 			metaData = METADATAFIELD(res) = (infiCmiChunkMetaData *)malloc(sizeof(infiCmiChunkMetaData));
@@ -2592,14 +2591,14 @@ static inline void *getInfiCmiChunkThread(int dataSize){
 				metaData->owner->metaData->count = count;
 				metaData->nextBuf = NULL;
 			}else{
-				void *startBuf = res - sizeof(infiCmiChunkHeader);
+				void *startBuf = res - sizeof(CmiChunkHeader);
 				metaData->nextBuf = infiCmiChunkPools[CmiMyRank()][poolIdx].startBuf;
 				infiCmiChunkPools[CmiMyRank()][poolIdx].startBuf = startBuf;
 				infiCmiChunkPools[CmiMyRank()][poolIdx].count++;
 				
 			}
 			if(i != count-1){
-				res += (allocSize+sizeof(infiCmiChunkHeader));
+				res += (allocSize+sizeof(CmiChunkHeader));
 			}
 	  }	
 		
@@ -2612,7 +2611,7 @@ static inline void *getInfiCmiChunkThread(int dataSize){
 		infiCmiChunkMetaData *metaData;				
 	
 		res = (char *)infiCmiChunkPools[CmiMyRank()][poolIdx].startBuf;
-		res += sizeof(infiCmiChunkHeader);
+		res += sizeof(CmiChunkHeader);
 
 		MACHSTATE2(2,"Reusing old pool %d buf %p",poolIdx,res);
 		metaData = METADATAFIELD(res);
@@ -2652,7 +2651,7 @@ static inline void *getInfiCmiChunk(int dataSize){
         MACHSTATE2(2,"getInfiCmiChunk for size %d in poolIdx %d",dataSize,poolIdx);
         if((poolIdx < INFINUMPOOLS && infiCmiChunkPools[poolIdx].startBuf == NULL) || poolIdx >= INFINUMPOOLS){
                 infiCmiChunkMetaData *metaData;
-                infiCmiChunkHeader *hdr;
+                CmiChunkHeader *hdr;
                 int allocSize;
                 int count=1;
                 int i;
@@ -2669,16 +2668,16 @@ static inline void *getInfiCmiChunk(int dataSize){
                 if(poolIdx < blockThreshold){
                         count = blockAllocRatio;
                 }
-                posix_memalign((void **)&res, ALIGN_BYTES, (allocSize+sizeof(infiCmiChunkHeader))*count);
-                hdr = (infiCmiChunkHeader *)res;
+                posix_memalign((void **)&res, ALIGN_BYTES, (allocSize+sizeof(CmiChunkHeader))*count);
+                hdr = (CmiChunkHeader *)res;
 
-                key = ibv_reg_mr(context->pd,res,(allocSize+sizeof(infiCmiChunkHeader))*count,IBV_ACCESS_REMOTE_READ | IBV_ACCESS_LOCAL_WRITE | IBV_ACCESS_REMOTE_WRITE);
+                key = ibv_reg_mr(context->pd,res,(allocSize+sizeof(CmiChunkHeader))*count,IBV_ACCESS_REMOTE_READ | IBV_ACCESS_LOCAL_WRITE | IBV_ACCESS_REMOTE_WRITE);
                 CmiAssert(key != NULL);
 #if CMK_IBVERBS_STATS
 		numCurReg++;
 		numReg++;
 #endif
-                origres = (res += sizeof(infiCmiChunkHeader));
+                origres = (res += sizeof(CmiChunkHeader));
 
                 for(i=0;i<count;i++){
                         metaData = METADATAFIELD(res) = (infiCmiChunkMetaData *)malloc(sizeof(infiCmiChunkMetaData));
@@ -2690,14 +2689,14 @@ static inline void *getInfiCmiChunk(int dataSize){
                                 metaData->owner->metaData->count = count;
                                 metaData->nextBuf = NULL;
                         }else{
-                                void *startBuf = res - sizeof(infiCmiChunkHeader);
+                                void *startBuf = res - sizeof(CmiChunkHeader);
                                 metaData->nextBuf = infiCmiChunkPools[poolIdx].startBuf;
                                 infiCmiChunkPools[poolIdx].startBuf = startBuf;
                                 infiCmiChunkPools[poolIdx].count++;
 
                         }
                         if(i != count-1){
-                                res += (allocSize+sizeof(infiCmiChunkHeader));
+                                res += (allocSize+sizeof(CmiChunkHeader));
                         }
           }
 
@@ -2710,7 +2709,7 @@ static inline void *getInfiCmiChunk(int dataSize){
                 infiCmiChunkMetaData *metaData;
 
                 res = (char *)infiCmiChunkPools[poolIdx].startBuf;
-                res += sizeof(infiCmiChunkHeader);
+                res += sizeof(CmiChunkHeader);
 
                 MACHSTATE2(2,"Reusing old pool %d buf %p",poolIdx,res);
                 metaData = METADATAFIELD(res);
@@ -2738,8 +2737,7 @@ void * infi_CmiAlloc(int size){
 	numAlloc++;
 #endif
         if (Cmi_charmrun_fd == -1) {
-          posix_memalign((void **)&res, ALIGN_BYTES, size + sizeof(void*));
-          res += sizeof(void*);
+          posix_memalign((void **)&res, ALIGN_BYTES, size);
           return res;
 	}
 #if THREAD_MULTI_POOL
@@ -2782,8 +2780,7 @@ void infi_CmiFreeDirect(void *ptr){
 /*      if(size > firstBinSize){*/
         infiCmiChunkMetaData *metaData;
         int poolIdx;
-        //there is a infiniband specific header
-        freePtr = (char *)ptr - sizeof(infiCmiChunkHeader);
+        freePtr = (char *)ptr - sizeof(CmiChunkHeader);
         metaData = METADATAFIELD(ptr);
         poolIdx = metaData->poolIdx;
 	infiCmiChunkPool *pool = infiCmiChunkPools[CmiMyRank()] + poolIdx;
@@ -2846,14 +2843,13 @@ void infi_CmiFree(void *ptr){
 
 	MACHSTATE(3,"Freeing");
 
-        if (Cmi_charmrun_fd == -1) { char *res = (char *)ptr; res -= sizeof(void*); free(res); return; }
+        if (Cmi_charmrun_fd == -1) { free(ptr); return; }
         ptr = (char *)ptr + sizeof(CmiChunkHeader);
         size = SIZEFIELD (ptr);
 /*      if(size > firstBinSize){*/
 	infiCmiChunkMetaData *metaData;
         int poolIdx;
-        //there is a infiniband specific header
-        freePtr = (char *)ptr - sizeof(infiCmiChunkHeader);
+        freePtr = (char *)ptr - sizeof(CmiChunkHeader);
         metaData = METADATAFIELD(ptr);
         poolIdx = metaData->poolIdx;
 
@@ -2897,8 +2893,7 @@ void infi_CmiFree(void *ptr){
 /*	if(size > firstBinSize){*/
 		infiCmiChunkMetaData *metaData;
 		int poolIdx;
-		//there is a infiniband specific header
-		freePtr = (char*)ptr - sizeof(infiCmiChunkHeader);
+		freePtr = (char*)ptr - sizeof(CmiChunkHeader);
 		metaData = METADATAFIELD(ptr);
 		poolIdx = metaData->poolIdx;
 		if(poolIdx == INFIMULTIPOOL){

--- a/src/ck-core/envelope.h
+++ b/src/ck-core/envelope.h
@@ -200,13 +200,8 @@ namespace ck {
   UShort epIdx;        /* Entry point to call */                               \
   ck::impl::s_attribs attribs;
 
-class envelope {
+class alignas(ALIGN_BYTES) envelope {
 private:
-
-    class envelopeSizeHelper {
-      CMK_ENVELOPE_FIELDS
-      CMK_ENVELOPE_FT_FIELDS
-    };
 
     #ifdef __clang__
     #pragma GCC diagnostic push
@@ -220,19 +215,6 @@ private:
 public:
 
     CMK_ENVELOPE_FT_FIELDS
-
-    #if defined(__GNUC__) || defined(__clang__)
-    #pragma GCC diagnostic push
-    #pragma GCC diagnostic ignored "-Wpedantic"
-    #if defined(__clang__)
-    #pragma GCC diagnostic ignored "-Wunused-private-field"
-    #endif
-    #endif
-    // padding to ensure ALIGN_BYTES alignment
-    UChar align[CkMsgAlignOffset(sizeof(envelopeSizeHelper))];
-    #if defined(__GNUC__) || defined(__clang__)
-    #pragma GCC diagnostic pop
-    #endif
 
     void pup(PUP::er &p);
 #if CMK_REPLAYSYSTEM || CMK_TRACE_ENABLED

--- a/src/ck-core/envelope.h
+++ b/src/ck-core/envelope.h
@@ -200,6 +200,9 @@ namespace ck {
   UShort epIdx;        /* Entry point to call */                               \
   ck::impl::s_attribs attribs;
 
+// alignas is used for padding here, rather than for alignment of the envelope
+// itself, to ensure that the message following the envelope is aligned relative
+// to the start of the envelope.
 class alignas(ALIGN_BYTES) envelope {
 private:
 

--- a/src/conv-core/cmishmem.h
+++ b/src/conv-core/cmishmem.h
@@ -33,28 +33,18 @@ constexpr auto defaultTimeout = 4;
 }  // namespace ipc
 }  // namespace cmi
 
-// TODO ( find better names than src/dst? )
-#define CMK_IPC_BLOCK_FIELDS \
-  int src;                   \
-  std::uintptr_t orig;       \
-  int dst;                   \
-  std::uintptr_t next;       \
-  std::size_t size;
-
-struct CmiIpcBlock {
+struct alignas(ALIGN_BYTES) CmiIpcBlock {
+  // TODO ( find better names than src/dst? )
+public:
   // "home" rank of the block
- private:
-  class blockSizeHelper_ {
-    CMK_IPC_BLOCK_FIELDS;
-  };
-
- public:
-  CMK_IPC_BLOCK_FIELDS;
+  int src;
+  std::uintptr_t orig;
+  int dst;
+  std::uintptr_t next;
+  std::size_t size;
 
   CmiIpcBlock(std::size_t size_, std::uintptr_t orig_)
       : orig(orig_), next(cmi::ipc::nil), size(size_) {}
-
-  char padding[(sizeof(blockSizeHelper_) % ALIGN_BYTES)];
 };
 
 struct CmiIpcManager;

--- a/src/conv-core/cmishmem.h
+++ b/src/conv-core/cmishmem.h
@@ -38,8 +38,8 @@ struct alignas(ALIGN_BYTES) CmiIpcBlock {
 public:
   // "home" rank of the block
   int src;
-  std::uintptr_t orig;
   int dst;
+  std::uintptr_t orig;
   std::uintptr_t next;
   std::size_t size;
 

--- a/src/conv-core/cmishmem.h
+++ b/src/conv-core/cmishmem.h
@@ -33,6 +33,8 @@ constexpr auto defaultTimeout = 4;
 }  // namespace ipc
 }  // namespace cmi
 
+// alignas is used for padding here, rather than for alignment of the
+// CmiIpcBlock itself.
 struct alignas(ALIGN_BYTES) CmiIpcBlock {
   // TODO ( find better names than src/dst? )
 public:

--- a/src/conv-core/converse.h
+++ b/src/conv-core/converse.h
@@ -780,31 +780,17 @@ CpvExtern(int, _curRestartPhase);      /* number of restarts */
 /** This header goes before each chunk of memory allocated with CmiAlloc. 
     See the comment in convcore.C for details on the fields.
 */
-struct CmiChunkHeader {
+struct
+#if !(CMK_USE_IBVERBS | CMK_USE_IBUD)
+  alignas(ALIGN_BYTES) // If in verbs mode, align in infiCmiChunkHeader instead
+#endif
+CmiChunkHeader {
   int size;
 private:
 #if CMK_SMP
   std::atomic<int> ref;
 #else
   int ref;
-#endif
-#if ALIGN_BYTES > 8
-  #if defined(__GNUC__) || defined(__clang__)
-  #pragma GCC diagnostic push
-  #pragma GCC diagnostic ignored "-Wpedantic"
-  #if defined(__clang__)
-  #pragma GCC diagnostic ignored "-Wunused-private-field"
-  #endif
-  #endif
-  char align[ALIGN_BYTES
-             - sizeof(int)*2
-#if (CMK_USE_IBVERBS || CMK_USE_IBUD)
-             - sizeof(void *)
-#endif
-            ];
-  #if defined(__GNUC__) || defined(__clang__)
-  #pragma GCC diagnostic pop
-  #endif
 #endif
 public:
   CmiChunkHeader() = default;
@@ -838,16 +824,9 @@ public:
 #if CMK_USE_IBVERBS | CMK_USE_IBUD
 struct infiCmiChunkMetaDataStruct;
 
-#define CMI_INFI_CHUNK_HEADER_FIELDS \
-struct infiCmiChunkMetaDataStruct *metaData;\
-CmiChunkHeader chunkHeader;
-
-struct infiCmiChunkHeaderHelper{
-  CMI_INFI_CHUNK_HEADER_FIELDS
-};
-
-typedef struct infiCmiChunkHeaderStruct{
-  CMI_INFI_CHUNK_HEADER_FIELDS
+typedef struct alignas(ALIGN_BYTES) infiCmiChunkHeaderStruct {
+  struct infiCmiChunkMetaDataStruct *metaData;
+  CmiChunkHeader chunkHeader;
 } infiCmiChunkHeader;
 
 struct infiCmiChunkMetaDataStruct *registerMultiSendMesg(char *msg,int msgSize);

--- a/src/conv-core/converse.h
+++ b/src/conv-core/converse.h
@@ -782,6 +782,9 @@ CpvExtern(int, _curRestartPhase);      /* number of restarts */
 */
 struct
 #if !(CMK_USE_IBVERBS | CMK_USE_IBUD)
+// alignas is used for padding here, rather than for alignment of the
+// CmiChunkHeader itself, to ensure that the chunk following the envelope is
+// aligned relative to the start of the header.
   alignas(ALIGN_BYTES) // If in verbs mode, align in infiCmiChunkHeader instead
 #endif
 CmiChunkHeader {

--- a/tests/charm++/alignment/alignmentCheck.C
+++ b/tests/charm++/alignment/alignmentCheck.C
@@ -36,11 +36,7 @@ void alignmentTest(std::vector<TestMessage*> &allMsgs, const std::string &identi
     TestMessage *msg = allMsgs[i];
     envelope *env = UsrToEnv(msg);
 
-#if CMK_USE_IBVERBS | CMK_USE_IBUD
-    intptr_t startHdr = (intptr_t) &(((infiCmiChunkHeader *) env)[-1]);
-#else
     intptr_t startHdr = (intptr_t) BLKSTART(env);
-#endif
     intptr_t startEnv = (intptr_t) env;
     intptr_t startUsr = (intptr_t) msg;
     intptr_t startVar1 = (intptr_t) msg->varArray1;


### PR DESCRIPTION
Use alignas instead of error-prone explicit padding with char[].
