### PR TITLE
bugfix: use CMK_SHARED_SUF instead of a hardcoded .so

### DIFF
--- a/src/scripts/Makefile
+++ b/src/scripts/Makefile
@@ -82,7 +82,7 @@ AMPIC AMPIF: AMPI
 f90charm: charm++
 
 libcharm: charm++
-	cd $(L) ; $(CHARMC) -standalone -whole-archive -c++stl -shared -o libcharm.so $(LIBCHARM_LIBS)
+	cd $(L) ; $(CHARMC) -standalone -whole-archive -c++stl -shared -o libcharm.$(CMK_SHARED_SUF) $(LIBCHARM_LIBS)
 
 charm4py: libcharm
 


### PR DESCRIPTION
Address buildold issue for libcharm as used by charm4py on Darwin