### PR TITLE
ckio: set AnytimeMigration to false for WriteSession

### DIFF
--- a/src/libs/ck-libs/io/ckio.C
+++ b/src/libs/ck-libs/io/ckio.C
@@ -125,6 +125,7 @@ namespace Ck { namespace IO {
 
           CkArrayOptions sessionOpts(numStripes);
           sessionOpts.setStaticInsertion(true);
+          sessionOpts.setAnytimeMigration(false);
 
           CkCallback sessionInitDone(CkIndex_Director::sessionReady(NULL), thisProxy);
           sessionInitDone.setRefnum(sessionID);


### PR DESCRIPTION
This prevents springCleaning on the WriteSession array, and works around possible problems after the array gets deleted.

This works around the springCleaning problem reported in #3762.
It may also fix #3678, but testing this is still in progress.
