### PR TITLE
CkPupPerPlaceData(): set numObjects correctly.

### DIFF
--- a/src/ck-core/ckcheckpoint.C
+++ b/src/ck-core/ckcheckpoint.C
@@ -607,9 +607,9 @@ static void CkPupPerPlaceData(PUP::er &p, GroupIDTable *idTable, GroupTable *obj
   }
 
   if (p.isUnpacking()) {
-    if(CkMyPe()==0)  
-      numObjects = maxGroup+1; 
-    else 
+    if(CkMyPe()==0)
+      numObjects = maxGroup+1;
+    else
       numObjects = 1;
   }
 }


### PR DESCRIPTION
In CkPupPerPlaceData(), numObjects will set _numGroups and _numNodeGroups, and these need to be greater than the maximum index of a valid entry in _groupTable and _nodeGroupTable, respectively.

This is a proposed fix for #3898 and #3678.
I will do some testing.
