### PR TITLE
HAPI createPool() and releasePool(): save chunk addresses for cudaFreeHost()

### DIFF
--- a/src/arch/cuda/hybridAPI/hapi_impl.cpp
+++ b/src/arch/cuda/hybridAPI/hapi_impl.cpp
@@ -1118,6 +1118,7 @@ static void createPool(int *n_buffers, int n_slots, std::vector<BufferPool> &poo
     }
 
     pools[i].head = previous;
+    pools[i].chunk = pinned_chunk;
 #ifdef HAPI_MEMPOOL_DEBUG
     pools[i].num = num_buffers;
 #endif
@@ -1125,10 +1126,12 @@ static void createPool(int *n_buffers, int n_slots, std::vector<BufferPool> &poo
 }
 
 static void releasePool(std::vector<BufferPool> &pools){
+  int device;
+  hapiCheck(cudaGetDevice(&device));
   for (int i = 0; i < pools.size(); i++) {
-    BufferPoolHeader* hdr = pools[i].head;
-    if (hdr != NULL) {
-      hapiCheck(cudaFreeHost((void*)hdr));
+    void* chunk = pools[i].chunk;
+    if (chunk != NULL) {
+      hapiCheck(cudaFreeHost(chunk));
     }
   }
   pools.clear();
@@ -1152,6 +1155,7 @@ static int findPool(size_t size){
       return -1;
     }
     newpool.size = size;
+    newpool.chunk = (void *)newpool.head;
 #ifdef HAPI_MEMPOOL_DEBUG
     newpool.num = 1;
 #endif

--- a/src/arch/cuda/hybridAPI/hapi_impl.h
+++ b/src/arch/cuda/hybridAPI/hapi_impl.h
@@ -33,6 +33,7 @@ typedef struct _bufferPoolHeader {
 typedef struct _bufferPool {
   BufferPoolHeader *head;
   size_t size;
+  void *chunk;
 #ifdef HAPI_MEMPOOL_DEBUG
   int num;
 #endif


### PR DESCRIPTION
This fixes issue #3639 