### PR TITLE
CkIO documentation and cleanup

### DIFF
--- a/doc/libraries/manual.rst
+++ b/doc/libraries/manual.rst
@@ -826,7 +826,7 @@ using the library are different for input and output, but follow the same basic 
 
 #. Open a file via ``Ck::IO::open``.
 #. Create a session for writing to the file via ``Ck::IO::startSession`` or create a session for reading from a file via ``Ck::IO::startReadSession``.
-#. Write or read via ``Ck::IO::write`` or ``Ck::IO::write``. Note that these function take a
+#. Write or read via ``Ck::IO::write`` or ``Ck::IO::read``. Note that these function take a
    session token that is passed into the callback, which should refer to the current session.
 #. In the case of a read session, the session must be closed manually when the read is complete via ``Ck::IO::closeReadSession``
 #. When the specified amount of data for the session has been written or a read session has been closed, a
@@ -967,8 +967,6 @@ The following functions comprise the interface to the library for parallel file 
 
 - Reading data:
 
-  Note there are three variants of the ``read`` call.
-
   .. code-block:: c++
 
     void read(Session session, size_t bytes, size_t offset, char* data, CkCallback after_read);
@@ -978,13 +976,6 @@ The following functions comprise the interface to the library for parallel file 
   after_read callback is invoked taking a ReadCompleteMsg* which points to a vector<char> buffer, the offset,
   and the number of bytes of the read.
 
-  .. code-block:: c++
-
-    void read(Session session, size_t bytes, size_t offset, char* data, CkCallback after_read, size_t tag);
-
-  .. code-block:: c++
-
-    void read(Session session, size_t bytes, size_t offset, char* data, CkCallback after_read, size_t tag, char* user_buffer);
 
 - Closing a file:
 
@@ -996,6 +987,7 @@ The following functions comprise the interface to the library for parallel file 
   been closed. Note that ``file`` is provided as a member of
   the ``FileReadyMsg`` sent to the ``opened`` callback after a file has been
   opened. This method should only be called from a single PE, once per file.
+
 
 Examples
 --------

--- a/doc/libraries/manual.rst
+++ b/doc/libraries/manual.rst
@@ -1001,4 +1001,5 @@ Examples
 --------
 
 For example code showing how to use CkIO for output, see ``tests/charm++/io/``.
+
 For example code showing how to use CkIO for input, see ``tests/charm++/io_read/``.

--- a/doc/libraries/manual.rst
+++ b/doc/libraries/manual.rst
@@ -795,11 +795,15 @@ CkIO
 Overview
 --------
 
-CkIO is a library for parallel I/O in Charm++. Currently it only supports
-writing files, not reading them. CkIO improves the performance of write
+CkIO is a library for parallel I/O in Charm++. It supports both reading and writing via two independent library components which both involve aggregation. The CkIO abstraction helps get the best performance out of the parallel file system and avoid contention on I/O nodes, while supporting any user-level chare decomposition. 
+
+CkIO Output
+-----------
+
+The CkIO output library improves the performance of write
 operations by aggregating data at intermediate nodes and batching writes to
 align with the stripe size of the underlying parallel file system (such as
-Lustre). This avoids contention on the I/O nodes by using fewer messages to
+Lustre). This helps avoid contention on the I/O nodes by using fewer messages to
 communicate with them and preventing small or non-contiguous disk operations.
 
 Under the hood, when a write is issued, the associated data is sent to the PE(s)
@@ -809,22 +813,30 @@ entire stripe is actually written to the filesystem all in one fell swoop. The
 size and layout of stripes and the number and organization of aggregating PEs
 are available as options for the user to customize.
 
+CkIO Input
+----------
+
+The CkIO input library similarly aggregates read requests for a single file via an intermediate layer of chares, called "Buffer Chares." The number of Buffer Chares should be chosen to read from the file system with optimal granularity. Currently, the choice of the number of Buffer Bhares must be made by the user (via the Options parameter, discussed below), considering factors such as file size, number of PEs, and number of nodes.
+
 Using CkIO
 ----------
 
 CkIO is designed as a session-oriented, callback-centric library. The steps to
-using the library are as follows (each step is invoked via a callback specified
-in an earlier step):
+using the library are different for input and output, but follow the same basic structure:
 
 #. Open a file via ``Ck::IO::open``.
-#. Create a session for writing to the file via ``Ck::IO::startSession``.
-#. Write to the file via ``Ck::IO::write``. Note that this function takes a
-   session token that is passed into the callback.
-#. When the specified amount of data for the session has been written, a
+#. Create a session for writing to the file via ``Ck::IO::startSession`` or create a session for reading from a file via ``Ck::IO::startReadSession``.
+#. Write or read via ``Ck::IO::write`` or ``Ck::IO::write``. Note that these function take a
+   session token that is passed into the callback, which should refer to the current session.
+#. In the case of a read session, the session must be closed manually when the read is complete via ``Ck::IO::closeReadSession``
+#. When the specified amount of data for the session has been written or a read session has been closed, a
    completion callback is invoked, from which one may start another session or
-   close the file via ``Ck::IO::close``.
+   close the file via ``Ck::IO::close`` (same call for writing or reading).
 
-The following functions comprise the interface to the library:
+Parallel Output API
+~~~~~~~~~~~~~~~~~~~
+
+The following functions comprise the interface to the library for parallel file output:
 
 
 - Opening a file:
@@ -839,7 +851,7 @@ The following functions comprise the interface to the library:
   specified file does not exist, it will be created. Should only be called from
   a single PE, once per file.
 
-  ``Ck::IO::Options`` is a struct with the following fields:
+  ``Ck::IO::Options`` is a struct with the following output-relevant fields:
 
   - ``writeStripe`` - Amount of contiguous data (in bytes) to gather before
     writing to the file (default: file system stripe size if using Lustre and
@@ -852,7 +864,7 @@ The following functions comprise the interface to the library:
   - ``skipPEs`` - Gap between participating PEs (default : ``CkMyNodeSize()``)
 
 
-- Starting a session:
+- Starting a write session:
 
   Note there are two variants of the ``startSession`` function, a regular one
   and one that writes a user specified chunk of data to the file at the end of a
@@ -909,8 +921,84 @@ The following functions comprise the interface to the library:
   the ``FileReadyMsg`` sent to the ``opened`` callback after a file has been
   opened. Should only be called from a single PE, once per file.
 
+Parallel Input API
+~~~~~~~~~~~~~~~~~~
 
-Example
--------
+The following functions comprise the interface to the library for parallel file input:
 
-For example code showing how to use CkIO, see ``tests/charm++/io/``.
+
+- Opening a file:
+
+  .. code-block:: c++
+
+     void Ck::IO::open(std::string path, CkCallback opened, Ck::IO::Options opts)
+
+  Open the given file with the options specified in ``opts``, and send a
+  ``FileReadyMsg`` (wraps a ``Ck::IO::File file``) to the ``opened`` callback
+  when the system is ready to accept session requests on that file. If the
+  specified file does not exist, it will be created. Should only be called from
+  a single PE, once per file.
+
+  ``Ck::IO::Options`` is a struct with the following input-relevant fields:
+
+  - ``numReaders`` - number of Buffer Chares, or aggregators. The user should chose this number to optimally decompose the read. Typically, chosing the number of Buffer Chares to be the number of PEs performs well.
+
+
+- Starting a read session:
+
+  Note there are two variants of the ``startReadSession`` function, a regular one and a variant which takes an additional argument allowing the user to map Buffer Chares to specified PEs in a round-robin fashion.
+
+  .. code-block:: c++
+
+    void startReadSession(File file, size_t bytes, size_t offset, CkCallback ready)
+
+  Prepare to read data from ``file``, in the window defined by ``size`` and
+  ``offset`` (both specified in bytes). On starting the session, the buffer 
+  chares begin eagerly reading all requested data into memory. The ready callback 
+  is invoked once these reads have been initiated (but they are not guaranteed to be complete at this point).
+
+  .. code-block:: c++
+
+    void startReadSession(File file, size_t bytes, size_t offset, CkCallback ready, std::vector<int> pes_to_map)
+
+  This function is similar to the previous one, but the extra argument pes_to_map allows the user to specify a list of PEs to map the Buffer Chares to. 
+  This argument should contain a sequence of numbers representing pes. The Buffer Chares will be mapped to the PEs in a round-robin fashion. 
+  This can be useful when the user has a specific decomposition in mind for the read.
+
+- Reading data:
+
+  Note there are three variants of the ``read`` call.
+
+  .. code-block:: c++
+
+    void read(Session session, size_t bytes, size_t offset, char* data, CkCallback after_read);
+
+   This method is invoked to read data from the read session. If the data is not yet available, this request
+   will be buffered until the Buffer Chares can respond with the requested data. After the read finishes, the 
+   after_read callback is invoked taking a ReadCompleteMsg* which points to a vector<char> buffer, the offset,
+   and the number of bytes of the read.
+
+  .. code-block:: c++
+
+    void read(Session session, size_t bytes, size_t offset, char* data, CkCallback after_read, size_t tag);
+
+  .. code-block:: c++
+
+    void read(Session session, size_t bytes, size_t offset, char* data, CkCallback after_read, size_t tag, char* user_buffer);
+
+- Closing a file:
+
+  .. code-block:: c++
+
+    void Ck::IO::close(Ck::IO::File file, CkCallback closed)
+
+  Close a previously-opened file. All read sessions on that file must have already
+  been closed. Note that ``file`` is provided as a member of
+  the ``FileReadyMsg`` sent to the ``opened`` callback after a file has been
+  opened. This method should only be called from a single PE, once per file.
+
+Examples
+--------
+
+For example code showing how to use CkIO for output, see ``tests/charm++/io/``.
+For example code showing how to use CkIO for input, see ``tests/charm++/io_read/``.

--- a/doc/libraries/manual.rst
+++ b/doc/libraries/manual.rst
@@ -816,7 +816,7 @@ are available as options for the user to customize.
 CkIO Input
 ----------
 
-The CkIO input library similarly aggregates read requests for a single file via an intermediate layer of chares, called "Buffer Chares." The number of Buffer Chares should be chosen to read from the file system with optimal granularity. Currently, the choice of the number of Buffer Bhares must be made by the user (via the Options parameter, discussed below), considering factors such as file size, number of PEs, and number of nodes.
+The CkIO input library similarly aggregates read requests for a single file via an intermediate layer of chares, called "Buffer Chares." The number of Buffer Chares should be chosen to read from the file system with optimal granularity. Currently, the choice of the number of Buffer Chares must be made by the user (via the Options parameter, discussed below), considering factors such as file size, number of PEs, and number of nodes.
 
 Using CkIO
 ----------

--- a/doc/libraries/manual.rst
+++ b/doc/libraries/manual.rst
@@ -824,7 +824,7 @@ Using CkIO
 CkIO is designed as a session-oriented, callback-centric library. The steps to
 using the library are different for input and output, but follow the same basic structure:
 
-#. Open a file via ``Ck::IO::open``.
+#. Open a file via ``Ck::IO::open``. Note that at the lowest level CkIO uses POSIX seek, read, and write (or the Microsoft equivalent for Windows) and therefore must only be used on seek-able file types. 
 #. Create a session for writing to the file via ``Ck::IO::startSession`` or create a session for reading from a file via ``Ck::IO::startReadSession``.
 #. Write or read via ``Ck::IO::write`` or ``Ck::IO::read``. Note that these function take a
    session token that is passed into the callback, which should refer to the current session.

--- a/doc/libraries/manual.rst
+++ b/doc/libraries/manual.rst
@@ -973,10 +973,10 @@ The following functions comprise the interface to the library for parallel file 
 
     void read(Session session, size_t bytes, size_t offset, char* data, CkCallback after_read);
 
-   This method is invoked to read data from the read session. If the data is not yet available, this request
-   will be buffered until the Buffer Chares can respond with the requested data. After the read finishes, the 
-   after_read callback is invoked taking a ReadCompleteMsg* which points to a vector<char> buffer, the offset,
-   and the number of bytes of the read.
+  This method is invoked to read data from the read session. If the data is not yet available, this request
+  will be buffered until the Buffer Chares can respond with the requested data. After the read finishes, the 
+  after_read callback is invoked taking a ReadCompleteMsg* which points to a vector<char> buffer, the offset,
+  and the number of bytes of the read.
 
   .. code-block:: c++
 

--- a/doc/libraries/manual.rst
+++ b/doc/libraries/manual.rst
@@ -971,8 +971,9 @@ The following functions comprise the interface to the library for parallel file 
 
     void read(Session session, size_t bytes, size_t offset, char* data, CkCallback after_read);
 
-  This method is invoked to read data from the read session. If the data is not yet available, this request
-  will be buffered until the Buffer Chares can respond with the requested data. After the read finishes, the 
+  This method is invoked to read data asynchronously from the read session. This method returns immediately to the caller, but the 
+  read is only guaranteed complete once the callback ``after_read`` is called. Internally, the read request is buffered
+  until the Buffer Chares can respond with the requested data. After the read finishes, the 
   after_read callback is invoked taking a ReadCompleteMsg* which points to a vector<char> buffer, the offset,
   and the number of bytes of the read.
 

--- a/src/libs/ck-libs/io/ckio.h
+++ b/src/libs/ck-libs/io/ckio.h
@@ -26,13 +26,7 @@ namespace IO
 struct Options
 {
   Options()
-      : peStripe(0),
-        writeStripe(0),
-        activePEs(-1),
-        basePE(-1),
-        skipPEs(-1),
-        read_stride(0),
-        numReaders(0)
+      : peStripe(0), writeStripe(0), activePEs(-1), basePE(-1), skipPEs(-1), numReaders(0)
   {
   }
 
@@ -46,8 +40,6 @@ struct Options
   int basePE;
   /// How should active PEs be spaced out?
   int skipPEs;
-  // How many bytes each Read Session should hold
-  size_t read_stride;
   // How many IO buffers should there be
   size_t numReaders;
 
@@ -58,7 +50,6 @@ struct Options
     p | activePEs;
     p | basePE;
     p | skipPEs;
-    p | read_stride;
     p | numReaders;
   }
 };
@@ -101,8 +92,9 @@ void close(File file, CkCallback closed);
 /**
  * Prepare to read data from @arg file section specified by @arg bytes and @arg offset.
  * On starting the session, the buffer chares begin eagerly reading all requested data
- * into memory. The ready callback is invoked once these reads have been initiated (but
- * they are not guaranteed to be complete at this point).
+ * into memory. The ready callback is invoked once all buffer chares have been created and
+ * their reads have been initiated (but the reads are not guaranteed to be complete at
+ * this point).
  */
 void startReadSession(File file, size_t bytes, size_t offset, CkCallback ready);
 
@@ -129,12 +121,6 @@ void closeReadSession(Session read_session, CkCallback after_end);
  * */
 void read(Session session, size_t bytes, size_t offset, char* data,
           CkCallback after_read);
-void read(Session session, size_t bytes, size_t offset, CkCallback after_read,
-          size_t tag);
-
-// ZERO COPY READ;
-void read(Session session, size_t bytes, size_t offset, CkCallback after_read, size_t tag,
-          char* user_buffer);
 
 class File
 {

--- a/src/libs/ck-libs/io/ckio.h
+++ b/src/libs/ck-libs/io/ckio.h
@@ -1,209 +1,237 @@
 #ifndef CK_IO_H
 #define CK_IO_H
 
-#include <vector>
-#include <string>
-#include <pup.h>
 #include <ckcallback.h>
 #include <iostream>
+#include <pup.h>
+#include <string>
+#include <vector>
 
 #include "CkIO.decl.h"
 
+namespace Ck
+{
+namespace IO
+{
+class Session;
+}
+}  // namespace Ck
 
-namespace Ck { namespace IO { class Session; }}
-
-namespace Ck { namespace IO {
-  /// Note: The values in options are not currently a stable or working interface.
-  /// Users should not set anything in them.
-  struct Options {
-    Options()
-      : peStripe(0), writeStripe(0), activePEs(-1), basePE(-1), skipPEs(-1), read_stride(0), numReaders(0)
-      { }
-
-    /// How much contiguous data (in bytes) should be assigned to each active PE
-    size_t peStripe;
-    /// How much contiguous data (in bytes) should a PE gather before writing it out
-    size_t writeStripe;
-    /// How many PEs should participate in this activity
-    int activePEs;
-    /// Which PE should be the first to participate in this activity
-    int basePE;
-    /// How should active PEs be spaced out?
-    int skipPEs;
-    // How many bytes each Read Session should hold
-    size_t read_stride;
-    // How many IO buffers should there be
-    size_t numReaders;
-
-    void pup(PUP::er &p) {
-      p|peStripe;
-      p|writeStripe;
-      p|activePEs;
-      p|basePE;
-      p|skipPEs;
-      p|read_stride;
-      p | numReaders;
-    }
-  };
-
-  class File;
-  // class ReadAssembler;
-  /// Open the named file on the selected subset of PEs, and send a
-  /// FileReadyMsg to the opened callback when the system is ready to accept
-  /// session requests on that file.
-  /// Note: The values in options are not currently a stable or working interface.
-  /// Users should not set anything in them.
-  void open(std::string name, CkCallback opened, Options opts);
-
-  /// Prepare to write data into the file described by token, in the window
-  /// defined by the offset and byte length. When the session is set up, a
-  /// SessionReadyMsg will be sent to the ready callback. When all of the data
-  /// has been written and synced, a message will be sent to the complete
-  /// callback.
-  void startSession(File file, size_t bytes, size_t offset,
-                    CkCallback ready, CkCallback complete);
-
-  /// Prepare to write data into @arg file, in the window defined by the @arg
-  /// offset and length in @arg bytes. When the session is set up, a
-  /// SessionReadyMsg will be sent to the @arg ready callback. When all of the
-  /// data has been written and synced, an additional write will be made to the
-  /// file to `commit' the session's work. When that write has completed, a
-  /// message will be sent to the @arg complete callback.
-  void startSession(File file, size_t bytes, size_t offset, CkCallback ready,
-                    const char *commitData, size_t commitBytes, size_t commitOffset,
-                    CkCallback complete);
-
-  /// Write the given data into the file to which session is attached. The
-  /// offset is relative to the file as a whole, not to the session's offset.
-  void write(Session session, const char *data, size_t bytes, size_t offset);
-
-  /// Close a previously-opened file. All sessions on that file must have
-  /// already signalled that they are complete.
-  void close(File file, CkCallback closed);
-  
-  /**
-   * Prepare to read data from @arg file section specified by @arg bytes and @arg offset.
-   * This method will proceed to eagerly read all of the data in that window into memory
-   * for future read calls. After all the data is read in, the ready callback will be invoked.
-   * The ready callback will take in a SessionReadyMessage* that will contain the offset, the amount of bytes
-   * , and the buffer in the form of a vector<char>.
-   */
-  void startReadSession(File file, size_t bytes, size_t offset, CkCallback ready);
-
-  /**
- * Same as the above start session in function. However, there is an extra @arg pes_to_map. pes_to_map will contain a sequence
- * of numbers representing pes. CkIO will map the IO Buffer chares to those pes specified in pes_to_map in a round_robin fashion.
- */
-  void startReadSession(File file, size_t bytes, size_t offset, CkCallback ready, std::vector<int> pes_to_map);
-
-  /**
-   * Used to end the current read session and will then invoke the after_end callback that takes a CkReductionMsg* with nothing in it
-   * Will effectively call ckDestroy() on the CProxy_Reader of the associated FileInfo
-   */
-  
-  void closeReadSession(Session read_session, CkCallback after_end);
-  /**
-   * Is a method that reads data from the @arg session of length @arg bytes at offset
-   * @arg offset (in file). After this read finishes, the @arg after_read callback is invoked, taking 
-   * a ReadCompleteMsg* which points to a vector<char> buffer, the offset, and the number of 
-   * bytes of the read.
-   * */
-  void read(Session session, size_t bytes, size_t offset, char* data, CkCallback after_read); 
-  void read(Session session, size_t bytes, size_t offset, CkCallback after_read, size_t tag);
-
-// ZERO COPY READ;
-  void read(Session session, size_t bytes, size_t offset, CkCallback after_read, size_t tag, char* user_buffer);
-
-
-  class File {
-    int token;
-    friend void startSession(File file, size_t bytes, size_t offset,
-                             CkCallback ready, CkCallback complete);
-
-    friend void startReadSession(File file, size_t bytes, size_t offset, CkCallback ready);
-    friend void startReadSession(File file, size_t bytes, size_t offset, CkCallback ready, std::vector<int> pes_to_map);
-
-    friend void startSession(File file, size_t bytes, size_t offset, CkCallback ready,
-                             const char *commitData, size_t commitBytes, size_t commitOffset,
-                             CkCallback complete);
-    friend void close(File file, CkCallback closed);
-    friend class FileReadyMsg;
-
-  public:
-    File(int token_) : token(token_) { }
-    File() : token(-1) { }
-    void pup(PUP::er &p) { p|token; }
-  };
-
-  class FileReadyMsg : public CMessage_FileReadyMsg {
-  public:
-    File file;
-    FileReadyMsg(const File &tok) : file(tok) {}
-  };
-
-  namespace impl { 
-	class Manager; 
-	int getRDMATag();
-  	class Director; // forward declare Director class as impl
-	class ReadAssembler;
+namespace Ck
+{
+namespace IO
+{
+/// Note: The values in options are not currently a stable or working interface.
+/// Users should not set anything in them.
+struct Options
+{
+  Options()
+      : peStripe(0),
+        writeStripe(0),
+        activePEs(-1),
+        basePE(-1),
+        skipPEs(-1),
+        read_stride(0),
+        numReaders(0)
+  {
   }
 
-  class Session {
-    int file;
-    size_t bytes, offset;
-    CkArrayID sessionID;
-    friend class Ck::IO::impl::Manager;
-    friend class Ck::IO::impl::Director; 
-    friend class Ck::IO::impl::ReadAssembler;
-    friend void read(Session session, size_t bytes, size_t offset, char* data, CkCallback after_read);
-    friend struct std::hash<Ck::IO::Session>;
-  public:
-    Session(int file_, size_t bytes_, size_t offset_,
-            CkArrayID sessionID_)
-      : file(file_), bytes(bytes_), offset(offset_), sessionID(sessionID_)
-      { }
-    Session() { }
-    void pup(PUP::er &p) {
-      p|file;
-      p|bytes;
-      p|offset;
-      p|sessionID;
-    }
-    
-    int getFile() const { return file;}
+  /// How much contiguous data (in bytes) should be assigned to each active PE
+  size_t peStripe;
+  /// How much contiguous data (in bytes) should a PE gather before writing it out
+  size_t writeStripe;
+  /// How many PEs should participate in this activity
+  int activePEs;
+  /// Which PE should be the first to participate in this activity
+  int basePE;
+  /// How should active PEs be spaced out?
+  int skipPEs;
+  // How many bytes each Read Session should hold
+  size_t read_stride;
+  // How many IO buffers should there be
+  size_t numReaders;
 
-    size_t getBytes() const { return bytes; }
-    size_t getOffset() const { return offset;}
-    CkArrayID getSessionID() const { return sessionID;}
-    bool operator==(const Ck::IO::Session& other) const{
-	return ((file == other.file) && (bytes==other.bytes) && (offset == other.offset) && (sessionID == other.sessionID));
-    }  
+  void pup(PUP::er& p)
+  {
+    p | peStripe;
+    p | writeStripe;
+    p | activePEs;
+    p | basePE;
+    p | skipPEs;
+    p | read_stride;
+    p | numReaders;
+  }
 };
 
+class File;
+// class ReadAssembler;
+/// Open the named file on the selected subset of PEs, and send a
+/// FileReadyMsg to the opened callback when the system is ready to accept
+/// session requests on that file.
+/// Note: The values in options are not currently a stable or working interface.
+/// Users should not set anything in them.
+void open(std::string name, CkCallback opened, Options opts);
 
+/// Prepare to write data into the file described by token, in the window
+/// defined by the offset and byte length. When the session is set up, a
+/// SessionReadyMsg will be sent to the ready callback. When all of the data
+/// has been written and synced, a message will be sent to the complete
+/// callback.
+void startSession(File file, size_t bytes, size_t offset, CkCallback ready,
+                  CkCallback complete);
 
-  class SessionReadyMsg : public CMessage_SessionReadyMsg {
-  public:
-    Session session;
-    SessionReadyMsg(Session session_) : session(session_) { }
-  };
+/// Prepare to write data into @arg file, in the window defined by the @arg
+/// offset and length in @arg bytes. When the session is set up, a
+/// SessionReadyMsg will be sent to the @arg ready callback. When all of the
+/// data has been written and synced, an additional write will be made to the
+/// file to `commit' the session's work. When that write has completed, a
+/// message will be sent to the @arg complete callback.
+void startSession(File file, size_t bytes, size_t offset, CkCallback ready,
+                  const char* commitData, size_t commitBytes, size_t commitOffset,
+                  CkCallback complete);
 
-  class ReadCompleteMsg : public CMessage_ReadCompleteMsg {
-	public:
-	    size_t read_tag;
-	    size_t offset;
-	    size_t bytes;
-	    ReadCompleteMsg(){}
-	    ReadCompleteMsg(size_t in_tag, size_t in_offset, size_t in_bytes) : read_tag(in_tag), offset(in_offset), bytes(in_bytes){
+/// Write the given data into the file to which session is attached. The
+/// offset is relative to the file as a whole, not to the session's offset.
+void write(Session session, const char* data, size_t bytes, size_t offset);
 
-	    }
-		
+/// Close a previously-opened file. All sessions on that file must have
+/// already signalled that they are complete.
+void close(File file, CkCallback closed);
 
-  };
+/**
+ * Prepare to read data from @arg file section specified by @arg bytes and @arg offset.
+ * On starting the session, the buffer chares begin eagerly reading all requested data
+ * into memory. The ready callback is invoked once these reads have been initiated (but
+ * they are not guaranteed to be complete at this point).
+ */
+void startReadSession(File file, size_t bytes, size_t offset, CkCallback ready);
 
-}}
+/**
+ * Same as the above start session in function. However, there is an extra @arg
+ * pes_to_map. pes_to_map will contain a sequence of numbers representing pes. CkIO will
+ * map the IO Buffer chares to those pes specified in pes_to_map in a round_robin fashion.
+ */
+void startReadSession(File file, size_t bytes, size_t offset, CkCallback ready,
+                      std::vector<int> pes_to_map);
 
+/**
+ * Used to end the current read session and will then invoke the after_end callback that
+ * takes a CkReductionMsg* with nothing in it Will effectively call ckDestroy() on the
+ * CProxy_Reader of the associated FileInfo
+ */
 
+void closeReadSession(Session read_session, CkCallback after_end);
+/**
+ * Is a method that reads data from the @arg session of length @arg bytes at offset
+ * @arg offset (in file). After this read finishes, the @arg after_read callback is
+ * invoked, taking a ReadCompleteMsg* which points to a vector<char> buffer, the offset,
+ * and the number of bytes of the read.
+ * */
+void read(Session session, size_t bytes, size_t offset, char* data,
+          CkCallback after_read);
+void read(Session session, size_t bytes, size_t offset, CkCallback after_read,
+          size_t tag);
+
+// ZERO COPY READ;
+void read(Session session, size_t bytes, size_t offset, CkCallback after_read, size_t tag,
+          char* user_buffer);
+
+class File
+{
+  int token;
+  friend void startSession(File file, size_t bytes, size_t offset, CkCallback ready,
+                           CkCallback complete);
+
+  friend void startReadSession(File file, size_t bytes, size_t offset, CkCallback ready);
+  friend void startReadSession(File file, size_t bytes, size_t offset, CkCallback ready,
+                               std::vector<int> pes_to_map);
+
+  friend void startSession(File file, size_t bytes, size_t offset, CkCallback ready,
+                           const char* commitData, size_t commitBytes,
+                           size_t commitOffset, CkCallback complete);
+  friend void close(File file, CkCallback closed);
+  friend class FileReadyMsg;
+
+public:
+  File(int token_) : token(token_) {}
+  File() : token(-1) {}
+  void pup(PUP::er& p) { p | token; }
+};
+
+class FileReadyMsg : public CMessage_FileReadyMsg
+{
+public:
+  File file;
+  FileReadyMsg(const File& tok) : file(tok) {}
+};
+
+namespace impl
+{
+class Manager;
+int getRDMATag();
+class Director;  // forward declare Director class as impl
+class ReadAssembler;
+}  // namespace impl
+
+class Session
+{
+  int file;
+  size_t bytes, offset;
+  CkArrayID sessionID;
+  friend class Ck::IO::impl::Manager;
+  friend class Ck::IO::impl::Director;
+  friend class Ck::IO::impl::ReadAssembler;
+  friend void read(Session session, size_t bytes, size_t offset, char* data,
+                   CkCallback after_read);
+  friend struct std::hash<Ck::IO::Session>;
+
+public:
+  Session(int file_, size_t bytes_, size_t offset_, CkArrayID sessionID_)
+      : file(file_), bytes(bytes_), offset(offset_), sessionID(sessionID_)
+  {
+  }
+  Session() {}
+  void pup(PUP::er& p)
+  {
+    p | file;
+    p | bytes;
+    p | offset;
+    p | sessionID;
+  }
+
+  int getFile() const { return file; }
+
+  size_t getBytes() const { return bytes; }
+  size_t getOffset() const { return offset; }
+  CkArrayID getSessionID() const { return sessionID; }
+  bool operator==(const Ck::IO::Session& other) const
+  {
+    return ((file == other.file) && (bytes == other.bytes) && (offset == other.offset) &&
+            (sessionID == other.sessionID));
+  }
+};
+
+class SessionReadyMsg : public CMessage_SessionReadyMsg
+{
+public:
+  Session session;
+  SessionReadyMsg(Session session_) : session(session_) {}
+};
+
+class ReadCompleteMsg : public CMessage_ReadCompleteMsg
+{
+public:
+  size_t read_tag;
+  size_t offset;
+  size_t bytes;
+  ReadCompleteMsg() {}
+  ReadCompleteMsg(size_t in_tag, size_t in_offset, size_t in_bytes)
+      : read_tag(in_tag), offset(in_offset), bytes(in_bytes)
+  {
+  }
+};
+
+}  // namespace IO
+}  // namespace Ck
 
 #endif
-


### PR DESCRIPTION
Adding CkIO Input documentation to the Charm++ readthedocs and updating relevant comments to address #1521 . This should be basically complete for the current status of CkIO in main. Mat implemented a FileReader streaming abstraction as well (not merged yet) - should that be merged in for this release? In this case, we should add these docs.