### PR TITLE
Resolving CkIO + ChaNGa bug: restored spring cleaning workaround

### DIFF
--- a/src/libs/ck-libs/io/ckio.C
+++ b/src/libs/ck-libs/io/ckio.C
@@ -184,6 +184,8 @@ class Director : public CBase_Director
 
     CkArrayOptions sessionOpts(numStripes);
     sessionOpts.setStaticInsertion(true);
+    sessionOpts.setAnytimeMigration(false);
+	      
 
     CkCallback sessionInitDone(CkIndex_Director::sessionReady(NULL), thisProxy);
     sessionInitDone.setRefnum(sessionID);


### PR DESCRIPTION
One line addition to undo a bug caused by the CkIO reading PR (#3788) in response to Tom's issue #3798.
