### PR TITLE
Change license to Apache-2.0 with LLVM exceptions

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,20 @@
 This file describes the most significant changes. For more detail, use
 'git log' on a clone of the charm repository.
 
+===============================================================================
+What's new in Charm++ 7.0.1
+================================================================================
+
+This is a change license only release, with the following change:
+
+Highlights:
+
+- The License has changed to Apache 2.0 with LLVM exception.  This
+  change to a popular Open Source license is intended to simplify use,
+  collaboration, and greater community involvement in the development
+  of Charm++. The NOTICE file contains the pertinent disclaimers.
+
+
 ================================================================================
 What's new in Charm++ 7.0.0
 ================================================================================

--- a/LICENSE
+++ b/LICENSE
@@ -1,183 +1,217 @@
-Non-Commercial Non-Exclusive License for Charm++ Software
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
 
-The Software (as defined below) will only be licensed to You (as
-defined below) upon the condition that You accept all of the terms and
-conditions contained in this license agreement ("License").  Please
-read this License carefully. By downloading and using the Software,
-You accept the terms and conditions of this License.
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
-1 Definitions.  
+   1. Definitions.
 
-  1.1 "Illinois" means The Board of Trustees of the University of
-      Illinois.
- 
-  1.2 "Software" means the Charm++/Converse parallel programming 
-      software source code and object code.
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
 
-  1.3 "You" (or "Your") means an individual or legal entity exercising
-      rights under, and complying with all of the terms of, this
-      License.  For legal entities, "You" includes any entity that
-      controls, is controlled by, or is under common control with
-      You. For purposes of this License, "control" means ownership,
-      directly or indirectly, of more than fifty percent (50%) of the
-      equity capital of the legal entity.
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
 
-2 License Grant.  Subject to Your compliance with the terms and
-  conditions of this License, Illinois on behalf of Prof. Sanjay
-  Kale's Parallel Programming Laboratory (PPL) group in the Department
-  of Computer Science, hereby grants You a non-commercial,
-  non-exclusive, non-transferable, royalty-free, restrictive license
-  to download, use, and create derivative works of the Software for
-  academic and research purposes only.
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
 
-License Restrictions.  Any uses of Software or Software derivative
-works beyond those granted in Section 2 above require a separate for a
-fee license.  To negotiate a license with additional rights, You may
-contact Illinois at the Office of Technology Management at
-otm@illinois.edu or Charmworks, Inc. at info@hpccharm.com.
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
 
-3 The following are some of the restricted use cases:
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
 
-  3.1 Integration of all or part of the Software or Software
-      derivative works into a product for sale, lease or license by or
-      on behalf of You to third parties; or
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
 
-  3.2 Distribution of all or part of the Software or Software
-      derivative works to third parties for any reason, including for
-      commercializing products sold or licensed by or on behalf of
-      You, except for contributing changes to Software;
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
 
-  3.3 Use of Software or Software derivative works for internal
-      commercial purposes.  
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
 
-  3.4 For avoidance of doubt, You may at Your own expense, create and
-      freely distribute Your works that interoperate with the
-      Software, directing the users of such works to license and
-      download the Software itself from Illinois' site at
-      http://charm.cs.illinois.edu/research/charm.
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
 
-4 Derivative works: You may at Your own expense, modify the Software
-  to make derivative works as outlined in Section 2.  Any derivative
-  work should be clearly marked and renamed to notify users that it is
-  a modified version and not the original Software distributed by
-  Illinois.  You agree to reproduce the copyright notice per Section 7
-  and other proprietary markings on any derivative work and to include
-  in the documentation of such work the acknowledgement: "This
-  software includes code developed by Parallel Programming Laboratory
-  research group in the Department of Computer Science, at the
-  University of Illinois at Urbana-Champaign."
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
 
-5 Contributing derivative works: Software is being freely distributed
-  as a research and teaching tool and as such, PPL research group
-  encourages feedback and contributions from users of the code that
-  might, at Illinois' sole discretion, be used or incorporated to make
-  the basic operating framework of the Software a more stable,
-  flexible, and/or useful product.  If You wish to contribute Your
-  code to become an internal portion of the Software:
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
 
-  5.1 You agree that such code may be distributed by Illinois under
-      the terms of this License; and
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
 
-  5.2 You may be required to sign an "Agreement Regarding Contributory
-      Code for Charm++ Software" (contact kale@illinois.edu), before
-      Illinois can accept it.
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
 
-6 Acknowledgment.  
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
 
-  6.1 You shall own the results obtained by using the outputs of
-      Software and Software derivative works. If You publish such
-      results, You shall acknowledge the use of Software and its
-      derivative works by the appropriate citation as follows:
-      "Charm++ software was developed by the Parallel Programming
-      Laboratory research group in the Department of Computer Science
-      at the University of Illinois at Urbana-Champaign."
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
 
- 6.2 Any published work, which utilizes Software, shall include the
-     following the references listed in the file named CITATION.cff 
-     in the distribution.
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
 
- 6.3 Electronic documents will include a direct link to the official
-	 Software page at http://charm.cs.illinois.edu/research/charm.
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
 
-7 Copyright Notices.  All copies of the Software or derivative works
-  shall include the following copyright notice: "Copyright 2019 The
-  Board of Trustees of the University of Illinois. All rights
-  reserved."
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
 
-8 Confidential Information. You acknowledge that the Software is
-  proprietary to Illinois.  You agree to protect the Software from
-  unauthorized disclosure, use, or release and to treat the Software
-  with at least the same level of care as You use to protect Your own
-  proprietary software and/or confidential information, but in no
-  event less than a reasonable standard of care.  If You become aware
-  of any unauthorized licensing, copying or use of the Software, You
-  shall promptly notify Illinois in writing at otm@illinois.edu.
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
 
-9 Limitation of Warranties. Limitation of
-  Liability. Indemnification. THIS SOFTWARE IS PROVIDED "AS IS" AND
-  ILLINOIS MAKES NO REPRESENTATIONS AND EXTENDS NO WARRANTIES OF ANY
-  KIND, EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
-  WARRANTIES OR MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE,
-  OR THAT THE USE OF THE SOFTWARE AND DERIVATIVE WORKS WILL NOT
-  INFRINGE ANY PATENT, TRADEMARK, OR OTHER RIGHTS.  YOU ASSUME THE
-  ENTIRE RISK AS TO THE RESULTS AND PERFORMANCE OF THE SOFTWARE AND/OR
-  DERIVATIVE WORKS.  YOU AGREE THAT ILLINOIS SHALL NOT BE HELD LIABLE
-  FOR ANY DIRECT, INDIRECT, CONSEQUENTIAL, OR INCIDENTAL DAMAGES WITH
-  RESPECT TO ANY CLAIM BY YOU OR ANY THIRD PARTY ON ACCOUNT OF OR
-  ARISING FROM THIS LICENSE OR USE OF THE SOFTWARE AND/OR DERIVATIVE
-  WORKS.  YOU SHALL INDEMNIFY AND HOLD HARMLESS ILLINOIS (INCLUDING
-  ITS TRUSTEES, FELLOWS, OFFICERS, EMPLOYEES, STUDENTS, AND AGENTS)
-  AGAINST ANY AND ALL CLAIMS, LOSSES, DAMAGES, AND/OR LIABILITY, AS
-  WELL AS COSTS AND EXPENSES (INCLUDING LEGAL EXPENSES AND REASONABLE
-  ATTORNEYS' FEES) ARISING OUT OF OR RELATED TO YOUR USE, OR INABILITY
-  TO USE, THE SOFTWARE OR SOFTWARE DERIVATIVE WORKS, REGARDLESS OF
-  THEORY OF LIABILITY, WHETHER FOR BREACH OR IN TORT (INCLUDING
-  NEGLIGENCE).
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
 
-10 Termination.
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
 
-   10.1 This License is effective until terminated, as provided
-        herein, or until all intellectual property rights in the
-        Software expire.
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
 
-   10.2 You may terminate this License at any time by destroying all
-        copies of the Software and its derivative works.
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
 
-   10.3 This License, and the rights granted hereunder, will terminate
-        automatically, and without any further notice from or action
-        by Illinois, if You fail to comply with any obligation of this
-        License.
+   END OF TERMS AND CONDITIONS
 
-   10.4 Upon termination, You must immediately cease use of and destroy
-     	all copies of the Software and its derivative works and verify
-     	such destruction in writing.
+   APPENDIX: How to apply the Apache License to your work.
 
-   10.5 The provisions set forth in Sections 5, 9, 11, 12, 13, 14, 15
-        shall survive termination or expiration of this License.
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
 
-11 Governing Law. By using this Software, You agree to abide by the
-   laws of the State of Illinois and all other applicable laws of the
-   U.S, including, but not limited to, export control laws, copyright
-   law and the terms of this License.
+   Copyright [yyyy] [name of copyright owner]
 
-12 Severability.  If any provision of this License is held to be
-   invalid or unenforceable by a court of competent jurisdiction, such
-   invalidity or unenforceability shall not in any way affect the
-   validity or enforceability of the remaining provisions.
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
 
-13 Assignment.  You may not assign or otherwise transfer any of Your
-   rights or obligations under this License, without the prior written
-   consent of Illinois.
+       http://www.apache.org/licenses/LICENSE-2.0
 
-14 Entire License.  This License represents the parties' entire
-   agreement relating to the Software.  Except as otherwise provided
-   herein, no modification of this License is binding unless in
-   writing and signed by an authorized representative of each party.
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
 
-15 Waiver.  The failure of either party to enforce any provision of
-   this License shall not constitute a waiver of that right or future
-   enforcement of that or any other provision.
+--- LLVM Exceptions to the Apache 2.0 License ----
 
-Approved for legal form Illinois Counsel SJA 10/18
+As an exception, if, as a result of your compiling your source code, portions
+of this Software are embedded into an Object form of such source code, you
+may redistribute such embedded portions in such Object form without complying
+with the conditions of Sections 4(a), 4(b) and 4(d) of the License.
 
-University Technology No. TF08023 Commercial Non-Exclusive Software License
+In addition, if you combine or link compiled forms of this Software with
+software that is licensed under the GPLv2 ("Combined Software") and if a
+court of competent jurisdiction determines that the patent provision (Section
+3), the indemnity provision (Section 9) or other Section of the License
+conflicts with the conditions of the GPLv2, you may retroactively and
+prospectively choose to deem waived or otherwise exclude such Section(s) of
+the License, but only in their entirety and only with respect to the Combined
+Software.

--- a/NOTICE
+++ b/NOTICE
@@ -3,7 +3,6 @@ Charmworks, Inc. with funding from various funding agencies, including
 the Department of Energy, National Science Foundation, National
 Institutes of Health.
 
-
 Neither the University of Illinois, nor Charmworks, Inc., nor any of
 their employees makes any warranty, expressed or implied, or assumes
 any legal liability or responsibility for the accuracy, completeness,

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,12 @@
+This work was developed at the University of Illinois and at
+Charmworks, Inc. with funding from various funding agencies, including
+the Department of Energy, National Science Foundation, National
+Institutes of Health.
+
+
+Neither the University of Illinois, nor Charmworks, Inc., nor any of
+their employees makes any warranty, expressed or implied, or assumes
+any legal liability or responsibility for the accuracy, completeness,
+or usefulness of any information, apparatus, product, or process
+disclosed, or represents that its use would not infringe privately
+owned rights.

--- a/NOTICE
+++ b/NOTICE
@@ -1,11 +1,11 @@
 This work was developed at the University of Illinois and at
-Charmworks, Inc. with funding from various funding agencies, including
-the Department of Energy, National Science Foundation, National
+Charmworks, Inc., with funding from various funding agencies, including
+the Department of Energy, National Science Foundation, and National
 Institutes of Health.
 
 Neither the University of Illinois, nor Charmworks, Inc., nor any of
-their employees makes any warranty, expressed or implied, or assumes
+their employees make any warranty, expressed or implied, or assume
 any legal liability or responsibility for the accuracy, completeness,
 or usefulness of any information, apparatus, product, or process
-disclosed, or represents that its use would not infringe privately
+disclosed, or represent that its use would not infringe privately
 owned rights.


### PR DESCRIPTION
(per our email discussion)

Same could be done for charm4py, projections, ...