### PR TITLE
[CrayPMI] Missing headers

### DIFF
--- a/cmake/detect-features-c.cmake
+++ b/cmake/detect-features-c.cmake
@@ -290,7 +290,8 @@ int main()
 }
 " CMK_HAS_NUMACTRL)
 
-set(tmp ${CMAKE_REQUIRED_LIBRARIES})
+set(tmp0 ${CMAKE_REQUIRED_INCLUDES})
+set(tmp1 ${CMAKE_REQUIRED_LIBRARIES})
 set(CMAKE_REQUIRED_INCLUDES $ENV{CRAY_PMI_PREFIX}/include)
 set(CMAKE_REQUIRED_LIBRARIES $ENV{CRAY_PMI_POST_LINK_OPTS} -lpmi)
 check_c_source_compiles("
@@ -302,7 +303,8 @@ int main() {
     return 0;
 }
 " CMK_HAS_PMI_GET_NID)
-set(CMAKE_REQUIRED_LIBRARIES ${tmp})
+set(CMAKE_REQUIRED_INCLUDES ${tmp0})
+set(CMAKE_REQUIRED_LIBRARIES ${tmp1})
 
 check_c_source_compiles("
 #include <rca_lib.h>


### PR DESCRIPTION
When checking for the appropriate pmi functionalities, we use the module defined variables to get the library path, but we don't do that for the headers.

In the (common) situation where we load cray modules but do not use the wrapper, this breaks. By explicitly adding the include path, we wont get issues.