### PR TITLE
LB: fix pup of CkLBOptions class

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -100,7 +100,7 @@ jobs:
         make html
 
   mpi-linux-x86_64:
-    timeout-minutes: 60
+    timeout-minutes: 90
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4

--- a/src/ck-ldb/LBManager.h
+++ b/src/ck-ldb/LBManager.h
@@ -6,6 +6,8 @@
 #ifndef LBMANAGER_H
 #define LBMANAGER_H
 
+#include <cassert>
+
 #include "LBDatabase.h"
 #include "json_fwd.hpp"
 using json = nlohmann::json;
@@ -99,15 +101,24 @@ class CkLBOptions
 {
  private:
   int seqno;  // for centralized lb, the seqno
-  const char* legacyName;
+  std::string legacyName;
  public:
-  CkLBOptions() : seqno(-1), legacyName(nullptr) {}
-  CkLBOptions(int s) : seqno(s), legacyName(nullptr) {}
-  CkLBOptions(int s, const char* legacyName) : seqno(s), legacyName(legacyName) {}
+  CkLBOptions() : seqno(-1), legacyName() {}
+  CkLBOptions(int s) : seqno(s), legacyName() {}
+  CkLBOptions(int s, const char* legacyName) : seqno(s), legacyName(legacyName ? legacyName : "") {}
   int getSeqNo() const { return seqno; }
-  const char* getLegacyName() const { return legacyName; }
+  bool hasLegacyName() const { return !legacyName.empty(); }
+  const char* getLegacyName() const {
+    assert(hasLegacyName());
+    return legacyName.c_str();
+  }
+
+  void pup(PUP::er& p)
+  {
+    p | seqno;
+    p | legacyName;
+  }
 };
-PUPbytes(CkLBOptions)
 
 #include "LBManager.decl.h"
 
@@ -377,7 +388,7 @@ class LBManager : public CBase_LBManager
   void RemoveStartLBFn(int handle);
 
   void StartLB();
-  
+
   template <typename T>
   inline int AddMigrationDoneFn(T* obj, void (T::*method)(void))
   {

--- a/src/ck-ldb/TreeLB.C
+++ b/src/ck-ldb/TreeLB.C
@@ -31,7 +31,7 @@ void TreeLB::loadConfigFile(const CkLBOptions& opts)
 {
   config.clear();
   std::ifstream ifs(_lb_args.treeLBFile(), std::ifstream::in);
-  if (opts.getLegacyName() != nullptr)
+  if (opts.hasLegacyName())
   {
     // support legacy mode, e.g. map "+GreedyLB" to PE_Root tree using Greedy
     // use 2-level tree


### PR DESCRIPTION
I was testing some charm4py examples and noticing segfaults in `TreeLB::loadConfigFile(CkLBOptions const&)`.

Possibly due to the invalid `const char *`-pupping of `legacyName` in `CkLBOptions`:

```
// used in constructor of all load balancers
class CkLBOptions
{
 private:
  int seqno;  // for centralized lb, the seqno
  const char* legacyName;
 public:
  CkLBOptions() : seqno(-1), legacyName(nullptr) {}
  CkLBOptions(int s) : seqno(s), legacyName(nullptr) {}
  CkLBOptions(int s, const char* legacyName) : seqno(s), legacyName(legacyName) {}
  int getSeqNo() const { return seqno; }
  const char* getLegacyName() const { return legacyName; }
};
PUPbytes(CkLBOptions)
```

A proposed fix in this PR