### PR TITLE
CcdCallbacks: manage timer-based cond callbacks properly

### DIFF
--- a/src/conv-core/converse.h
+++ b/src/conv-core/converse.h
@@ -1096,14 +1096,21 @@ typedef void (*CmiStartFn)(int argc, char **argv);
   @addtogroup ConverseScheduler
   @{
 */
-extern void  CcdCallBacks(void);
 #if CSD_NO_PERIODIC
 #define CsdPeriodic()
 #define CsdResetPeriodic()
 #else
+extern void  CcdCallBacks(void);
+extern int CcdNumTimerCBs(void);
 CpvExtern(int, _ccd_numchecks);
 CpvExtern(int, _ccd_heaplen);
-#define CsdPeriodic() do{ if (CpvAccess(_ccd_heaplen) > 0 && CpvAccess(_ccd_numchecks)-- <= 0) CcdCallBacks(); } while(0)
+CpvExtern(int, _ccd_num_timed_cond_cbs);
+#define CsdPeriodic() \
+  do{ \
+    if ((CcdNumTimerCBs() > 0) && (CpvAccess(_ccd_numchecks)-- <= 0)) { \
+      CcdCallBacks(); \
+    } \
+  } while(0);
 #define CsdResetPeriodic()    CpvAccess(_ccd_numchecks) = 0
 #endif
 
@@ -1785,34 +1792,36 @@ typedef void (*CcdCondFn)(void *userParam);
 typedef void (*CcdVoidFn)(void *userParam,double curWallTime);
 
 /*CPU conditions*/
-#define CcdPROCESSOR_BEGIN_BUSY 0
-#define CcdPROCESSOR_END_IDLE 0 /*Synonym*/
-#define CcdPROCESSOR_BEGIN_IDLE 1
-#define CcdPROCESSOR_END_BUSY 1 /*Synonym*/
-#define CcdPROCESSOR_STILL_IDLE 2
-#define CcdPROCESSOR_LONG_IDLE 3
+#define CcdSCHEDLOOP            0
+#define CcdPROCESSOR_BEGIN_BUSY 1
+#define CcdPROCESSOR_END_IDLE   1 /*Synonym*/
+#define CcdPROCESSOR_BEGIN_IDLE 2
+#define CcdPROCESSOR_END_BUSY   2 /*Synonym*/
+#define CcdPROCESSOR_STILL_IDLE 3
+#define CcdPROCESSOR_LONG_IDLE  4
 
 /*Periodic calls*/
-#define CcdPERIODIC           4 /*every few ms*/
-#define CcdPERIODIC_10ms      5 /*every 10ms (100Hz)*/
-#define CcdPERIODIC_100ms     6 /*every 100ms (10Hz)*/
-#define CcdPERIODIC_1second   7 /*every second*/
-#define CcdPERIODIC_1s        7 /*every second*/
-#define CcdPERIODIC_5s        8 /*every second*/
-#define CcdPERIODIC_5seconds  8 /*every second*/
-#define CcdPERIODIC_10second  9 /*every 10 seconds*/
-#define CcdPERIODIC_10seconds 9 /*every 10 seconds*/
-#define CcdPERIODIC_10s       9 /*every 10 seconds*/
-#define CcdPERIODIC_1minute  10 /*every minute*/
-#define CcdPERIODIC_2minute  11 /*every 2 minute*/
-#define CcdPERIODIC_5minute  12 /*every 5 minute*/
-#define CcdPERIODIC_10minute 13 /*every 10 minutes*/
-#define CcdPERIODIC_1hour    14 /*every hour*/
-#define CcdPERIODIC_12hour   15 /*every 12 hours*/
-#define CcdPERIODIC_1day     16 /*every day*/
+#define CcdPERIODIC_FIRST     5 /*first periodic value*/
+#define CcdPERIODIC           5 /*every few ms*/
+#define CcdPERIODIC_10ms      6 /*every 10ms (100Hz)*/
+#define CcdPERIODIC_100ms     7 /*every 100ms (10Hz)*/
+#define CcdPERIODIC_1second   8 /*every second*/
+#define CcdPERIODIC_1s        8 /*every second*/
+#define CcdPERIODIC_5s        9 /*every second*/
+#define CcdPERIODIC_5seconds  9 /*every second*/
+#define CcdPERIODIC_10second  10 /*every 10 seconds*/
+#define CcdPERIODIC_10seconds 10 /*every 10 seconds*/
+#define CcdPERIODIC_10s       10 /*every 10 seconds*/
+#define CcdPERIODIC_1minute   11 /*every minute*/
+#define CcdPERIODIC_2minute   12 /*every 2 minute*/
+#define CcdPERIODIC_5minute   13 /*every 5 minute*/
+#define CcdPERIODIC_10minute  14 /*every 10 minutes*/
+#define CcdPERIODIC_1hour     15 /*every hour*/
+#define CcdPERIODIC_12hour    16 /*every 12 hours*/
+#define CcdPERIODIC_1day      17 /*every day*/
+#define CcdPERIODIC_LAST      18 /*last periodic value +1*/
 
 /*Other conditions*/
-#define CcdSCHEDLOOP         17
 #define CcdQUIESCENCE        18
 #define CcdTOPOLOGY_AVAIL    19
 #define CcdSIGUSR1           20

--- a/tests/charm++/Makefile
+++ b/tests/charm++/Makefile
@@ -25,6 +25,7 @@ DIRS = \
   zerocopy \
   within_node_bcast \
   longIdle \
+  periodic \
   bombard \
   varTRAM \
 

--- a/tests/charm++/periodic/Makefile
+++ b/tests/charm++/periodic/Makefile
@@ -1,0 +1,25 @@
+-include ../../common.mk
+-include ../../../include/conv-mach-opt.mak
+CHARMC=../../../bin/charmc $(OPTS)
+
+all: periodic
+
+periodic: periodic.decl.h periodic.def.h periodic.C
+	$(CHARMC) -language charm++ periodic.C -o periodic
+
+periodic.decl.h periodic.def.h: periodic.ci
+	$(CHARMC) periodic.ci
+
+clean:
+	rm -f *.decl.h *.def.h *.o periodic charmrun
+
+test: all
+	$(call run, ./periodic +p1 )
+	$(call run, ./periodic +p2 )
+
+testp: all
+	$(call run, ./periodic +p$(P))
+
+smptest:
+	$(call run, ./periodic +p2 ++ppn 2)
+	$(call run, ./periodic +p4 ++ppn 2)

--- a/tests/charm++/periodic/periodic.C
+++ b/tests/charm++/periodic/periodic.C
@@ -1,0 +1,98 @@
+/*
+ * This test starts a timer on the mainchare then broadcasts
+ * over a group to start periodic callbacks which will print
+ * from each PE every second for a total of MAX_COUNTER
+ * seconds before performing a reduction to the mainchare.
+ * The mainchare checks that the run indeed took MAX_COUNTER
+ * seconds at minimum before exiting. If this program hangs,
+ * periodic callbacks are likely not being triggered properly.
+ */
+
+#include "periodic.decl.h"
+
+/* 
+ * Change to 1 in order to test CcdCallFnAfter, otherwise
+ * this tests CcdCallOnConditionKeep.
+ */
+#ifndef CALL_FN_AFTER
+#define CALL_FN_AFTER 0
+#endif
+
+CProxy_main mProxy;
+CProxy_testGroup gProxy;
+
+static constexpr int COUNTER_MAX = 3; /* How many iters or seconds to run for */
+static constexpr double TOL = 0.9;    /* 10% tolerance */
+
+void userFn(void *arg, double time);
+
+class main : public CBase_main {
+  double startTime;
+  public:
+
+  main(CkArgMsg *msg) {
+    delete msg;
+
+    mProxy = thisProxy;
+    startTime = CkWallTimer();
+    gProxy = CProxy_testGroup::ckNew(COUNTER_MAX);
+    CkPrintf("Testing Converse periodic callbacks on %d PEs for %d seconds\n",
+             CkNumPes(), COUNTER_MAX);
+
+    gProxy.testPeriodic();
+  }
+
+  void done() {
+    /* Time taken for the test should be at least MAX_COUNTER seconds */
+    double totalTime = CkWallTimer() - startTime;
+    if (totalTime >= ((double)COUNTER_MAX * TOL)) {
+      CkPrintf("CcdPeriodic test PASSED\n");
+      CkExit();
+    }
+    else {
+      CkAbort("CcdPeriodic test FAILED: run only took %f seconds (less than minimum %d seconds)!\n",
+              totalTime, COUNTER_MAX);
+    }
+  }
+};
+
+
+class testGroup : public CBase_testGroup {
+  int counter;
+  CkCallback cb;
+
+  public:
+  testGroup(int max) {
+    CkAssert(max > 0);
+    counter = max;
+    cb = CkCallback(CkReductionTarget(main, done), mProxy);
+  }
+
+  void testPeriodic(void) {
+#if CALL_FN_AFTER
+    CcdCallFnAfter((CcdVoidFn)userFn, &counter, 1000 /*ms*/);
+#else
+    CcdCallOnConditionKeep(CcdPERIODIC_1s, (CcdCondFn)userFn, &counter);
+#endif
+  }
+
+  void reduceToCompletion() {
+    contribute(cb);
+  }
+};
+
+void userFn(void *arg, double time) {
+  int *counter = (int *)arg;
+  (*counter)--;
+  CmiPrintf("PE %d inside periodic user callback fn: counter %d, time %f\n", CkMyPe(), *counter, time);
+  if (*counter == 0) {
+    gProxy.ckLocalBranch()->reduceToCompletion();
+  }
+#if CALL_FN_AFTER
+  else {
+    CcdCallFnAfter((CcdVoidFn)userFn, counter, 1000 /*ms*/);
+  }
+#endif
+}
+
+#include "periodic.def.h"

--- a/tests/charm++/periodic/periodic.ci
+++ b/tests/charm++/periodic/periodic.ci
@@ -1,0 +1,15 @@
+mainmodule periodic {
+
+  readonly CProxy_main mProxy;
+  readonly CProxy_testGroup gProxy;
+
+  mainchare main {
+    entry main(CkArgMsg *msg);
+    entry [reductiontarget] void done();
+  }
+
+  group testGroup {
+    entry testGroup(int max);
+    entry void testPeriodic();
+  }
+};


### PR DESCRIPTION
Fix support for timer-based conditional callbacks that was broken by PR #3537,
while still minimizing timer calls when possible.

Also add a test for timer-based conditional callbacks.