### PR TITLE
Ifdef to if typo fix

### DIFF
--- a/tests/charm++/periodic/periodic.C
+++ b/tests/charm++/periodic/periodic.C
@@ -34,7 +34,11 @@ class main : public CBase_main {
     delete msg;
 
     mProxy = thisProxy;
+    #if CALL_FN_AFTER
     startTime = CkWallTimer();
+    #else
+    startTime = 0.0;
+    #endif
     gProxy = CProxy_testGroup::ckNew(COUNTER_MAX);
     CkPrintf("Testing Converse periodic callbacks on %d PEs for %d seconds\n",
              CkNumPes(), COUNTER_MAX);


### PR DESCRIPTION
Reverts charmplusplus/charm#3841 because of a typo in the code. Line 37 in periodic.C should be #if CALL_FN_AFTER not #ifdef.