### PR TITLE
perf: old dequeue is scheme faster for ucx-arm

### DIFF
--- a/src/arch/ucx-linux-arm8/conv-mach.h
+++ b/src/arch/ucx-linux-arm8/conv-mach.h
@@ -82,5 +82,6 @@ In fault tolerant architectures, CK_MEM_CHECKPOINT can be set. In this case the
 extended header must contain also another field called "pn" (phase number).
 
 */
+#define CMK_NODE_QUEUE_LOCK_BEFORE_CHECK	1
 
 #endif

--- a/src/conv-core/convcore.C
+++ b/src/conv-core/convcore.C
@@ -1766,6 +1766,13 @@ void *CsdNextMessage(CsdSchedulerState_t *s) {
 	/*#warning "CsdNextMessage: CMK_NODE_QUEUE_AVAILABLE" */
 	if (NULL!=(msg=CmiGetNonLocalNodeQ())) return msg;
 #if !CMK_NO_MSG_PRIOS
+#if CMK_NODE_QUEUE_LOCK_BEFORE_CHECK
+	//performs better on grace-hopper
+	if(CmiTryLock(s->nodeLock) == 0) {{
+	  if (!CqsEmpty(s->nodeQ)
+          && CqsPrioGT(CqsGetPriority(s->schedQ),
+                        CqsGetPriority(s->nodeQ))) {
+#else
 	/* Check the node queue lock-free if we have anything to work with. */
 	/* This significantly reduces redundant thread contention in CmiTryLock(). */
 	if (!CqsEmpty(s->nodeQ)) {
@@ -1773,6 +1780,7 @@ void *CsdNextMessage(CsdSchedulerState_t *s) {
 	    if (!CqsEmpty(s->nodeQ)
 	    && CqsPrioGT(CqsGetPriority(s->schedQ),
 	                    CqsGetPriority(s->nodeQ))) {
+#endif
 	      CqsDequeue(s->nodeQ,(void **)&msg);
 	    }
 	    CmiUnlock(s->nodeLock);


### PR DESCRIPTION
The dequeue optimization in #3916 creates a
performance regression (loss of 1ns/day) for NAMD on Vista at large scale. This adds CMK_NODE_QUEUE_LOCK_BEFORE_CHECK to switch back to the prior scheme and enables it in the
ucx-linux-arm8 conv-mach.h