### PR TITLE
Fix FTBFS of NAMD when using GCC 13.1 with --std=c++20

### DIFF
--- a/src/util/ckhashtable.h
+++ b/src/util/ckhashtable.h
@@ -437,9 +437,9 @@ as a fast key like this:
 template <class T> class CkHashtableAdaptorT {
 	T val;
 public:
-	CkHashtableAdaptorT<T>(const T &v):val(v) {}
+	CkHashtableAdaptorT(const T &v):val(v) {}
 	/**added to allow pup to do Key k while unPacking*/
-	CkHashtableAdaptorT<T>(){}
+	CkHashtableAdaptorT(){}
 	operator T & () {return val;}
 	operator const T & () const {return val;}
 	inline CkHashCode hash(void) const 


### PR DESCRIPTION
The following use of class template fails to build when using GCC 13.1 with --std=c++20:
```
template <typename T>
class Foo {
public:
  Foo<T>() {}
};
```
The extra "<T>" in the constructor should be removed for compilation. NAMD uses `CkHashtableAdaptorT` so I need to remove the redundant `<T>` to make it compiled.