### PR TITLE
bugfix: update namd binary from namd2 to namd3

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -180,7 +180,7 @@ jobs:
       if: ${{ env.namd_secret != '' }}
       run: |
         cd ../namd/Linux-x86_64-g++
-        ./charmrun ++local +p2 ./namd2 src/alanin
+        ./charmrun ++local +p2 ./namd3 src/alanin
 
     - name: Cache apoa1 files
       if: ${{ env.namd_secret != '' }}
@@ -204,7 +204,7 @@ jobs:
       if: ${{ env.namd_secret != '' }}
       run: |
         cd ../namd/Linux-x86_64-g++
-        ./charmrun ++local +p4 ./namd2 ~/namddata/apoa1/apoa1.namd
+        ./charmrun ++local +p4 ./namd3 ~/namddata/apoa1/apoa1.namd
 
   netlrts-darwin-x86_64:
     timeout-minutes: 60


### PR DESCRIPTION
In preparation for the next release, NAMD's default branch (main) has updated to using namd3.  So our test had to be updated to call namd3 instead of namd2.