### PR TITLE
Verbs: Fix CMI_DEST_RANK_NET macro

### DIFF
--- a/src/arch/netlrts/machine-persistent.C
+++ b/src/arch/netlrts/machine-persistent.C
@@ -17,7 +17,7 @@
  */
 #include "persist_impl.h"
 
-#define CMI_DEST_RANK_NET(msg)	*(int *)(msg)
+#define CMI_DEST_RANK_NET(msg)	((CmiMsgHeaderBasic*)msg)->rank
 int persistentSendMsgHandlerIdx;
 
 static void sendPerMsgHandler(char *msg)

--- a/src/arch/verbs/machine-persistent.C
+++ b/src/arch/verbs/machine-persistent.C
@@ -17,7 +17,7 @@
  */
 #include "persist_impl.h"
 
-#define CMI_DEST_RANK_NET(msg)	*(int *)(msg)
+#define CMI_DEST_RANK_NET(msg)	((CmiMsgHeaderBasic*)msg)->rank
 int persistentSendMsgHandlerIdx;
 
 static void sendPerMsgHandler(char *msg)


### PR DESCRIPTION
Merging #3733 exposed some kind of bug in the Verbs layer causing many tests to fail during autobuild, all in the same way.

Verbs non-SMP: `Fatal error on PE 0> [0] Assertion "startNode >=0 && startNode<_Cmi_numpes" failed in file src/arch/util/machine-broadcast.C line 141`
Verbs SMP: `Fatal error on PE 2> [2] Assertion "((CmiMsgHeaderBasic *)msg)->rank==0" failed in file src/arch/util/machine-broadcast.C line 66`