### PR TITLE
Revert Verbs message header padding change

### DIFF
--- a/src/arch/netlrts/machine-dgram.C
+++ b/src/arch/netlrts/machine-dgram.C
@@ -15,10 +15,6 @@
  * @{
  */
 
-#define DGRAM_HEADER_SIZE 8
-
-#define CmiMsgNext(msg) (*((void**)(msg)))
-
 #define DGRAM_ROOTPE_MASK   (0xFFFFu)
 #define DGRAM_SRCPE_MASK    (0xFFFF)
 #define DGRAM_MAGIC_MASK    (0xFF)
@@ -43,6 +39,9 @@ typedef struct {
         unsigned int rootpe:16; /* broadcast root processor */
 } DgramHeader;
 
+#define DGRAM_HEADER_SIZE (sizeof(DgramHeader))
+static_assert(DGRAM_HEADER_SIZE == 4 * sizeof(uint16_t),
+  "DgramHeader must be equivalent to 4x uint16_t");
 
 /* the window size needs to be Cmi_window_size + sizeof(unsigned int) bytes) */
 typedef struct { DgramHeader head; char window[1024]; } DgramAck;
@@ -50,7 +49,7 @@ typedef struct { DgramHeader head; char window[1024]; } DgramAck;
 unsigned char computeCheckSum(unsigned char *data, int len);
 
 #define DgramHeaderMake(ptr, dstrank_, srcpe_, magic_, seqno_, root_) { \
-   DgramHeader *header = (DgramHeader *)(ptr);	\
+   DgramHeader * header = (ptr); \
    header->seqno = seqno_; \
    header->srcpe = srcpe_; \
    header->dstrank = dstrank_; \
@@ -59,7 +58,7 @@ unsigned char computeCheckSum(unsigned char *data, int len);
 }
 
 #define DgramHeaderBreak(ptr, dstrank_, srcpe_, magic_, seqno_, root_) { \
-   DgramHeader *header = (DgramHeader *)(ptr);	\
+   const DgramHeader * header = (ptr); \
    seqno_ = header->seqno; \
    srcpe_ = header->srcpe; \
    dstrank_ = header->dstrank; \
@@ -155,9 +154,6 @@ static void extract_args(char **argv)
   Cmi_comm_periodic_delay=(int)(1000*Cmi_delay_retransmit);
   if (Cmi_comm_periodic_delay>60) Cmi_comm_periodic_delay=60;
   Cmi_comm_clock_delay=(int)(1000*Cmi_ack_delay);
-  if (sizeof(DgramHeader)!=DGRAM_HEADER_SIZE) {
-    CmiAbort("DatagramHeader in machine-dgram.C is the wrong size!\n");
-  }
 }
 
 

--- a/src/arch/netlrts/machine-tcp.C
+++ b/src/arch/netlrts/machine-tcp.C
@@ -315,7 +315,7 @@ static void IntegrateMessageDatagram(char **msg, int len)
   int size;
   
   if (len >= DGRAM_HEADER_SIZE) {
-    DgramHeaderBreak(*msg, rank, srcpe, magic, seqno, broot);
+    DgramHeaderBreak((const DgramHeader *)*msg, rank, srcpe, magic, seqno, broot);
     if (magic == (Cmi_charmrun_pid&DGRAM_MAGIC_MASK)) {
       OtherNode node = nodes_by_pe[srcpe];
       newmsg = node->asm_msg;

--- a/src/arch/pami/conv-common.h
+++ b/src/arch/pami/conv-common.h
@@ -5,7 +5,7 @@
 
 #define CMK_HANDLE_SIGUSR                                  1
 
-#define CMK_MSG_HEADER_EXT_     int root, size; CmiUInt2 rank, hdl,xhdl,info, stratid, redID, padding; unsigned char cksum, magic; CmiUInt1 cmaMsgType:2, nokeep:1;
+#define CMK_MSG_HEADER_EXT_    int root, size; CmiUInt2 rank, hdl,xhdl,info, stratid, redID, padding; unsigned char cksum, magic; CmiUInt1 cmaMsgType:2, nokeep:1;
 
 #define CMK_MSG_HEADER_BASIC  CMK_MSG_HEADER_EXT
 #define CMK_MSG_HEADER_EXT    { CMK_MSG_HEADER_EXT_ }

--- a/src/arch/pamilrts/conv-common.h
+++ b/src/arch/pamilrts/conv-common.h
@@ -11,7 +11,7 @@
 
 //#define  DELTA_COMPRESS                                     1
 #if DELTA_COMPRESS
-#define CMK_MSG_HEADER_EXT_     CmiUInt8 persistRecvHandler; CmiUInt4 compressStart; int root, size; CmiUInt2 rank, hdl,xhdl,info,redID,padding,compress_flag,xxhdl; unsigned char cksum, magic; CmiUInt1 zcMsgType:4, cmaMsgType:2, nokeep:1;
+#define CMK_MSG_HEADER_EXT_    CmiUInt8 persistRecvHandler; CmiUInt4 compressStart; int root, size; CmiUInt2 rank, hdl,xhdl,info,redID,padding,compress_flag,xxhdl; unsigned char cksum, magic; CmiUInt1 zcMsgType:4, cmaMsgType:2, nokeep:1;
 #else
 #define CMK_MSG_HEADER_EXT_    int root, size; CmiUInt2 rank, hdl,xhdl,info,redID,padding; unsigned char cksum, magic; CmiUInt1 zcMsgType:4, cmaMsgType:2, nokeep:1;
 #endif

--- a/src/arch/verbs/conv-common.h
+++ b/src/arch/verbs/conv-common.h
@@ -24,7 +24,7 @@
    of the message and used in the LRTS based CMA implementaion.
 */
 #define CMK_MSG_HEADER_BASIC   CMK_MSG_HEADER_EXT
-#define CMK_MSG_HEADER_EXT_    CmiInt4 root, size; CmiUInt2 d0,d1,d2,d3,hdl,xhdl,info,redID,rank; CmiUInt1 zcMsgType:4, cmaMsgType:2, nokeep:1;
+#define CMK_MSG_HEADER_EXT_    CmiUInt2 d0,d1,d2,d3,hdl,xhdl,info,redID,rank; CmiInt4 root, size; CmiUInt1 zcMsgType:4, cmaMsgType:2, nokeep:1;
 #define CMK_MSG_HEADER_EXT       { CMK_MSG_HEADER_EXT_ }
 
 #define CMK_SPANTREE_MAXSPAN                               4

--- a/src/arch/verbs/conv-mach-syncft.h
+++ b/src/arch/verbs/conv-mach-syncft.h
@@ -4,7 +4,7 @@
 //#undef CMK_MSG_HEADER_EXT
 /* expand the header to store the restart phase counter(pn) */
 #define CMK_MSG_HEADER_BASIC   CMK_MSG_HEADER_EXT
-#define CMK_MSG_HEADER_EXT_    CmiUInt4 root,size; CmiUInt2 d0,d1,d2,d3,hdl,pn,d4,type,xhdl,info,dd,redID,pad2,rank; CmiUInt1 zcMsgType:4, cmaMsgType:2, nokeep:1;
+#define CMK_MSG_HEADER_EXT_    CmiUInt2 d0,d1,d2,d3,hdl,pn,d4,type,xhdl,info,dd,redID,pad2,rank; CmiInt4 root,size; CmiUInt1 zcMsgType:4, cmaMsgType:2, nokeep:1;
 //#define CMK_MSG_HEADER_EXT    { CMK_MSG_HEADER_EXT_ }
 
 #define CmiGetRestartPhase(m)       ((((CmiMsgHeaderExt*)m)->pn))

--- a/src/arch/verbs/machine-ibverbs.C
+++ b/src/arch/verbs/machine-ibverbs.C
@@ -1302,7 +1302,7 @@ void DeliverViaNetwork(OutgoingMsg ogm, OtherNode node, int rank, unsigned int b
 	MACHSTATE3(3,"Sending ogm %p of size %d to %d",ogm,size,node->infiData->nodeNo);
 	//First packet has dgram header, other packets dont
 	
-  DgramHeaderMake(data, rank, ogm->src, Cmi_charmrun_pid, 1, broot);
+	DgramHeaderMake((DgramHeader *)data, rank, ogm->src, Cmi_charmrun_pid, 1, broot);
 	
 	CMI_MSG_SIZE(ogm->data)=ogm->size;
 
@@ -1690,8 +1690,8 @@ static inline void processMessage(int nodeNo,int len,char *msg,const int toBuffe
 		{
 			int size;
 			int rank, srcpe, seqno, magic, i;
-			unsigned int broot;
-			DgramHeaderBreak(msg, rank, srcpe, magic, seqno, broot);
+			int broot;
+			DgramHeaderBreak((const DgramHeader *)msg, rank, srcpe, magic, seqno, broot);
 			size = CMI_MSG_SIZE(msg);
 			MACHSTATE2(3,"START of a new message from node %d of total size %d",nodeNo,size);
 //			CmiAssert(size > 0);
@@ -2096,9 +2096,9 @@ static inline  void processRdmaWC(struct ibv_wc *rdmaWC,const int toBuffer){
 	{
 		int size;
 		int rank, srcpe, seqno, magic, i;
-		unsigned int broot;
+		int broot;
 		char *msg = buffer->buf;
-		DgramHeaderBreak(msg, rank, srcpe, magic, seqno, broot);
+		DgramHeaderBreak((const DgramHeader *)msg, rank, srcpe, magic, seqno, broot);
 		size = CMI_MSG_SIZE(msg);
 /*		CmiAssert(size == buffer->size);*/
 		handoverMessage(buffer->buf,size,rank,broot,toBuffer);


### PR DESCRIPTION
After examining the runtime issues experienced with the Verbs layer after #3733, and replicating them with NetLRTS by applying the same change to its headers, I believe it is best to revert the change for now, just for Verbs, because fixing the root of the issue will involve deeper cleanup of NetLRTS and Verbs, which is not worth holding up a release.