### PR TITLE
bugfix: craycc now uses -v instead of -V

### DIFF
--- a/src/arch/common/cc-craycc.sh
+++ b/src/arch/common/cc-craycc.sh
@@ -6,6 +6,6 @@
 #      Further tinkering should be done only as necessary and tested thoroughly.  
 
 #verify that cc is actually the cray compiler, otherwise bail
-CRAYCC_test=`cc -V 2>&1 >/dev/null | grep 'Version' | awk -F' ' '{print $1; exit}'`
+CRAYCC_test=`cc -v 2>&1 >/dev/null | grep -i 'version' | awk -F' ' '{print $1; exit}'`
 test -z "$CRAYCC_test" && echo "cc is not CrayCC, check your modules!" && exit 1
 test "$CRAYCC_test" != "Cray"  && echo "cc is not CrayCC, check your modules!" && exit 1


### PR DESCRIPTION
Cray (HPE) has switched over to clang/LLVM, so the command line interface for their compiler is different.

This just replaces -V with -v and a test for the string Version with version.  Nonetheless, it will allow a simple multicore-linux-x86_64 craycc build to compile properly on frontier with the cray compilers. This is desirable for NAMD GPU Resident targets to use newer versions of cce, rocm, and hip modules.