### PR TITLE
add .readthedocs.yaml

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,22 @@
+# .readthedocs.yaml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Set the version of Python and other tools you might need
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.11"
+
+# Build documentation in the doc/ directory with Sphinx
+sphinx:
+  configuration: doc/conf.py
+
+# We recommend specifying your dependencies to enable reproducible builds:
+# https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
+python:
+  install:
+  - requirements: doc/requirements.txt

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -2,3 +2,4 @@
 
 pygments>=2.4.0
 sphinx>4
+sphinx-rtd-theme>=1.3.0


### PR DESCRIPTION
RTD recently started requiring this file: https://blog.readthedocs.com/migrate-configuration-v2/