### PR TITLE
cleanup: support Win64 builds on Windows 11

### DIFF
--- a/src/arch/common/cc-msvc.sh
+++ b/src/arch/common/cc-msvc.sh
@@ -1,5 +1,6 @@
 
 CMK_CC="$CHARMBIN/unix2nt_cc"
+CMK_SEQ_CC="$CMK_CC"
 CMK_CPP_C="$CMK_CC"
 CMK_CXX="$CHARMBIN/unix2nt_cc"
 CMK_LD="$CMK_CC"

--- a/src/arch/win/unix2nt_cc
+++ b/src/arch/win/unix2nt_cc
@@ -15,30 +15,15 @@ set -o errexit
 # Configurable option: Location of MSDEV
 if [[ -z "$VCINSTALLDIR" ]]
 then
-  VCC_DIR='C:/Program Files (x86)/Microsoft Visual Studio 14.0/VC'
+  VCC_DIR='C:/Program Files/Microsoft Visual Studio/2022/Community/VC'
 else
   VCC_DIR="$VCINSTALLDIR"
 fi
-if [[ ! -d "$(cygpath -u "$VCC_DIR")" ]]
+if [[ ! -d "$(cygpath.exe -u "$VCC_DIR")" ]]
 then
   echo "\$VCINSTALLDIR is not set properly: $VCC_DIR"
   exit 1
 fi
-if [[ -n "$WINDOWSSDKDIR" ]]
-then
-  SDK_DIR="$WINDOWSSDKDIR"
-elif [[ -n "$WindowsSdkDir" ]]
-then
-  SDK_DIR="$WindowsSdkDir"
-else
-  SDK_DIR='C:/Program Files/Windows Kits/10'
-fi
-if [[ ! -d "$(cygpath -u "$SDK_DIR")" ]]
-then
-  echo "\$WindowsSdkDir is not set properly: $SDK_DIR"
-  exit 1
-fi
-
 #CL command-line options for -O and -g mode
 #only for the environment that has set corresponding environmental variables
 CL_CMD='CL.EXE'
@@ -71,8 +56,7 @@ else
 LINK_CMD="$VCC_DIR/BIN/LINK.EXE"
 fi
 LINK_COMMON=(-nologo -subsystem:console -DYNAMICBASE:NO)
-LINK_POST=(ws2_32.lib kernel32.lib user32.lib psapi.lib gdi32.lib winspool.lib comdlg32.lib advapi32.lib shell32.lib ole32.lib oleaut32.lib uuid.lib -MACHINE:X64 -ERRORREPORT:PROMPT)
-
+LINK_POST=(WS2_32.lib WSock32.lib kernel32.lib user32.lib psapi.lib gdi32.lib winspool.lib comdlg32.lib advapi32.lib shell32.lib ole32.lib oleaut32.lib uuid.lib -MACHINE:X64 -ERRORREPORT:PROMPT)
 if [[ -z "$LIB" ]]
 then
 	echo "Variables already set!"

--- a/src/ck-perf/trace-common.C
+++ b/src/ck-perf/trace-common.C
@@ -4,8 +4,10 @@
 /*@{*/
 
 #include <sys/stat.h>
-#include <sys/types.h>
 
+#if !defined(_WIN64)
+#include <sys/types.h>
+#endif
 #include <ctime>        // std::time_t, std::gmtime
 #include <chrono>       // std::chrono::system_clock
 
@@ -32,7 +34,7 @@
 
 // To get hostname
 #if defined(_WIN32) || defined(_WIN64)
-#  include <Winsock2.h>
+//#  include <Winsock2.h>
 #else
 #  include <unistd.h>
 #  include <limits.h> // For HOST_NAME_MAX
@@ -145,7 +147,7 @@ static void traceCommonInit(char **argv)
     // Trying to decide if the traceroot path is absolute or not. If it is not
     // then create an absolute pathname for it.
     if (temproot[0] != PATHSEP) {
-      temproot2 = GETCWD(NULL,0);
+ //     temproot2 = GETCWD(NULL,0);
       root = (char *)malloc(strlen(temproot2)+1+strlen(temproot)+1);
       strcpy(root, temproot2);
       strcat(root, PATHSEPSTR);
@@ -259,8 +261,9 @@ void traceWriteSTS(FILE *stsfp,int nUserEvents) {
 
   // Add 1 for null terminator
   char hostname[HOST_NAME_MAX + 1];
-  if(gethostname(hostname, HOST_NAME_MAX + 1) == 0)
-    fprintf(stsfp, "HOSTNAME \"%s\"\n", hostname);
+
+  //if(gethostname(hostname, HOST_NAME_MAX + 1) == 0)
+//    fprintf(stsfp, "HOSTNAME \"%s\"\n", hostname);
 
   fprintf(stsfp, "COMMANDLINE \"");
   int index = 0;
@@ -277,7 +280,7 @@ void traceWriteSTS(FILE *stsfp,int nUserEvents) {
   using std::chrono::system_clock;
   const time_t now = system_clock::to_time_t(system_clock::now());
   struct tm currentTime;
-#if defined(_WIN32) || defined(_WIN64)
+#if defined(_WIN32) || defined(_WIN64) && !defined(__CYGWIN__)
   gmtime_s(&currentTime, &now);
 #else
   gmtime_r(&now, &currentTime);

--- a/src/ck-perf/trace-common.h
+++ b/src/ck-perf/trace-common.h
@@ -15,9 +15,11 @@
 #define PATHSEP '\\'
 #define PATHSEPSTR "\\"
 #else
+#if !defined(_WIN64)
 #include <unistd.h>
+#endif
 #define CHDIR chdir
-#define GETCWD getcwd
+//#define GETCWD getcwd
 #define PATHSEP '/'
 #define PATHSEPSTR "/"
 #endif

--- a/src/scripts/Makefile
+++ b/src/scripts/Makefile
@@ -334,6 +334,11 @@ endif
 	-./system_ln  ../tmp/conv-mach-opt.mak ../include
 	if [ -x ./special.sh ] ; then SRCBASE=$(SRCBASE) ./special.sh ; fi
 	if [ ! -f conv-common.h ] ; then ( touch conv-common.h ) ; fi
+#       in the special case of reusing netlrts for windows, nuke Makefile.machine to not build charmrun
+	if case $(CMK_VDIR) in *-win-*) true;; *) false;; esac; then \
+		rm ../tmp/Makefile.machine ;\
+		touch ../tmp/Makefile.machine ; \
+	fi
 	touch dirs+sources
 
 ###############################################################################


### PR DESCRIPTION
If you do the following, you can build charm++ on windows 0. install WSL, Cygwin64, and Visual Studio Community
1. launch a Native x64 Developer Command Prompt for Visual Studio 2022
2. wsl
3. /cygwin/c/cygwin64/bin/bash --login
4. cd charm
5. ./buildold charm++ multicore-win-x86_64 msvc -j --with-production

These changes update the unix2nt_cc wrapper script to inherit the necessary path information from Windows (via WSL and Cygwin). Some additional changes disable a few problematic edge cases and turn off the building of charmrun (which never worked on windows).