### PR TITLE
MPI layer: add build-time option to use MPI_Alloc_mem inside CmiAlloc

### DIFF
--- a/src/arch/mpi/machine.C
+++ b/src/arch/mpi/machine.C
@@ -222,6 +222,11 @@ static void reportMsgHistogramInfo(void);
 
 #define USE_MPI_CTRLMSG_SCHEME 0
 
+/* to use MPI_Alloc_mem inside CmiAlloc */
+#ifndef CMK_USE_MPI_ALLOC_MEM
+#define CMK_USE_MPI_ALLOC_MEM USE_MPI_CTRLMSG_SCHEME
+#endif
+
 /* Defining this macro will use MPI_Irecv instead of MPI_Recv for
  * large messages. This could save synchronization overhead caused by
  * the rzv protocol used by MPI

--- a/src/conv-core/convcore.C
+++ b/src/conv-core/convcore.C
@@ -160,7 +160,7 @@ void CldModuleInit(char **);
 
 #include "quiescence.h"
 
-#if USE_MPI_CTRLMSG_SCHEME && CMK_CONVERSE_MPI
+#if CMK_CONVERSE_MPI && CMK_USE_MPI_ALLOC_MEM
 #include <mpi.h>
 #endif
 
@@ -3227,7 +3227,7 @@ void *CmiAlloc(int size)
   res =(char *) LrtsAlloc(size, sizeof(CmiChunkHeader));
 #elif CONVERSE_POOL
   res =(char *) CmiPoolAlloc(size+sizeof(CmiChunkHeader));
-#elif USE_MPI_CTRLMSG_SCHEME && CMK_CONVERSE_MPI
+#elif CMK_CONVERSE_MPI && CMK_USE_MPI_ALLOC_MEM
   MPI_Alloc_mem(size+sizeof(CmiChunkHeader), MPI_INFO_NULL, &res);
 #elif CMK_SMP && CMK_PPC_ATOMIC_QUEUE
   res = (char *) CmiAlloc_ppcq(size+sizeof(CmiChunkHeader));
@@ -3373,7 +3373,7 @@ void CmiFree(void *blk)
     LrtsFree(BLKSTART(parentBlk));
 #elif CONVERSE_POOL
     CmiPoolFree(BLKSTART(parentBlk));
-#elif USE_MPI_CTRLMSG_SCHEME && CMK_CONVERSE_MPI
+#elif CMK_CONVERSE_MPI && CMK_USE_MPI_ALLOC_MEM
     MPI_Free_mem(parentBlk);
 #elif CMK_SMP && CMK_PPC_ATOMIC_QUEUE
     CmiFree_ppcq(BLKSTART(parentBlk));


### PR DESCRIPTION
Enables building with "-DCMK_USE_MPI_ALLOC_MEM=1" to make CmiAlloc use
MPI_Alloc_mem internally, independent of USE_MPI_CTRLMSG_SCHEME.