### PR TITLE
Fix for redundant thread contention in CsdNextMessage

### DIFF
--- a/src/conv-core/convcore.C
+++ b/src/conv-core/convcore.C
@@ -1766,14 +1766,18 @@ void *CsdNextMessage(CsdSchedulerState_t *s) {
 	/*#warning "CsdNextMessage: CMK_NODE_QUEUE_AVAILABLE" */
 	if (NULL!=(msg=CmiGetNonLocalNodeQ())) return msg;
 #if !CMK_NO_MSG_PRIOS
-	if(CmiTryLock(s->nodeLock) == 0) {
-	  if (!CqsEmpty(s->nodeQ)
-	   && CqsPrioGT(CqsGetPriority(s->schedQ),
-		         CqsGetPriority(s->nodeQ))) {
-	    CqsDequeue(s->nodeQ,(void **)&msg);
+	/* Check the node queue lock-free if we have anything to work with. */
+	/* This significantly reduces redundant thread contention in CmiTryLock(). */
+	if (!CqsEmpty(s->nodeQ)) {
+	  if (CmiTryLock(s->nodeLock) == 0) {
+	    if (!CqsEmpty(s->nodeQ)
+	    && CqsPrioGT(CqsGetPriority(s->schedQ),
+	                    CqsGetPriority(s->nodeQ))) {
+	      CqsDequeue(s->nodeQ,(void **)&msg);
+	    }
+	    CmiUnlock(s->nodeLock);
+	    if (msg!=NULL) return msg;
 	  }
-	  CmiUnlock(s->nodeLock);
-	  if (msg!=NULL) return msg;
 	}
 #endif
 #endif


### PR DESCRIPTION
Fix for redundant thread contention in CsdNextMessage (CmiTryLock/pthread_mutex_trylock)  for node-level threading parallelism with high number of threads.
Instead of simple try_lock call this patch checks lock-free first that the queue is not empty and if it is not empty then there is try_lock and the queue is checked again inside the critical section to avoid a potential data race.